### PR TITLE
Injection error checking fix

### DIFF
--- a/SharpSploit/Execution/Injection/Execution.cs
+++ b/SharpSploit/Execution/Injection/Execution.cs
@@ -239,7 +239,7 @@ namespace SharpSploit.Execution.Injection
             }
 
             // If successful, return the handle to the new thread. Otherwise return NULL
-            if (result == Native.NTSTATUS.Unsuccessful || result <= Native.NTSTATUS.Success)
+            if (result != Native.NTSTATUS.Success)
             {
                 return false;
             }


### PR DESCRIPTION
A one-line change that fixes the error checking of `NTSTATUS` in `SharpSploit.Execution.Injection.RemoteThreadCreate.Inject`. The current version causes the function to return false incorrectly, making it difficult to know when the injection succeeded.