### PR TITLE
Add Reverse Port Forwarding

### DIFF
--- a/SharpSploit.Tests/SharpSploit.Tests/Pivoting/RPortFwdTests.cs
+++ b/SharpSploit.Tests/SharpSploit.Tests/Pivoting/RPortFwdTests.cs
@@ -1,0 +1,102 @@
+﻿// Author: Ryan Cobb (@cobbr_io)
+// Project: SharpSploit (https://github.com/cobbr/SharpSploit)
+// License: BSD 3-Clause
+
+using System.Net;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using SharpSploit.Pivoting;
+
+namespace SharpSploit.Tests.Pivoting
+{
+    [TestClass]
+    public class RPortFwdTest
+    {
+        [TestMethod]
+        public void TestAddReversePortForward()
+        {
+            ReversePortForwarding.AddReversePortForward("8080", "downloads.nickelviper.co.uk", "80");
+
+            string result = string.Empty;
+
+            using (var client = new WebClient())
+            {
+                try { result = client.DownloadString("http://localhost:8080/test.txt"); }
+                catch (WebException) { }
+            }
+
+            Assert.IsTrue(result.Equals("this is a test\n"));
+        }
+
+        [TestMethod]
+        public void TestDeleteReversePortForward()
+        {
+            ReversePortForwarding.AddReversePortForward("8080", "downloads.nickelviper.co.uk", "80");
+
+            string result = string.Empty;
+
+            using (var client = new WebClient())
+            {
+                try { result = client.DownloadString("http://localhost:8080/test.txt"); }
+                catch (WebException) { }
+
+                Assert.IsTrue(result.Equals("this is a test\n"));
+                result = string.Empty;
+
+                ReversePortForwarding.DeleteReversePortForward("8080");
+
+                try { result = client.DownloadString("http://localhost:8080/test.txt"); }
+                catch (WebException) { }
+
+                Assert.IsFalse(result.Equals("this is a test\n"));
+            }
+        }
+
+        [TestMethod]
+        public void TestFlushReversePortForward()
+        {
+            ReversePortForwarding.AddReversePortForward("8080", "downloads.nickelviper.co.uk", "80");
+            ReversePortForwarding.AddReversePortForward("8081", "downloads.nickelviper.co.uk", "80");
+
+            string result = string.Empty;
+
+            using (var client = new WebClient())
+            {
+                try { result = client.DownloadString("http://localhost:8080/test.txt"); }
+                catch (WebException) { }
+                Assert.IsTrue(result.Equals("this is a test\n"));
+                result = string.Empty;
+
+                try { result = client.DownloadString("http://localhost:8081/test.txt"); }
+                catch (WebException) { }
+                Assert.IsTrue(result.Equals("this is a test\n"));
+                result = string.Empty;
+
+                ReversePortForwarding.FlushReversePortFowards();
+
+                try { result = client.DownloadString("http://localhost:8080/test.txt"); }
+                catch (WebException) { }
+                Assert.IsFalse(result.Equals("this is a test\n"));
+                result = string.Empty;
+                try { result = client.DownloadString("http://localhost:8080/test.txt"); }
+                catch (WebException) { }
+                Assert.IsFalse(result.Equals("this is a test\n"));
+            };
+        }
+
+        [TestMethod]
+        public void TestListReversePortForwards()
+        {
+            var list = ReversePortForwarding.ListReversePortForwards();
+            Assert.IsTrue(list.Count == 0);
+
+            ReversePortForwarding.AddReversePortForward("8080", "downloads.nickelviper.co.uk", "80");
+            list = ReversePortForwarding.ListReversePortForwards();
+            Assert.IsTrue(list.Count == 1);
+
+            ReversePortForwarding.DeleteReversePortForward("8080");
+            list = ReversePortForwarding.ListReversePortForwards();
+            Assert.IsTrue(list.Count == 0);
+        }
+    }
+}

--- a/SharpSploit.Tests/SharpSploit.Tests/SharpSploit.Tests.csproj
+++ b/SharpSploit.Tests/SharpSploit.Tests/SharpSploit.Tests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="LateralMovement\SCMTests.cs" />
     <Compile Include="LateralMovement\WMITests.cs" />
     <Compile Include="Persistence\AutorunTests.cs" />
+    <Compile Include="Pivoting\RPortFwdTests.cs" />
     <Compile Include="Persistence\StartupTests.cs" />
     <Compile Include="Persistence\WMITests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/SharpSploit/Pivoting/ReversePortForwarding.cs
+++ b/SharpSploit/Pivoting/ReversePortForwarding.cs
@@ -12,6 +12,9 @@ using SharpSploit.Generic;
 
 namespace SharpSploit.Pivoting
 {
+    /// <summary>
+    /// ReversePortForwarding is a class that allows the addition and removal of Reverse Port Forwards.
+    /// </summary>
     public class ReversePortForwarding
     {
         public class ReversePortForward
@@ -128,6 +131,11 @@ namespace SharpSploit.Pivoting
             return success;
         }
 
+        /// <summary>
+        /// Returns a list of active Reverse Port Forwards.
+        /// </summary>
+        /// <returns>A SharpSploitResultList of ReversePortFwdResult</returns>
+        /// <author>Daniel Duggan (@_RastaMouse)</author>
         public static SharpSploitResultList<ReversePortFwdResult> ListReversePortForwards()
         {
             var reversePortForwards = new SharpSploitResultList<ReversePortFwdResult>();

--- a/SharpSploit/Pivoting/ReversePortForwarding.cs
+++ b/SharpSploit/Pivoting/ReversePortForwarding.cs
@@ -1,0 +1,254 @@
+﻿// Author: Ryan Cobb (@cobbr_io)
+// Project: SharpSploit (https://github.com/cobbr/SharpSploit)
+// License: BSD 3-Clause
+
+using System.Net;
+using System.Linq;
+using System.Threading;
+using System.Net.Sockets;
+using System.Collections.Generic;
+
+using SharpSploit.Generic;
+
+namespace SharpSploit.Pivoting
+{
+    public class ReversePortForwarding
+    {
+        public class ReversePortForward
+        {
+            public IPAddress[] BindAddresses { get; set; }
+            public int BindPort { get; set; }
+            public IPAddress ForwardAddress { get; set; }
+            public int ForwardPort { get; set; }
+        }
+
+        static List<ReversePortForward> _reversePortForwards = new List<ReversePortForward>();
+        static List<Dictionary<int, List<Socket>>> _boundSockets = new List<Dictionary<int, List<Socket>>>();
+
+        /// <summary>
+        /// Creates a new Reverse Port Forward.
+        /// </summary>
+        /// <param name="BindPort">The port to bind on the local system.</param>
+        /// <param name="ForwardAddress">The IP Address or DNS name to forward traffic to.</param>
+        /// <param name="ForwardPort">The port to forward traffic to.</param>
+        /// <returns>Bool.</returns>
+        /// <author>Daniel Duggan (@_RastaMouse)</author>
+        public static bool AddReversePortForward(string BindPort, string ForwardAddress, string ForwardPort)
+        {
+            // Sort inputs out
+            if (!int.TryParse(BindPort, out int bindPort) || !int.TryParse(ForwardPort, out int forwardPort))
+                return false;
+
+            var bindAddresses = new IPAddress[] { IPAddress.Any };
+
+            // If ForwardHost is not a valid IP, try to resolve it as DNS.
+            if (!IPAddress.TryParse(ForwardAddress, out IPAddress forwardAddress))
+            {
+                try
+                {
+                    var ipHostInfo = Dns.GetHostEntry(ForwardAddress);
+                    forwardAddress = ipHostInfo.AddressList[0];
+                }
+                catch { return false; }
+            }
+
+            // Check if bindPort is not already bound.
+            foreach (var boundSocket in _boundSockets)
+                if (boundSocket.ContainsKey(bindPort))
+                    return false;
+
+            // Bind the sockets
+            var newBoundSockets = BindSocket(bindAddresses, bindPort);
+            if (newBoundSockets != null && newBoundSockets.Count > 0)
+            {
+                var newReversePortForward = new ReversePortForward
+                {
+                    BindAddresses = bindAddresses,
+                    BindPort = bindPort,
+                    ForwardAddress = forwardAddress,
+                    ForwardPort = forwardPort
+                };
+
+                // Add to Lists
+                _reversePortForwards.Add(newReversePortForward);
+                _boundSockets.Add(new Dictionary<int, List<Socket>> { { bindPort, newBoundSockets } });
+
+                // Kick off client sockets in new thread.
+                var clientThread = new Thread(() => CreateClientSocketThread(newBoundSockets, forwardAddress, forwardPort));
+                clientThread.Start();
+
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Deletes an active Reverse Port Forward.
+        /// </summary>
+        /// <param name="BindPort">The bind port of the Reverse Port Forward.</param>
+        /// <returns>Bool.</returns>
+        /// <author>Daniel Duggan (@_RastaMouse)</author>
+        public static bool DeleteReversePortForward(string BindPort)
+        {
+            var success = false;
+
+            if (!int.TryParse(BindPort, out int bindPort))
+                return false;
+
+            if (_boundSockets.Count == 0)
+                return false;
+
+            try
+            {
+                foreach (var boundSocket in _boundSockets)
+                {
+                    if (boundSocket.TryGetValue(bindPort, out List<Socket> sockets))
+                    {
+                        foreach (var socket in sockets)
+                        {
+                            try { socket.Shutdown(SocketShutdown.Both); }
+                            catch (SocketException) { }
+                            socket.Close();
+                        }
+
+                        _boundSockets.Remove(boundSocket);
+
+                        var reversePortForward = _reversePortForwards.Where(r => r.BindPort.Equals(bindPort)).FirstOrDefault();
+                        _reversePortForwards.Remove(reversePortForward);
+
+                        success = true;
+                    }
+                }
+            }
+            catch { }
+
+            return success;
+        }
+
+        public static SharpSploitResultList<ReversePortFwdResult> ListReversePortForwards()
+        {
+            var reversePortForwards = new SharpSploitResultList<ReversePortFwdResult>();
+
+            foreach (var rportwd in _reversePortForwards)
+            {
+                var bindAddresses = string.Join(",", rportwd.BindAddresses.Select(a => a.ToString()).ToArray());
+                reversePortForwards.Add(new ReversePortFwdResult
+                {
+                    BindAddresses = bindAddresses,
+                    BindPort = rportwd.BindPort,
+                    ForwardAddress = rportwd.ForwardAddress.ToString(),
+                    ForwardPort = rportwd.ForwardPort
+                });
+            }
+            return reversePortForwards;
+        }
+
+        /// <summary>
+        /// Delete all active Reverse Port Forwards.
+        /// </summary>
+        /// <author>Daniel Duggan (@_RastaMouse)</author>
+        public static void FlushReversePortFowards()
+        {
+            if (_boundSockets.Count == 0)
+                return;
+
+            try
+            {
+                foreach (var dict in _boundSockets)
+                {
+                    foreach (var list in dict.Values)
+                    {
+                        foreach (var socket in list)
+                        {
+                            try { socket.Shutdown(SocketShutdown.Both); }
+                            catch (SocketException) { }
+                            socket.Close();
+                        }
+
+                    }
+                }
+
+                _boundSockets.Clear();
+                _reversePortForwards.Clear();
+            }
+            catch { }
+        }
+
+        private static List<Socket> BindSocket(IPAddress[] BindAddreses, int BindPort)
+        {
+            var socketList = new List<Socket>();
+
+            foreach (var bindAddress in BindAddreses)
+            {
+                var localEP = new IPEndPoint(bindAddress, BindPort);
+                var socket = new Socket(bindAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+                try
+                {
+                    socket.Bind(localEP);
+                    socket.Listen(10);
+                    socketList.Add(socket);
+                }
+                catch (SocketException) { }
+            }
+            return socketList;
+        }
+
+        private static void CreateClientSocketThread(List<Socket> BoundSockets, IPAddress ForwardAddress, int ForwardPort)
+        {
+            var remoteEP = new IPEndPoint(ForwardAddress, ForwardPort);
+
+            while (true)
+            {
+                var boundBuffer = new byte[1024];
+                var clientBuffer = new byte[1048576];
+
+                foreach (var boundSocket in BoundSockets)
+                {
+                    try
+                    {
+                        // Receive data on bound socket
+                        var handler = boundSocket.Accept();
+                        handler.Receive(boundBuffer);
+
+                        // Create new client socket
+                        using (var clientSocket = new Socket(ForwardAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
+                        {
+                            try
+                            {
+                                clientSocket.Connect(remoteEP);
+                                clientSocket.Send(boundBuffer);
+                                clientSocket.Receive(clientBuffer);
+                            }
+                            catch (SocketException) { }
+                        }
+                        handler.Send(clientBuffer);
+                    }
+                    catch { }
+                }
+            }
+        }
+
+        public sealed class ReversePortFwdResult : SharpSploitResult
+        {
+            public string BindAddresses { get; set; }
+            public int BindPort { get; set; }
+            public string ForwardAddress { get; set; }
+            public int ForwardPort { get; set; }
+            protected internal override IList<SharpSploitResultProperty> ResultProperties
+            {
+                get
+                {
+                    return new List<SharpSploitResultProperty> {
+                        new SharpSploitResultProperty { Name = "BindAddresses", Value = this.BindAddresses },
+                        new SharpSploitResultProperty { Name = "BindPort", Value = this.BindPort },
+                        new SharpSploitResultProperty { Name = "ForwardAddress", Value = this.ForwardAddress },
+                        new SharpSploitResultProperty { Name = "ForwardPort", Value = this.ForwardPort }
+                    };
+                }
+            }
+        }
+    }
+}

--- a/SharpSploit/SharpSploit.xml
+++ b/SharpSploit/SharpSploit.xml
@@ -1826,6 +1826,30 @@
             <param name="ProcessName">Specifies the process name when the ProcessStart trigger is selected. Defaults to notepad.exe.</param>
             <param name="ScriptingEngine">Specifies the scripting engine when the ActiveScript consumer is selected. Defaults to VBScript.</param>
         </member>
+        <member name="M:SharpSploit.Pivoting.ReversePortForwarding.AddReversePortForward(System.String,System.String,System.String)">
+            <summary>
+            Creates a new Reverse Port Forward.
+            </summary>
+            <param name="BindPort">The port to bind on the local system.</param>
+            <param name="ForwardAddress">The IP Address or DNS name to forward traffic to.</param>
+            <param name="ForwardPort">The port to forward traffic to.</param>
+            <returns>Bool.</returns>
+            <author>Daniel Duggan (@_RastaMouse)</author>
+        </member>
+        <member name="M:SharpSploit.Pivoting.ReversePortForwarding.DeleteReversePortForward(System.String)">
+            <summary>
+            Deletes an active Reverse Port Forward.
+            </summary>
+            <param name="BindPort">The bind port of the Reverse Port Forward.</param>
+            <returns>Bool.</returns>
+            <author>Daniel Duggan (@_RastaMouse)</author>
+        </member>
+        <member name="M:SharpSploit.Pivoting.ReversePortForwarding.FlushReversePortFowards">
+            <summary>
+            Delete all active Reverse Port Forwards.
+            </summary>
+            <author>Daniel Duggan (@_RastaMouse)</author>
+        </member>
         <member name="T:SharpSploit.PrivilegeEscalation.Exchange">
             <summary>
             Exchange is a class for abusing Microsoft Exchange for privilege escalation.


### PR DESCRIPTION
This PR is a first stab at providing a Reverse Port Forwarding capability, using Sockets.

#### Summary of Additions
- `SharpSploit.Pivoting` namespace.
  - `ReversePortForwarding` class.
    - `AddReversePortForward` function - adds a single reverse port foward of a given `BindPort`, `ForwardAddress` and `ForwardPort`.
    - `ListReversePortForwards` function - lists all currently active reverse port forwards.
    - `DeleteReversePortForward` function - deletes a single reverse port forward of a given a `BindPort`.
    - `FlushReversePortForwards` function - deletes all currently active reverse port forwards.