### PR TITLE
Added fix for rewriting IAT of modules with no import table

### DIFF
--- a/SharpSploit/Execution/ManualMap/Map.cs
+++ b/SharpSploit/Execution/ManualMap/Map.cs
@@ -189,6 +189,13 @@ namespace SharpSploit.Execution.ManualMap
         {
             PE.IMAGE_DATA_DIRECTORY idd = PEINFO.Is32Bit ? PEINFO.OptHeader32.ImportTable : PEINFO.OptHeader64.ImportTable;
 
+            //Check if there is no import table
+            if (idd.VirtualAddress == 0)
+            {
+                //Return so that the rest of the module mapping process may continue.
+                return;
+            }
+
             // Ptr for the base import directory
             IntPtr pImportTable = (IntPtr)((UInt64)ModuleMemoryBase + idd.VirtualAddress);
 


### PR DESCRIPTION
Added a fix for the issue multiple people had with manually mapping ntdll.dll. The problem was that ntdll.dll does not have an import table and we currently assume that modules do. Used the suggestion by @Dewera to simply check whether or not the module has an import table and return if not. 