### PR TITLE
Manual map from disk

### DIFF
--- a/SharpSploit/Execution/DynamicInvoke/Generic.cs
+++ b/SharpSploit/Execution/DynamicInvoke/Generic.cs
@@ -150,8 +150,6 @@ namespace SharpSploit.Execution.DynamicInvoke
                 Int32 NamesRVA = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x20));
                 Int32 OrdinalsRVA = Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + ExportRVA + 0x24));
 
-                IntPtr namesAbsolute = (IntPtr)(ModuleBase.ToInt64() + Marshal.ReadInt32((IntPtr)(ModuleBase.ToInt64() + NamesRVA)));
-
                 // Loop the array of export name RVA's
                 for (int i = 0; i < NumberOfNames; i++)
                 {

--- a/SharpSploit/Execution/DynamicInvoke/Win32.cs
+++ b/SharpSploit/Execution/DynamicInvoke/Win32.cs
@@ -54,7 +54,7 @@ namespace SharpSploit.Execution.DynamicInvoke
             return retVal;
         }
 
-        private static class Delegates
+        public static class Delegates
         {
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate IntPtr OpenProcess(
@@ -66,6 +66,19 @@ namespace SharpSploit.Execution.DynamicInvoke
             [UnmanagedFunctionPointer(CallingConvention.StdCall)]
             public delegate bool IsWow64Process(
                 System.IntPtr hProcess, ref bool lpSystemInfo
+            );
+
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate int MessageBox(
+                IntPtr hWnd, String text, String caption, int options
+            );
+
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            public delegate bool VirtualProtect(
+                IntPtr lpAddress,
+                int dwSize,
+                uint flNewProtect,
+                out uint lpflOldProtect
             );
         }
     }

--- a/SharpSploit/Execution/Win32.cs
+++ b/SharpSploit/Execution/Win32.cs
@@ -282,6 +282,9 @@ namespace SharpSploit.Execution
 
             [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
             public static extern short GetKeyState(int nVirtKey);
+
+            [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+            public static extern int MessageBox(IntPtr hWnd, String text, String caption, int options);
         }
 
         public static class Netapi32
@@ -1287,7 +1290,12 @@ namespace SharpSploit.Execution
                 WINSTA_READSCREEN = 0x00000200,
                 WINSTA_ALL_ACCESS = 0x0000037F,
 
-                SECTION_ALL_ACCESS = 0x10000000,
+                SECTION_ALL_ACCESS = STANDARD_RIGHTS_REQUIRED |
+                    SECTION_QUERY |
+                    SECTION_MAP_WRITE |
+                    SECTION_MAP_READ |
+                    SECTION_MAP_EXECUTE |
+                    SECTION_EXTEND_SIZE,
                 SECTION_QUERY = 0x0001,
                 SECTION_MAP_WRITE = 0x0002,
                 SECTION_MAP_READ = 0x0004,

--- a/SharpSploit/SharpSploit.xml
+++ b/SharpSploit/SharpSploit.xml
@@ -1225,6 +1225,20 @@
             <param name="ExportName">The name of the export to search for (e.g. "NtAlertResumeThread").</param>
             <returns>IntPtr for the desired function.</returns>
         </member>
+        <member name="M:SharpSploit.Execution.DynamicInvoke.Generic.MapModuleFromDisk(System.String)">
+            <summary>
+            Maps a DLL from disk into a Section.
+            </summary>
+            <author>The Wover (@TheRealWover)</author>
+            <param name="DLLName">Path of the file on disk.</param>
+            <returns>Pointer to the mapped DLL in memory.</returns>
+        </member>
+        <member name="M:SharpSploit.Execution.DynamicInvoke.Generic.MapModuleFromMemory(System.Byte[])">
+            <summary>
+            
+            </summary>
+            <param name="module"></param>
+        </member>
         <member name="T:SharpSploit.Execution.DynamicInvoke.Native">
             <summary>
             Contains function prototypes and wrapper functions for dynamically invoking NT API Calls.

--- a/SharpSploit/SharpSploit.xml
+++ b/SharpSploit/SharpSploit.xml
@@ -1233,12 +1233,6 @@
             <param name="DLLName">Path of the file on disk.</param>
             <returns>Pointer to the mapped DLL in memory.</returns>
         </member>
-        <member name="M:SharpSploit.Execution.DynamicInvoke.Generic.MapModuleFromMemory(System.Byte[])">
-            <summary>
-            
-            </summary>
-            <param name="module"></param>
-        </member>
         <member name="T:SharpSploit.Execution.DynamicInvoke.Native">
             <summary>
             Contains function prototypes and wrapper functions for dynamically invoking NT API Calls.


### PR DESCRIPTION
Provides a DInvoke function to manually map a DLL from disk into memory using `NtCreateSection` + `NtMapViewOfSection`. After the DLL is mapped, it's exports may be used reflectively using `GetExportAddress`. This completely bypasses all user-mode API hooks and results in the DLL executing from what appears to be normally mapped memory, except that `LoadLibrary` is never called and the module is not referenced as a loaded module in the PEB.

![image](https://user-images.githubusercontent.com/17090738/68719995-d0c66280-057b-11ea-8a32-c3fe82835957.png)

Am working on adding Module Overloading to hide DLLs downloaded into memory and allow them to be executed from "file-backed" memory, appearing to be a legitimate, signed DLL on disk. Hasherezade and I have a PoC working and I am converting it to C#. https://github.com/hasherezade/module_overloading

Incidentally, there are real-world examples of attackers using this technique, such as in: https://blog.malwarebytes.com/threat-analysis/2018/08/process-doppelganging-meets-process-hollowing_osiris/