### PR TITLE
Property Parsing in GetDomainComputer 

### DIFF
--- a/SharpSploit/Enumeration/Domain.cs
+++ b/SharpSploit/Enumeration/Domain.cs
@@ -414,6 +414,12 @@ namespace SharpSploit.Enumeration
 
                 this.DirectorySearcher.Filter = "(&(samAccountType=805306369)" + Filter + ")";
 
+                if (Properties != null)
+                {
+                    this.DirectorySearcher.PropertiesToLoad.Clear();
+                    this.DirectorySearcher.PropertiesToLoad.AddRange(Properties.ToArray());
+                }
+
                 List<SearchResult> results = new List<SearchResult>();
                 try
                 {


### PR DESCRIPTION
The logic for parsing Properties was missing in GetDomainComputer (`SharpSploit/Enumeration/Domain.cs`)