### PR TITLE
WOW64 Stub for D/Invoke

### DIFF
--- a/SharpSploit/Execution/DynamicInvoke/Generic.cs
+++ b/SharpSploit/Execution/DynamicInvoke/Generic.cs
@@ -634,28 +634,19 @@ namespace SharpSploit.Execution.DynamicInvoke
         /// <summary>
         /// Read ntdll from disk, find/copy the appropriate syscall stub and free ntdll.
         /// </summary>
-        /// <author>Ruben Boonen (@FuzzySec)</author>
+        /// <author>Ruben Boonen (@FuzzySec) and Paul Laîné (@am0nsec)</author>
         /// <param name="FunctionName">The name of the function to search for (e.g. "NtAlertResumeThread").</param>
         /// <returns>IntPtr, Syscall stub</returns>
-        public static IntPtr GetSyscallStub(string FunctionName)
-        {
-            // Verify process & architecture
-            bool isWOW64 = Native.NtQueryInformationProcessWow64Information((IntPtr)(-1));
-            if (IntPtr.Size == 4 && isWOW64)
-            {
-                throw new InvalidOperationException("Generating Syscall stubs is not supported for WOW64.");
-            }
+        public static IntPtr GetSyscallStub(string FunctionName) {
 
             // Find the path for ntdll by looking at the currently loaded module
-            string NtdllPath = string.Empty;
-            ProcessModuleCollection ProcModules = Process.GetCurrentProcess().Modules;
-            foreach (ProcessModule Mod in ProcModules)
-            {
-                if (Mod.FileName.EndsWith("ntdll.dll", StringComparison.OrdinalIgnoreCase))
-                {
-                    NtdllPath = Mod.FileName;
+            ProcessModule NativeModule = null;
+            foreach (ProcessModule _ in Process.GetCurrentProcess().Modules) {
+                if (_.FileName.EndsWith("ntdll.dll", StringComparison.OrdinalIgnoreCase)) {
+                    NativeModule = _;
                 }
             }
+            string NtdllPath = NativeModule.FileName;
 
             // Alloc module into memory for parsing
             IntPtr pModule = Execute.ManualMap.Map.AllocateFileToMemory(NtdllPath);
@@ -678,24 +669,21 @@ namespace SharpSploit.Execution.DynamicInvoke
             UInt32 BytesWritten = Native.NtWriteVirtualMemory((IntPtr)(-1), pImage, pModule, SizeOfHeaders);
 
             // Write sections to memory
-            foreach (PE.IMAGE_SECTION_HEADER ish in PEINFO.Sections)
-            {
+            foreach (PE.IMAGE_SECTION_HEADER ish in PEINFO.Sections) {
                 // Calculate offsets
                 IntPtr pVirtualSectionBase = (IntPtr)((UInt64)pImage + ish.VirtualAddress);
                 IntPtr pRawSectionBase = (IntPtr)((UInt64)pModule + ish.PointerToRawData);
 
                 // Write data
                 BytesWritten = Native.NtWriteVirtualMemory((IntPtr)(-1), pVirtualSectionBase, pRawSectionBase, ish.SizeOfRawData);
-                if (BytesWritten != ish.SizeOfRawData)
-                {
+                if (BytesWritten != ish.SizeOfRawData) {
                     throw new InvalidOperationException("Failed to write to memory.");
                 }
             }
 
             // Get Ptr to function
             IntPtr pFunc = GetExportAddress(pImage, FunctionName);
-            if (pFunc == IntPtr.Zero)
-            {
+            if (pFunc == IntPtr.Zero) {
                 throw new InvalidOperationException("Failed to resolve ntdll export.");
             }
 
@@ -710,9 +698,31 @@ namespace SharpSploit.Execution.DynamicInvoke
 
             // Write call stub
             BytesWritten = Native.NtWriteVirtualMemory((IntPtr)(-1), pCallStub, pFunc, 0x50);
-            if (BytesWritten != 0x50)
-            {
+            if (BytesWritten != 0x50) {
                 throw new InvalidOperationException("Failed to write to memory.");
+            }
+
+            // Verify process & architecture
+            bool isWOW64 = Native.NtQueryInformationProcessWow64Information((IntPtr)(-1));
+
+            // Create custom WOW64 stub
+            if (IntPtr.Size == 4 && isWOW64) {
+                IntPtr pNativeWow64Transition = GetExportAddress(NativeModule.BaseAddress, "Wow64Transition");
+                byte bRetValue = Marshal.ReadByte(pCallStub, 13);
+
+                // CALL DWORD PTR ntdll!Wow64SystemServiceCall
+                Marshal.WriteByte(pCallStub, 5, 0xff);
+                Marshal.WriteByte(pCallStub, 6, 0x15);
+                Marshal.WriteInt32(pCallStub, 7, pNativeWow64Transition.ToInt32());
+
+                // RET <val>
+                Marshal.WriteByte(pCallStub, 11, 0xc2);
+                Marshal.WriteByte(pCallStub, 12, bRetValue);
+                Marshal.WriteByte(pCallStub, 13, 0x00);
+
+                // NOP for alignment
+                Marshal.WriteByte(pCallStub, 14, 0x90);
+                Marshal.WriteByte(pCallStub, 15, 0x90);
             }
 
             // Change call stub permissions


### PR DESCRIPTION
## Abstract ##
Two days ago I discussed with @TheWover and @FuzzySecurity about contributing to this project, and they both mentioned that D/Invoke wasn't supporting Windows on Windows x64 (hereby as "WOW64"). I therefore made a custom stub to implement this feature.

WOW64 is a feature that was introduced with Windows XP and that allow the execution of x86 applications on  x64 systems. This is done via three main DLLs (hereby as "module"):
* `wow64.dll` for non-GUI-related API calls translation;
* `wow64win.dll` for GUI-related API translation; and
* `wow64cpu.dll` for x86 emulation.

I don't know the inner mechanisms and how all of that work; however I know that there is an insane number of things that happen for each system calls and re-implementing everything would be a huge piece of work.

## Implementation ##
A normal WOW64 stub from NTDLL is as follows:
```
0:000> u NtCreateMutant
ntdll!NtCreateMutant:
773b1be0 b8b3000000      mov     eax,0B3h
773b1be5 bad0603c77      mov     edx,offset ntdll!Wow64SystemServiceCall (773c60d0)
773b1bea ffd2            call    edx
773b1bec c21000          ret     10h
773b1bef 90              nop
```

As shown, there is no system call executed from here, instead the stub call `ntdll!Wow64SystemServiceCall`. The problem is that this is a private (i.e. not exported) function and I still did not find a reliable way to retrieve the address of the function. 

But this is not a big deal because this is only pointing to a `JMP` instruction to an exported function: `Wow64Transition`. This function is responsible for switching the segment register (i.e. CPU long mode) to transition from x86 to x64 and therefore to the `whNt*` functions.
```
0:000> u ntdll!Wow64SystemServiceCall L 1
ntdll!Wow64SystemServiceCall:
773c60d0 ff2528824677    jmp     dword ptr [ntdll!Wow64Transition (77468228)]
```

The address of the `Wow64Transition` exported function can be easily found by using `GetExportAddress()` from `SharpSploit.Execution.DynamicInvoke` class. With the address, a custom stub can be created:
```
0:006> u 04d90000
04d90000 b8b3000000      mov     eax,0B3h
04d90005 ff1528824677    call    dword ptr [ntdll!Wow64Transition (77468228)]
04d9000b c21000          ret     10h
04d9000e 90              nop
04d9000f 90              nop
```

If you are executig `NtAllocateVirtualMemory`, this should look like that:
1. .NET delegate from function pointer (x86)
2. Custom stub (x86)
3. ntdll!Wow64Transition (x86)
4. wow64!whNNtAllocateVirtualMemory (x64)
5. ntdll!NtAllocateVirtualMemory (x64)
6. syscall (x64)

## Final Notes ##
Target Framework: .NET Framework 4.7.1
Build and Run: Dubug, Release, Release with optimisation
Test Program: https://gist.github.com/am0nsec/dc81efa478b7d6c8d948177bcb5a276d