### PR TITLE
Adi dns dump

### DIFF
--- a/SharpSploit.Tests/SharpSploit.Tests/Enumeration/DnsTests.cs
+++ b/SharpSploit.Tests/SharpSploit.Tests/Enumeration/DnsTests.cs
@@ -19,7 +19,7 @@ namespace SharpSploit.Tests.Enumeration
         [TestMethod]
         public void TestDumpDns()
         {
-            SharpSploitResultList<Dns.DnsResult> hosts = Dns.DumpDns(System.DirectoryServices.ActiveDirectory.Domain.GetCurrentDomain().FindDomainController().Name);
+            SharpSploitResultList<Dns.DnsResult> hosts = Dns.DumpDns(System.DirectoryServices.ActiveDirectory.Domain.GetCurrentDomain().FindDomainController().Name, true);
             Assert.IsTrue(hosts.Count > 0);
             foreach (Dns.DnsResult host in hosts)
             {

--- a/SharpSploit.Tests/SharpSploit.Tests/Enumeration/DnsTests.cs
+++ b/SharpSploit.Tests/SharpSploit.Tests/Enumeration/DnsTests.cs
@@ -1,0 +1,30 @@
+﻿// Author: Ryan Cobb (@cobbr_io)
+// Project: SharpSploit (https://github.com/cobbr/SharpSploit)
+// License: BSD 3-Clause
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using SharpSploit.Enumeration;
+using System.DirectoryServices.ActiveDirectory;
+using SharpSploit.Generic;
+
+namespace SharpSploit.Tests.Enumeration
+{
+    [TestClass]
+    public class DnsTests
+    {
+        [TestMethod]
+        public void TestDumpDns()
+        {
+            SharpSploitResultList<Dns.DnsResult> hosts = Dns.DumpDns(System.DirectoryServices.ActiveDirectory.Domain.GetCurrentDomain().FindDomainController().Name);
+            Assert.IsTrue(hosts.Count > 0);
+            foreach (Dns.DnsResult host in hosts)
+            {
+                Assert.IsTrue(!string.IsNullOrEmpty(host.IP) || host.Tombstoned == true);
+            }
+        }
+    }
+}

--- a/SharpSploit.Tests/SharpSploit.Tests/SharpSploit.Tests.csproj
+++ b/SharpSploit.Tests/SharpSploit.Tests/SharpSploit.Tests.csproj
@@ -55,6 +55,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Credentials\TokensTests.cs" />
+    <Compile Include="Enumeration\DnsTests.cs" />
     <Compile Include="Enumeration\DomainTests.cs" />
     <Compile Include="Enumeration\HostTests.cs" />
     <Compile Include="Enumeration\NetworkTests.cs" />

--- a/SharpSploit/Enumeration/Dns.cs
+++ b/SharpSploit/Enumeration/Dns.cs
@@ -76,13 +76,16 @@ namespace SharpSploit.Enumeration
         /// https://dirkjanm.io/getting-in-the-zone-dumping-active-directory-dns-with-adidnsdump/
         /// by @_dirkjan
         /// </remarks>
-        public static SharpSploitResultList<DnsResult> DumpDns(string DomainController)
+        public static SharpSploitResultList<DnsResult> DumpDns(string DomainController, bool ssl)
         {
             SharpSploitResultList<DnsResult> results = new SharpSploitResultList<DnsResult>();
 
             try
             {
-                
+                string proto = "ldap";
+                if (ssl)
+                    proto = "ldaps";
+
                 string rootDn = "DC=DomainDnsZones";
 
                 string domain_local = System.Net.NetworkInformation.IPGlobalProperties.GetIPGlobalProperties().DomainName;
@@ -95,7 +98,7 @@ namespace SharpSploit.Enumeration
                 }
 
                 rootDn += domain_path;
-                DirectoryEntry rootEntry = new DirectoryEntry("LDAP://" + DomainController + "/" + rootDn);
+                DirectoryEntry rootEntry = new DirectoryEntry(proto + "://" + DomainController + "/" + rootDn);
                 rootEntry.AuthenticationType = AuthenticationTypes.Delegation;
                 DirectorySearcher searcher = new DirectorySearcher(rootEntry);
 
@@ -111,7 +114,7 @@ namespace SharpSploit.Enumeration
                     Console.WriteLine("Domain: {0}", domain);
                     Console.WriteLine();
 
-                    DirectoryEntry rootEntry_d = new DirectoryEntry("LDAP://" + DomainController + "/DC=" + result.Properties["DC"][0].ToString() + ",CN=microsoftdns," + rootDn);
+                    DirectoryEntry rootEntry_d = new DirectoryEntry(proto + "://" + DomainController + "/DC=" + result.Properties["DC"][0].ToString() + ",CN=microsoftdns," + rootDn);
                     rootEntry_d.AuthenticationType = AuthenticationTypes.Delegation;
                     DirectorySearcher searcher_h = new DirectorySearcher(rootEntry_d);
 
@@ -132,7 +135,7 @@ namespace SharpSploit.Enumeration
                         {
                             //Hidden entry
                             String path = result_h.Path;
-                            target = (path.Substring(path.IndexOf("LDAP://" + DomainController + "/"), path.IndexOf(","))).Split('=')[1];
+                            target = (path.Substring(path.IndexOf(proto + "://" + DomainController + "/"), path.IndexOf(","))).Split('=')[1];
                         }
 
                         DnsResult dnsentry = new DnsResult(DomainName: domain, ComputerName: target);

--- a/SharpSploit/Enumeration/Dns.cs
+++ b/SharpSploit/Enumeration/Dns.cs
@@ -1,0 +1,181 @@
+﻿// Author: Ryan Cobb (@cobbr_io)
+// Project: SharpSploit (https://github.com/cobbr/SharpSploit)
+// License: BSD 3-Clause
+
+
+
+
+using System;
+using System.Net;
+using System.DirectoryServices;
+using SharpSploit.Generic;
+using System.Collections.Generic;
+
+namespace SharpSploit.Enumeration
+{
+    /// <summary>
+    /// Dns is a library for dumping dns via Active Directory.
+    /// </summary>
+    public class Dns
+    {
+        /// <summary>
+        /// DnsResult represent the result entry of an host.
+        /// </summary>
+        public sealed class DnsResult : SharpSploitResult
+        {
+            public string DomainName { get; } = string.Empty;
+            public string ComputerName { get; } = string.Empty;
+            public string IP { get; set; } = string.Empty;
+            public bool Tombstoned { get; set; } = false;
+            protected internal override IList<SharpSploitResultProperty> ResultProperties
+            {
+                get
+                {
+                    return new List<SharpSploitResultProperty>
+                    {
+                        new SharpSploitResultProperty
+                        {
+                            Name = "DomainName",
+                            Value = this.DomainName
+                        },
+                        new SharpSploitResultProperty
+                        {
+                            Name = "ComputerName",
+                            Value = this.ComputerName
+                        },
+                        new SharpSploitResultProperty
+                        {
+                            Name = "IP",
+                            Value = this.IP
+                        },
+                        new SharpSploitResultProperty
+                        {
+                            Name = "Tombstoned",
+                            Value = this.Tombstoned
+                        }
+                    };
+                }
+            }
+
+            public DnsResult(string DomainName = "", string ComputerName = "", string IP = "", bool Tombstoned = false)
+            {
+                this.DomainName = DomainName;
+                this.ComputerName = ComputerName;
+                this.IP = IP;
+                this.Tombstoned = Tombstoned;
+            }
+        }
+
+        /// <summary>
+        /// Query specified domain controller via ldap and extrat hosts name list from dns, than perform a dns lookup to resolve ips. .
+        /// </summary>
+        /// <author>@b4rtik</author>
+        /// <param name="DomainController">DomainController to query.</param>
+        /// <returns>List of PortScanResults</returns>
+        /// <remarks>
+        /// based on 
+        /// Getting in the zone dumping active directory dns with adidnsdump
+        /// https://dirkjanm.io/getting-in-the-zone-dumping-active-directory-dns-with-adidnsdump/
+        /// by @_dirkjan
+        /// </remarks>
+        public static SharpSploitResultList<DnsResult> DumpDns(string DomainController)
+        {
+            SharpSploitResultList<DnsResult> results = new SharpSploitResultList<DnsResult>();
+
+            try
+            {
+                
+                string rootDn = "DC=DomainDnsZones";
+
+                string domain_local = System.Net.NetworkInformation.IPGlobalProperties.GetIPGlobalProperties().DomainName;
+
+                string domain_path = "";
+
+                foreach (string domain_path_r in domain_local.Split('.'))
+                {
+                    domain_path += ",DC=" + domain_path_r;
+                }
+
+                rootDn += domain_path;
+                DirectoryEntry rootEntry = new DirectoryEntry("LDAP://" + DomainController + "/" + rootDn);
+                rootEntry.AuthenticationType = AuthenticationTypes.Delegation;
+                DirectorySearcher searcher = new DirectorySearcher(rootEntry);
+
+                //find domains
+                var queryFormat = "(&(objectClass=DnsZone)(!(DC=*arpa))(!(DC=RootDNSServers)))";
+                searcher.Filter = queryFormat;
+                searcher.SearchScope = SearchScope.Subtree;
+
+                foreach (SearchResult result in searcher.FindAll())
+                {
+                    String domain = (result.Properties["DC"].Count > 0 ? result.Properties["DC"][0].ToString() : string.Empty);
+                    Console.WriteLine();
+                    Console.WriteLine("Domain: {0}", domain);
+                    Console.WriteLine();
+
+                    DirectoryEntry rootEntry_d = new DirectoryEntry("LDAP://" + DomainController + "/DC=" + result.Properties["DC"][0].ToString() + ",CN=microsoftdns," + rootDn);
+                    rootEntry_d.AuthenticationType = AuthenticationTypes.Delegation;
+                    DirectorySearcher searcher_h = new DirectorySearcher(rootEntry_d);
+
+                    //find hosts
+                    queryFormat = "(&(!(objectClass=DnsZone))(!(DC=@))(!(DC=*arpa))(!(DC=*DNSZones)))";
+                    searcher_h.Filter = queryFormat;
+                    searcher_h.SearchScope = SearchScope.Subtree;
+
+                    foreach (SearchResult result_h in searcher_h.FindAll())
+                    {
+                        String target = "";
+
+                        if (result_h.Properties["DC"].Count > 0)
+                        {
+                            target = result_h.Properties["DC"][0].ToString();
+                        }
+                        else
+                        {
+                            //Hidden entry
+                            String path = result_h.Path;
+                            target = (path.Substring(path.IndexOf("LDAP://" + DomainController + "/"), path.IndexOf(","))).Split('=')[1];
+                        }
+
+                        DnsResult dnsentry = new DnsResult(DomainName: domain, ComputerName: target);
+
+                        if (!target.EndsWith("."))
+                            target += "." + domain;
+
+                        bool tombstoned = result_h.Properties["dNSTombstoned"].Count > 0 ? (bool)result_h.Properties["dNSTombstoned"][0] : false;
+
+                        dnsentry.Tombstoned = tombstoned;
+
+                        if(!tombstoned)
+                        {
+                            try
+                            {
+                                IPHostEntry hostInfo = System.Net.Dns.GetHostEntry(target);
+                                foreach (IPAddress result_ip in hostInfo.AddressList)
+                                {
+                                    dnsentry.IP = result_ip.ToString();
+                                    results.Add(dnsentry);
+                                }
+                            }
+                            catch (Exception)
+                            {
+                                
+                            }
+                        }
+                        else
+                        {
+                            results.Add(dnsentry);
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Error retriving data : {0}", e.Message);
+            }
+
+            return results;
+        }
+    }
+}
+

--- a/SharpSploit/Enumeration/Dns.cs
+++ b/SharpSploit/Enumeration/Dns.cs
@@ -2,9 +2,6 @@
 // Project: SharpSploit (https://github.com/cobbr/SharpSploit)
 // License: BSD 3-Clause
 
-
-
-
 using System;
 using System.Net;
 using System.DirectoryServices;
@@ -14,7 +11,7 @@ using System.Collections.Generic;
 namespace SharpSploit.Enumeration
 {
     /// <summary>
-    /// Dns is a library for dumping dns via Active Directory.
+    /// Dns is a library for dumping entry from Active Directory-integrated DNS.
     /// </summary>
     public class Dns
     {
@@ -27,6 +24,7 @@ namespace SharpSploit.Enumeration
             public string ComputerName { get; } = string.Empty;
             public string IP { get; set; } = string.Empty;
             public bool Tombstoned { get; set; } = false;
+
             protected internal override IList<SharpSploitResultProperty> ResultProperties
             {
                 get
@@ -67,7 +65,7 @@ namespace SharpSploit.Enumeration
         }
 
         /// <summary>
-        /// Query specified domain controller via ldap and extrat hosts name list from dns, than perform a dns lookup to resolve ips. .
+        /// Query specified domain controller via ldap and extrat hosts name list from Active Directory-integrated DNS, than perform a dns lookup to resolve ips. .
         /// </summary>
         /// <author>@b4rtik</author>
         /// <param name="DomainController">DomainController to query.</param>

--- a/SharpSploit/Enumeration/Dns.cs
+++ b/SharpSploit/Enumeration/Dns.cs
@@ -69,7 +69,8 @@ namespace SharpSploit.Enumeration
         /// </summary>
         /// <author>@b4rtik</author>
         /// <param name="DomainController">DomainController to query.</param>
-        /// <returns>List of PortScanResults</returns>
+        /// <param name="ssl">Use ldaps or not</param>
+        /// <returns>List of DnsResults</returns>
         /// <remarks>
         /// based on 
         /// Getting in the zone dumping active directory dns with adidnsdump

--- a/SharpSploit/SharpSploit.xml
+++ b/SharpSploit/SharpSploit.xml
@@ -200,7 +200,7 @@
         </member>
         <member name="T:SharpSploit.Enumeration.Dns">
             <summary>
-            Dns is a library for dumping dns via Active Directory.
+            Dns is a library for dumping entry from Active Directory-integrated DNS.
             </summary>
         </member>
         <member name="T:SharpSploit.Enumeration.Dns.DnsResult">
@@ -208,13 +208,14 @@
             DnsResult represent the result entry of an host.
             </summary>
         </member>
-        <member name="M:SharpSploit.Enumeration.Dns.DumpDns(System.String)">
+        <member name="M:SharpSploit.Enumeration.Dns.DumpDns(System.String,System.Boolean)">
             <summary>
-            Query specified domain controller via ldap and extrat hosts name list from dns, than perform a dns lookup to resolve ips. .
+            Query specified domain controller via ldap and extrat hosts name list from Active Directory-integrated DNS, than perform a dns lookup to resolve ips. .
             </summary>
             <author>@b4rtik</author>
             <param name="DomainController">DomainController to query.</param>
-            <returns>List of PortScanResults</returns>
+            <param name="ssl">Use ldaps or not</param>
+            <returns>List of DnsResults</returns>
             <remarks>
             based on 
             Getting in the zone dumping active directory dns with adidnsdump

--- a/SharpSploit/SharpSploit.xml
+++ b/SharpSploit/SharpSploit.xml
@@ -198,6 +198,30 @@
             <param name="Privilege">Privilege to enable.</param>
             <returns>True if enabling Token succeeds, false otherwise.</returns>
         </member>
+        <member name="T:SharpSploit.Enumeration.Dns">
+            <summary>
+            Dns is a library for dumping dns via Active Directory.
+            </summary>
+        </member>
+        <member name="T:SharpSploit.Enumeration.Dns.DnsResult">
+            <summary>
+            DnsResult represent the result entry of an host.
+            </summary>
+        </member>
+        <member name="M:SharpSploit.Enumeration.Dns.DumpDns(System.String)">
+            <summary>
+            Query specified domain controller via ldap and extrat hosts name list from dns, than perform a dns lookup to resolve ips. .
+            </summary>
+            <author>@b4rtik</author>
+            <param name="DomainController">DomainController to query.</param>
+            <returns>List of PortScanResults</returns>
+            <remarks>
+            based on 
+            Getting in the zone dumping active directory dns with adidnsdump
+            https://dirkjanm.io/getting-in-the-zone-dumping-active-directory-dns-with-adidnsdump/
+            by @_dirkjan
+            </remarks>
+        </member>
         <member name="T:SharpSploit.Enumeration.Domain">
             <summary>
             Domain is a library for domain enumeration that can be used to search for and query for information from


### PR DESCRIPTION
Added SharpSploit/Enumeration/Dns.cs with

public static SharpSploitResultList<DnsResult> DumpDns(string DomainController, bool ssl)

This Class extracts host names from AD via LDAP including the "hidden entries" and then performs a dns lookup to resolve IPs.

Added SharpSploit.Test/Enumeration/DnsTest test unit