### PR TITLE
In-Memory Export Parsing

### DIFF
--- a/SharpSploit/Execution/DynamicInvoke/Generic.cs
+++ b/SharpSploit/Execution/DynamicInvoke/Generic.cs
@@ -52,8 +52,76 @@ namespace SharpSploit.Execution.DynamicInvoke
         public static IntPtr GetLibraryAddress(string DLLName, string FunctionName)
         {
             IntPtr hModule = Execution.Win32.Kernel32.LoadLibrary(DLLName);
-
             return Execution.Win32.Kernel32.GetProcAddress(hModule, FunctionName);
+        }
+
+        /// <summary>
+        /// Helper for getting the base address of a module loaded by the current process. This base address could be passed to GetProcAddress/LdrGetProcedureAddress or it could be used for manual export parsing.
+        /// </summary>
+        /// <author>Ruben Boonen (@FuzzySec)</author>
+        /// <param name="DLLName">The name of the DLL (e.g. "ntdll.dll").</param>
+        /// <returns>IntPtr base address of the loaded module or IntPtr.Zero if the module is not found.</returns>
+        public static IntPtr GetLoadedModuleAddress(string DLLName)
+        {
+            ProcessModuleCollection ProcModules = Process.GetCurrentProcess().Modules;
+            foreach (ProcessModule Mod in ProcModules)
+            {
+                if (Mod.FileName.ToLower().EndsWith(DLLName.ToLower()))
+                {
+                    return Mod.BaseAddress;
+                }
+            }
+
+            return IntPtr.Zero;
+        }
+
+        /// <summary>
+        /// Given a module base address, resolve the address of a function by manually walking the module export table.
+        /// </summary>
+        /// <author>Ruben Boonen (@FuzzySec)</author>
+        /// <param name="ModuleBase">A pointer to the base address where the module is loaded in the current process.</param>
+        /// <param name="ExportName">The name of the export to search for (e.g. "NtAlertResumeThread").</param>
+        /// <returns>IntPtr for the desired function or IntPtr.Zero if the export is not found.</returns>
+        public static IntPtr GetExportAddress(IntPtr ModuleBase, string ExportName)
+        {
+            // Traverse the PE header in memory
+            Int32 PeHeader = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + 0x3C));
+            Int16 OptHeaderSize = Marshal.ReadInt16((IntPtr)(ModuleBase.ToInt64() + PeHeader + 0x14));
+            Int64 OptHeader = ModuleBase.ToInt64() + PeHeader + 0x18;
+            Int16 Magic = Marshal.ReadInt16((IntPtr)OptHeader);
+            Int64 pExport = 0;
+            if (Magic == 0x010b)
+            {
+                pExport = OptHeader + 0x60;
+            }
+            else
+            {
+                pExport = OptHeader + 0x70;
+            }
+
+            // Read -> IMAGE_EXPORT_DIRECTORY
+            Int32 ExportRVA = Marshal.ReadInt32((IntPtr)pExport);
+            Int32 OrdinalBase = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x10));
+            Int32 NumberOfFunctions = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x14));
+            Int32 NumberOfNames = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x18));
+            Int32 FunctionsRVA = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x1C));
+            Int32 NamesRVA = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x20));
+            Int32 OrdinalsRVA = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x24));
+
+            // Loop the array of export name RVA's
+            for (int i = 0; i < NumberOfNames; i++)
+            {
+                String FunctionName = Marshal.PtrToStringAnsi((IntPtr)(ModuleBase.ToInt64() + Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + NamesRVA + i * 4))));
+                if (FunctionName.ToLower() == ExportName.ToLower())
+                {
+                    Int32 FunctionOrdinal = Marshal.ReadInt16((IntPtr)(ModuleBase.ToInt64() + OrdinalsRVA + i * 2)) + OrdinalBase;
+                    Int32 FunctionRVA = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + FunctionsRVA + (4 * (FunctionOrdinal - OrdinalBase))));
+                    IntPtr FunctionPtr = (IntPtr)((Int64)ModuleBase + FunctionRVA);
+                    return FunctionPtr;
+                }
+            }
+
+            return IntPtr.Zero;
         }
     }
 }

--- a/SharpSploit/Execution/DynamicInvoke/Native.cs
+++ b/SharpSploit/Execution/DynamicInvoke/Native.cs
@@ -100,6 +100,36 @@ namespace SharpSploit.Execution.DynamicInvoke
             return retValue;
         }
 
+        public static void RtlInitUnicodeString(ref Execution.Win32.NtDll.UNICODE_STRING DestinationString, [MarshalAs(UnmanagedType.LPWStr)] string SourceString)
+        {
+            // Craft an array for the arguments
+            object[] funcargs =
+            {
+                DestinationString, SourceString
+            };
+
+            Generic.DynamicAPIInvoke(@"ntdll.dll", @"RtlInitUnicodeString", typeof(DELEGATES.RtlInitUnicodeString), ref funcargs);
+
+            // Update the modified variables
+            DestinationString = (Execution.Win32.NtDll.UNICODE_STRING)funcargs[0];
+        }
+
+        public static Execution.Win32.NtDll.NTSTATUS LdrLoadDll(IntPtr PathToFile, UInt32 dwFlags, ref Execution.Win32.NtDll.UNICODE_STRING ModuleFileName, ref IntPtr ModuleHandle)
+        {
+            // Craft an array for the arguments
+            object[] funcargs =
+            {
+                PathToFile, dwFlags, ModuleFileName, ModuleHandle
+            };
+
+            Execution.Win32.NtDll.NTSTATUS retValue = (Execution.Win32.NtDll.NTSTATUS)Generic.DynamicAPIInvoke(@"ntdll.dll", @"LdrLoadDll", typeof(DELEGATES.LdrLoadDll), ref funcargs);
+
+            // Update the modified variables
+            ModuleHandle = (IntPtr)funcargs[3];
+
+            return retValue;
+        }
+
         /// <summary>
         /// Holds delegates for API calls in the NT Layer.
         /// Must be public so that they may be used with SharpSploit.Execution.DynamicInvoke.Generic.DynamicFunctionInvoke
@@ -153,6 +183,19 @@ namespace SharpSploit.Execution.DynamicInvoke
                 uint InheritDisposition,
                 uint AllocationType,
                 uint Win32Protect);
+
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate UInt32 LdrLoadDll(
+                IntPtr PathToFile,
+                UInt32 dwFlags,
+                ref Execution.Win32.NtDll.UNICODE_STRING ModuleFileName,
+                ref IntPtr ModuleHandle);
+            
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate void RtlInitUnicodeString(
+                ref Execution.Win32.NtDll.UNICODE_STRING DestinationString,
+                [MarshalAs(UnmanagedType.LPWStr)]
+                string SourceString);
         }
     }
 }

--- a/SharpSploit/Execution/Win32.cs
+++ b/SharpSploit/Execution/Win32.cs
@@ -1510,6 +1510,14 @@ namespace SharpSploit.Execution
                 out int pSize
             );
 
+            [StructLayout(LayoutKind.Sequential)]
+            public struct UNICODE_STRING
+            {
+                public UInt16 Length;
+                public UInt16 MaximumLength;
+                public IntPtr Buffer;
+            }
+
             public struct PROCESS_BASIC_INFORMATION
             {
                 public IntPtr ExitStatus;


### PR DESCRIPTION
This pull request adds two functions to DynamicInvoke -> Generic
+ **GetLoadedModuleAddress**: This function gets the base address of a module loaded by the current process. This avoids the use of LoadLibrary API variants but requires that the process already has the DLL loaded. The return value can be used in functions such as GetProcAddress / LdrGetProcedureAddress or for manual export parsing.
+ **GetExportAddress**: This function takes the base address of a loaded module and performs a manual search of the module export table to find a specific function pointer. This avoids the use of GetProcAddress API variants.