### PR TITLE
Find function by ordinal/hash + Dinvoke

### DIFF
--- a/SharpSploit/Execution/DynamicInvoke/Generic.cs
+++ b/SharpSploit/Execution/DynamicInvoke/Generic.cs
@@ -8,6 +8,8 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 using Execute = SharpSploit.Execution;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace SharpSploit.Execution.DynamicInvoke
 {
@@ -122,6 +124,34 @@ namespace SharpSploit.Execution.DynamicInvoke
         }
 
         /// <summary>
+        /// Helper for getting the pointer to a function from a DLL loaded by the process.
+        /// </summary>
+        /// <author>Ruben Boonen (@FuzzySec)</author>
+        /// <param name="DLLName">The name of the DLL (e.g. "ntdll.dll" or "C:\Windows\System32\ntdll.dll").</param>
+        /// <param name="FunctionHash">Hash of the exported procedure.</param>
+        /// <param name="Key">64-bit integer to initialize the keyed hash object (e.g. 0xabc or 0x1122334455667788).</param>
+        /// <param name="CanLoadFromDisk">Optional, indicates if the function can try to load the DLL from disk if it is not found in the loaded module list.</param>
+        /// <returns>IntPtr for the desired function.</returns>
+        public static IntPtr GetLibraryAddress(string DLLName, string FunctionHash, Int64 Key, bool CanLoadFromDisk = false)
+        {
+            IntPtr hModule = GetLoadedModuleAddress(DLLName);
+            if (hModule == IntPtr.Zero && CanLoadFromDisk)
+            {
+                hModule = LoadModuleFromDisk(DLLName);
+                if (hModule == IntPtr.Zero)
+                {
+                    throw new FileNotFoundException(DLLName + ", unable to find the specified file.");
+                }
+            }
+            else if (hModule == IntPtr.Zero)
+            {
+                throw new DllNotFoundException(DLLName + ", Dll was not found.");
+            }
+
+            return GetExportAddress(hModule, FunctionHash, Key);
+        }
+
+        /// <summary>
         /// Helper for getting the base address of a module loaded by the current process. This base address could be passed to GetProcAddress/LdrGetProcedureAddress or it could be used for manual export parsing.
         /// </summary>
         /// <author>Ruben Boonen (@FuzzySec)</author>
@@ -139,6 +169,23 @@ namespace SharpSploit.Execution.DynamicInvoke
             }
 
             return IntPtr.Zero;
+        }
+
+        /// <summary>
+        /// Generate an HMAC-MD5 hash of the supplied string using an Int64 as the key. This is useful for unique hash based API lookups.
+        /// </summary>
+        /// <author>Ruben Boonen (@FuzzySec)</author>
+        /// <param name="APIName">API name to hash.</param>
+        /// <param name="Key">64-bit integer to initialize the keyed hash object (e.g. 0xabc or 0x1122334455667788).</param>
+        /// <returns>String, the computed MD5 hash value.</returns>
+        public static String GenerateUniqueAPIHash(String APIName, Int64 Key)
+        {
+            byte[] data = Encoding.UTF8.GetBytes(APIName.ToLower());
+            byte[] kbytes = BitConverter.GetBytes(Key);
+
+            HMACMD5 hmac = new HMACMD5(kbytes);
+            byte[] bHash = hmac.ComputeHash(data);
+            return BitConverter.ToString(bHash).Replace("-", "");
         }
 
         /// <summary>
@@ -200,6 +247,70 @@ namespace SharpSploit.Execution.DynamicInvoke
             {
                 // Export not found
                 throw new MissingMethodException(ExportName + ", export not found.");
+            }
+            return FunctionPtr;
+        }
+
+        /// <summary>
+        /// Given a module base address, resolve the address of a function by manually walking the module export table.
+        /// </summary>
+        /// <author>Ruben Boonen (@FuzzySec)</author>
+        /// <param name="ModuleBase">A pointer to the base address where the module is loaded in the current process.</param>
+        /// <param name="FunctionHash">Hash of the exported procedure.</param>
+        /// <param name="Key">64-bit integer to initialize the keyed hash object (e.g. 0xabc or 0x1122334455667788).</param>
+        /// <returns>IntPtr for the desired function.</returns>
+        public static IntPtr GetExportAddress(IntPtr ModuleBase, string FunctionHash, Int64 Key)
+        {
+            IntPtr FunctionPtr = IntPtr.Zero;
+            try
+            {
+                // Traverse the PE header in memory
+                Int32 PeHeader = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + 0x3C));
+                Int16 OptHeaderSize = Marshal.ReadInt16((IntPtr)(ModuleBase.ToInt64() + PeHeader + 0x14));
+                Int64 OptHeader = ModuleBase.ToInt64() + PeHeader + 0x18;
+                Int16 Magic = Marshal.ReadInt16((IntPtr)OptHeader);
+                Int64 pExport = 0;
+                if (Magic == 0x010b)
+                {
+                    pExport = OptHeader + 0x60;
+                }
+                else
+                {
+                    pExport = OptHeader + 0x70;
+                }
+
+                // Read -> IMAGE_EXPORT_DIRECTORY
+                Int32 ExportRVA = Marshal.ReadInt32((IntPtr)pExport);
+                Int32 OrdinalBase = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x10));
+                Int32 NumberOfFunctions = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x14));
+                Int32 NumberOfNames = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x18));
+                Int32 FunctionsRVA = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x1C));
+                Int32 NamesRVA = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x20));
+                Int32 OrdinalsRVA = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x24));
+
+                // Loop the array of export name RVA's
+                for (int i = 0; i < NumberOfNames; i++)
+                {
+                    String FunctionName = Marshal.PtrToStringAnsi((IntPtr)(ModuleBase.ToInt64() + Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + NamesRVA + i * 4))));
+                    if (GenerateUniqueAPIHash(FunctionName.ToLower(), Key).ToLower() == FunctionHash.ToLower())
+                    {
+                        Int32 FunctionOrdinal = Marshal.ReadInt16((IntPtr)(ModuleBase.ToInt64() + OrdinalsRVA + i * 2)) + OrdinalBase;
+                        Int32 FunctionRVA = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + FunctionsRVA + (4 * (FunctionOrdinal - OrdinalBase))));
+                        FunctionPtr = (IntPtr)((Int64)ModuleBase + FunctionRVA);
+                        break;
+                    }
+                }
+            }
+            catch
+            {
+                // Catch parser failure
+                throw new InvalidOperationException("Failed to parse module exports.");
+            }
+
+            if (FunctionPtr == IntPtr.Zero)
+            {
+                // Export not found
+                throw new MissingMethodException(FunctionHash + ", export hash not found.");
             }
             return FunctionPtr;
         }

--- a/SharpSploit/Execution/DynamicInvoke/Generic.cs
+++ b/SharpSploit/Execution/DynamicInvoke/Generic.cs
@@ -292,7 +292,7 @@ namespace SharpSploit.Execution.DynamicInvoke
                 for (int i = 0; i < NumberOfNames; i++)
                 {
                     String FunctionName = Marshal.PtrToStringAnsi((IntPtr)(ModuleBase.ToInt64() + Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + NamesRVA + i * 4))));
-                    if (GenerateUniqueAPIHash(FunctionName.ToLower(), Key).ToLower() == FunctionHash.ToLower())
+                    if (GenerateUniqueAPIHash(FunctionName, Key).ToLower() == FunctionHash.ToLower())
                     {
                         Int32 FunctionOrdinal = Marshal.ReadInt16((IntPtr)(ModuleBase.ToInt64() + OrdinalsRVA + i * 2)) + OrdinalBase;
                         Int32 FunctionRVA = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + FunctionsRVA + (4 * (FunctionOrdinal - OrdinalBase))));

--- a/SharpSploit/Execution/DynamicInvoke/Generic.cs
+++ b/SharpSploit/Execution/DynamicInvoke/Generic.cs
@@ -95,6 +95,33 @@ namespace SharpSploit.Execution.DynamicInvoke
         }
 
         /// <summary>
+        /// Helper for getting the pointer to a function from a DLL loaded by the process.
+        /// </summary>
+        /// <author>Ruben Boonen (@FuzzySec)</author>
+        /// <param name="DLLName">The name of the DLL (e.g. "ntdll.dll" or "C:\Windows\System32\ntdll.dll").</param>
+        /// <param name="Ordinal">Ordinal of the exported procedure.</param>
+        /// <param name="CanLoadFromDisk">Optional, indicates if the function can try to load the DLL from disk if it is not found in the loaded module list.</param>
+        /// <returns>IntPtr for the desired function.</returns>
+        public static IntPtr GetLibraryAddress(string DLLName, Int16 Ordinal, bool CanLoadFromDisk = false)
+        {
+            IntPtr hModule = GetLoadedModuleAddress(DLLName);
+            if (hModule == IntPtr.Zero && CanLoadFromDisk)
+            {
+                hModule = LoadModuleFromDisk(DLLName);
+                if (hModule == IntPtr.Zero)
+                {
+                    throw new FileNotFoundException(DLLName + ", unable to find the specified file.");
+                }
+            }
+            else if (hModule == IntPtr.Zero)
+            {
+                throw new DllNotFoundException(DLLName + ", Dll was not found.");
+            }
+
+            return GetExportAddress(hModule, Ordinal);
+        }
+
+        /// <summary>
         /// Helper for getting the base address of a module loaded by the current process. This base address could be passed to GetProcAddress/LdrGetProcedureAddress or it could be used for manual export parsing.
         /// </summary>
         /// <author>Ruben Boonen (@FuzzySec)</author>
@@ -173,6 +200,68 @@ namespace SharpSploit.Execution.DynamicInvoke
             {
                 // Export not found
                 throw new MissingMethodException(ExportName + ", export not found.");
+            }
+            return FunctionPtr;
+        }
+
+        /// <summary>
+        /// Given a module base address, resolve the address of a function by manually walking the module export table.
+        /// </summary>
+        /// <author>Ruben Boonen (@FuzzySec)</author>
+        /// <param name="ModuleBase">A pointer to the base address where the module is loaded in the current process.</param>
+        /// <param name="Ordinal">The ordinal number to search for (e.g. 0x136 -> ntdll!NtCreateThreadEx).</param>
+        /// <returns>IntPtr for the desired function.</returns>
+        public static IntPtr GetExportAddress(IntPtr ModuleBase, Int16 Ordinal)
+        {
+            IntPtr FunctionPtr = IntPtr.Zero;
+            try
+            {
+                // Traverse the PE header in memory
+                Int32 PeHeader = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + 0x3C));
+                Int16 OptHeaderSize = Marshal.ReadInt16((IntPtr)(ModuleBase.ToInt64() + PeHeader + 0x14));
+                Int64 OptHeader = ModuleBase.ToInt64() + PeHeader + 0x18;
+                Int16 Magic = Marshal.ReadInt16((IntPtr)OptHeader);
+                Int64 pExport = 0;
+                if (Magic == 0x010b)
+                {
+                    pExport = OptHeader + 0x60;
+                }
+                else
+                {
+                    pExport = OptHeader + 0x70;
+                }
+
+                // Read -> IMAGE_EXPORT_DIRECTORY
+                Int32 ExportRVA = Marshal.ReadInt32((IntPtr)pExport);
+                Int32 OrdinalBase = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x10));
+                Int32 NumberOfFunctions = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x14));
+                Int32 NumberOfNames = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x18));
+                Int32 FunctionsRVA = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x1C));
+                Int32 NamesRVA = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x20));
+                Int32 OrdinalsRVA = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x24));
+
+                // Loop the array of export name RVA's
+                for (int i = 0; i < NumberOfNames; i++)
+                {
+                    Int32 FunctionOrdinal = Marshal.ReadInt16((IntPtr)(ModuleBase.ToInt64() + OrdinalsRVA + i * 2)) + OrdinalBase;
+                    if (FunctionOrdinal == Ordinal)
+                    {
+                        Int32 FunctionRVA = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + FunctionsRVA + (4 * (FunctionOrdinal - OrdinalBase))));
+                        FunctionPtr = (IntPtr)((Int64)ModuleBase + FunctionRVA);
+                        break;
+                    }
+                }
+            }
+            catch
+            {
+                // Catch parser failure
+                throw new InvalidOperationException("Failed to parse module exports.");
+            }
+
+            if (FunctionPtr == IntPtr.Zero)
+            {
+                // Export not found
+                throw new MissingMethodException(Ordinal + ", ordinal not found.");
             }
             return FunctionPtr;
         }

--- a/SharpSploit/Execution/DynamicInvoke/Native.cs
+++ b/SharpSploit/Execution/DynamicInvoke/Native.cs
@@ -145,7 +145,7 @@ namespace SharpSploit.Execution.DynamicInvoke
 
         public static bool ProcessWow64Information(IntPtr hProcess)
         {
-            UInt32 processInformationClass = (UInt32)Execute.Native.PROCESSINFOCLASS.ProcessWow64Information;
+            Execute.Native.PROCESSINFOCLASS processInformationClass = Execute.Native.PROCESSINFOCLASS.ProcessWow64Information;
             IntPtr pProcInfo = Marshal.AllocHGlobal(IntPtr.Size);
             RtlZeroMemory(pProcInfo, IntPtr.Size);
             int processInformationLength = IntPtr.Size;
@@ -175,7 +175,7 @@ namespace SharpSploit.Execution.DynamicInvoke
 
         public static Execute.Native.PROCESS_BASIC_INFORMATION ProcessBasicInformation(IntPtr hProcess)
         {
-            UInt32 processInformationClass = (UInt32)Execute.Native.PROCESSINFOCLASS.ProcessBasicInformation;
+            Execute.Native.PROCESSINFOCLASS processInformationClass = Execute.Native.PROCESSINFOCLASS.ProcessBasicInformation;
             Execute.Native.PROCESS_BASIC_INFORMATION PBI = new Execute.Native.PROCESS_BASIC_INFORMATION();
             IntPtr pProcInfo = Marshal.AllocHGlobal(Marshal.SizeOf(PBI));
             RtlZeroMemory(pProcInfo, Marshal.SizeOf(PBI));
@@ -277,6 +277,164 @@ namespace SharpSploit.Execution.DynamicInvoke
             return ThreadHandle;
         }
 
+        public static IntPtr NtAllocateVirtualMemory(IntPtr ProcessHandle, ref IntPtr BaseAddress, IntPtr ZeroBits, ref IntPtr RegionSize, UInt32 AllocationType, UInt32 Protect)
+        {
+            // Craft an array for the arguments
+            object[] funcargs =
+            {
+                ProcessHandle, BaseAddress, ZeroBits, RegionSize, AllocationType, Protect
+            };
+
+            Execute.Native.NTSTATUS retValue = (Execute.Native.NTSTATUS)Generic.DynamicAPIInvoke(@"ntdll.dll", @"NtAllocateVirtualMemory", typeof(DELEGATES.NtAllocateVirtualMemory), ref funcargs);
+            if (retValue != Execute.Native.NTSTATUS.Success)
+            {
+                if (retValue == Execute.Native.NTSTATUS.AccessDenied)
+                {
+                    // STATUS_ACCESS_DENIED
+                    throw new UnauthorizedAccessException("Access is denied.");
+                }
+                else if (retValue == Execute.Native.NTSTATUS.AlreadyCommitted)
+                {
+                    // STATUS_ALREADY_COMMITTED
+                    throw new InvalidOperationException("The specified address range is already committed.");
+                }
+                else if (retValue == Execute.Native.NTSTATUS.CommitmentLimit)
+                {
+                    // STATUS_COMMITMENT_LIMIT
+                    throw new InvalidOperationException("Your system is low on virtual memory.");
+                }
+                else if (retValue == Execute.Native.NTSTATUS.ConflictingAddresses)
+                {
+                    // STATUS_CONFLICTING_ADDRESSES
+                    throw new InvalidOperationException("The specified address range conflicts with the address space.");
+                }
+                else if (retValue == Execute.Native.NTSTATUS.InsufficientResources)
+                {
+                    // STATUS_INSUFFICIENT_RESOURCES
+                    throw new InvalidOperationException("Insufficient system resources exist to complete the API call.");
+                }
+                else if (retValue == Execute.Native.NTSTATUS.InvalidHandle)
+                {
+                    // STATUS_INVALID_HANDLE
+                    throw new InvalidOperationException("An invalid HANDLE was specified.");
+                }
+                else if (retValue == Execute.Native.NTSTATUS.InvalidPageProtection)
+                {
+                    // STATUS_INVALID_PAGE_PROTECTION
+                    throw new InvalidOperationException("The specified page protection was not valid.");
+                }
+                else if (retValue == Execute.Native.NTSTATUS.NoMemory)
+                {
+                    // STATUS_NO_MEMORY
+                    throw new InvalidOperationException("Not enough virtual memory or paging file quota is available to complete the specified operation.");
+                }
+                else if (retValue == Execute.Native.NTSTATUS.ObjectTypeMismatch)
+                {
+                    // STATUS_OBJECT_TYPE_MISMATCH
+                    throw new InvalidOperationException("There is a mismatch between the type of object that is required by the requested operation and the type of object that is specified in the request.");
+                }
+                else
+                {
+                    // STATUS_PROCESS_IS_TERMINATING == 0xC000010A
+                    throw new InvalidOperationException("An attempt was made to duplicate an object handle into or out of an exiting process.");
+                }
+            } else
+            {
+                BaseAddress = (IntPtr)funcargs[1];
+                return BaseAddress;
+            }
+        }
+
+        public static void NtFreeVirtualMemory(IntPtr ProcessHandle, ref IntPtr BaseAddress, ref IntPtr RegionSize, UInt32 FreeType)
+        {
+            // Craft an array for the arguments
+            object[] funcargs =
+            {
+                ProcessHandle, BaseAddress, RegionSize, FreeType
+            };
+
+            Execute.Native.NTSTATUS retValue = (Execute.Native.NTSTATUS)Generic.DynamicAPIInvoke(@"ntdll.dll", @"NtFreeVirtualMemory", typeof(DELEGATES.NtFreeVirtualMemory), ref funcargs);
+            if (retValue != Execute.Native.NTSTATUS.Success)
+            {
+                if (retValue == Execute.Native.NTSTATUS.AccessDenied)
+                {
+                    // STATUS_ACCESS_DENIED
+                    throw new UnauthorizedAccessException("Access is denied.");
+                }
+                else if (retValue == Execute.Native.NTSTATUS.InvalidHandle)
+                {
+                    // STATUS_INVALID_HANDLE
+                    throw new InvalidOperationException("An invalid HANDLE was specified.");
+                }
+                else
+                {
+                    // STATUS_OBJECT_TYPE_MISMATCH == 0xC0000024
+                    throw new InvalidOperationException("There is a mismatch between the type of object that is required by the requested operation and the type of object that is specified in the request.");
+                }
+            }
+        }
+
+        public static String GetFilenameFromMemoryPointer(IntPtr hProc, IntPtr pMem)
+        {
+            // Alloc buffer for result struct
+            IntPtr pBase = IntPtr.Zero;
+            IntPtr RegionSize = (IntPtr)0x500;
+            IntPtr pAlloc = NtAllocateVirtualMemory(hProc, ref pBase, IntPtr.Zero, ref RegionSize, Execution.Win32.Kernel32.MEM_COMMIT | Execution.Win32.Kernel32.MEM_RESERVE, Execution.Win32.WinNT.PAGE_READWRITE);
+
+            // Prepare NtQueryVirtualMemory parameters
+            Execute.Native.MEMORYINFOCLASS mic = Execute.Native.MEMORYINFOCLASS.MemorySectionName;
+            UInt32 MemoryInformationLength = 0x500;
+            UInt32 Retlen = 0;
+
+            // Craft an array for the arguments
+            object[] funcargs =
+            {
+                hProc, pMem, mic, pAlloc, MemoryInformationLength, Retlen
+            };
+
+            Execute.Native.NTSTATUS retValue = (Execute.Native.NTSTATUS)Generic.DynamicAPIInvoke(@"ntdll.dll", @"NtQueryVirtualMemory", typeof(DELEGATES.NtQueryVirtualMemory), ref funcargs);
+            if (retValue != Execute.Native.NTSTATUS.Success)
+            {
+                // Free allocation
+                NtFreeVirtualMemory(hProc, ref pAlloc, ref RegionSize, Execution.Win32.Kernel32.MEM_RELEASE);
+
+                if (retValue == Execute.Native.NTSTATUS.AccessDenied)
+                {
+                    // STATUS_ACCESS_DENIED
+                    throw new UnauthorizedAccessException("Access is denied.");
+                }
+                else if (retValue == Execute.Native.NTSTATUS.AccessViolation)
+                {
+                    // STATUS_ACCESS_VIOLATION
+                    throw new InvalidOperationException("The specified base address is an invalid virtual address.");
+                }
+                else if (retValue == Execute.Native.NTSTATUS.InfoLengthMismatch)
+                {
+                    // STATUS_INFO_LENGTH_MISMATCH
+                    throw new InvalidOperationException("The MemoryInformation buffer is larger than MemoryInformationLength.");
+                }
+                else if (retValue == Execute.Native.NTSTATUS.InvalidParameter)
+                {
+                    // STATUS_INVALID_PARAMETER
+                    throw new InvalidOperationException("The specified base address is outside the range of accessible addresses.");
+                }
+                else
+                {
+                    // STATUS_INVALID_PARAMETER == 0xC0000141
+                    // This status is returned if the pointer is not backed by a file on disk
+                    return String.Empty;
+                }
+            } else
+            {
+                Execute.Native.UNICODE_STRING sn = (Execute.Native.UNICODE_STRING)Marshal.PtrToStructure(pAlloc, typeof(Execute.Native.UNICODE_STRING));
+                String FilePath = Marshal.PtrToStringUni(sn.Buffer);
+
+                // Free allocation
+                NtFreeVirtualMemory(hProc, ref pAlloc, ref RegionSize, Execution.Win32.Kernel32.MEM_RELEASE);
+                return FilePath;
+            }
+        }
+
         /// <summary>
         /// Holds delegates for API calls in the NT Layer.
         /// Must be public so that they may be used with SharpSploit.Execution.DynamicInvoke.Generic.DynamicFunctionInvoke
@@ -362,7 +520,7 @@ namespace SharpSploit.Execution.DynamicInvoke
             [UnmanagedFunctionPointer(CallingConvention.StdCall)]
             public delegate UInt32 NtQueryInformationProcess(
                 IntPtr processHandle,
-                UInt32 processInformationClass,
+                Execute.Native.PROCESSINFOCLASS processInformationClass,
                 IntPtr processInformation,
                 int processInformationLength,
                 ref UInt32 returnLength);
@@ -388,6 +546,31 @@ namespace SharpSploit.Execution.DynamicInvoke
                 Execute.Win32.Kernel32.ThreadAccess DesiredAccess,
                 ref Execute.Native.OBJECT_ATTRIBUTES ObjectAttributes,
                 ref Execute.Native.CLIENT_ID ClientId);
+
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate UInt32 NtAllocateVirtualMemory(
+                IntPtr ProcessHandle,
+                ref IntPtr BaseAddress,
+                IntPtr ZeroBits,
+                ref IntPtr RegionSize,
+                UInt32 AllocationType,
+                UInt32 Protect);
+
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate UInt32 NtFreeVirtualMemory(
+                IntPtr ProcessHandle,
+                ref IntPtr BaseAddress,
+                ref IntPtr RegionSize,
+                UInt32 FreeType);
+
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate UInt32 NtQueryVirtualMemory(
+                IntPtr ProcessHandle,
+                IntPtr BaseAddress,
+                Execute.Native.MEMORYINFOCLASS MemoryInformationClass,
+                IntPtr MemoryInformation,
+                UInt32 MemoryInformationLength,
+                ref UInt32 ReturnLength);
         }
     }
 }

--- a/SharpSploit/Execution/Native.cs
+++ b/SharpSploit/Execution/Native.cs
@@ -52,6 +52,14 @@ namespace SharpSploit.Execution
             public IntPtr UniqueThread;
         }
 
+        public enum MEMORYINFOCLASS : int
+        {
+            MemoryBasicInformation = 0,
+            MemoryWorkingSetList,
+            MemorySectionName,
+            MemoryBasicVlmInformation
+        }
+
         public enum PROCESSINFOCLASS : int
         {
             ProcessBasicInformation = 0, // 0, q: PROCESS_BASIC_INFORMATION, PROCESS_EXTENDED_BASIC_INFORMATION
@@ -336,6 +344,7 @@ namespace SharpSploit.Execution
             PrivilegedInstruction = 0xc0000096,
             TooManyPagingFiles = 0xc0000097,
             FileInvalid = 0xc0000098,
+            InsufficientResources = 0xc000009a,
             InstanceNotAvailable = 0xc00000ab,
             PipeNotAvailable = 0xc00000ac,
             InvalidPipeState = 0xc00000ad,
@@ -368,6 +377,7 @@ namespace SharpSploit.Execution
             InvalidParameter10 = 0xc00000f8,
             InvalidParameter11 = 0xc00000f9,
             InvalidParameter12 = 0xc00000fa,
+            ProcessIsTerminating = 0xc000010a,
             MappedFileSizeZero = 0xc000011e,
             TooManyOpenedFiles = 0xc000011f,
             Cancelled = 0xc0000120,
@@ -396,6 +406,7 @@ namespace SharpSploit.Execution
             OrdinalNotFound = 0xc0000138,
             EntryPointNotFound = 0xc0000139,
             ControlCExit = 0xc000013a,
+            InvalidAddress = 0xc0000141,
             PortNotSet = 0xc0000353,
             DebuggerInactive = 0xc0000354,
             CallbackBypass = 0xc0000503,

--- a/SharpSploit/Execution/Win32.cs
+++ b/SharpSploit/Execution/Win32.cs
@@ -19,6 +19,16 @@ namespace SharpSploit.Execution
         {
             public static uint MEM_COMMIT = 0x1000;
             public static uint MEM_RESERVE = 0x2000;
+            public static uint MEM_RESET = 0x80000;
+            public static uint MEM_RESET_UNDO = 0x1000000;
+            public static uint MEM_LARGE_PAGES = 0x20000000;
+            public static uint MEM_PHYSICAL = 0x400000;
+            public static uint MEM_TOP_DOWN = 0x100000;
+            public static uint MEM_WRITE_WATCH = 0x200000;
+            public static uint MEM_COALESCE_PLACEHOLDERS = 0x1;
+            public static uint MEM_PRESERVE_PLACEHOLDER = 0x2;
+            public static uint MEM_DECOMMIT = 0x4000;
+            public static uint MEM_RELEASE = 0x8000;
 
             [StructLayout(LayoutKind.Sequential)]
             public struct IMAGE_BASE_RELOCATION


### PR DESCRIPTION
I added two overloads to DynamicInvoke->Generic. GetLibraryAddress & GetExportAddress now support searching by ordinal.

You can grab PEBear (https://github.com/hasherezade/pe-bear-releases) to do some testing if you need to look up ordinals.

In code you can now do something like this:
```c#
MessageBox.Show("SamRidToSid -> " + String.Format("{0:X}", (
    SharpSploit.Execution.DynamicInvoke.Generic.GetLibraryAddress("samlib.dll", "SamRidToSid", true)
    ).ToInt64()));

MessageBox.Show("SamRidToSid -> " + String.Format("{0:X}", (
    SharpSploit.Execution.DynamicInvoke.Generic.GetLibraryAddress("samlib.dll", 0x32)
    ).ToInt64()));
```