### PR TITLE
Added support for standard error output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Added stderr to output of ShellExecute functions
+
 ## [v1.3] - 2019-03-03
 ### Fixed
 - Fixed SharpSploit.Enumeration.Host.ChangeCurrentDirectory() to accept absolute paths

--- a/SharpSploit/Execution/Shell.cs
+++ b/SharpSploit/Execution/Shell.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Diagnostics;
 using System.Management.Automation;
+using System.Text;
 
 namespace SharpSploit.Execution
 {
@@ -114,12 +115,19 @@ namespace SharpSploit.Execution
             shellProcess.StartInfo.UseShellExecute = false;
             shellProcess.StartInfo.CreateNoWindow = true;
             shellProcess.StartInfo.RedirectStandardOutput = true;
+            shellProcess.StartInfo.RedirectStandardError = true;
+
+            var output = new StringBuilder();
+            shellProcess.OutputDataReceived += (sender, args) => { output.AppendLine(args.Data); };
+            shellProcess.ErrorDataReceived += (sender, args) => { output.AppendLine(args.Data); };
+
             shellProcess.Start();
 
-            string output = shellProcess.StandardOutput.ReadToEnd();
+            shellProcess.BeginOutputReadLine();
+            shellProcess.BeginErrorReadLine();
             shellProcess.WaitForExit();
 
-            return output;
+            return output.ToString();
         }
     }
 }


### PR DESCRIPTION
I saw a number of ways to do this on StackOverflow, but I think this one is pretty concise. Whenever there is data written to the process's standard out or error streams, an event is triggered and that line is added to the output, which is returned. 

The shell tests passed. 

Addresses #12.